### PR TITLE
Wiki: Update and expand specific pages

### DIFF
--- a/home/Gaming.md
+++ b/home/Gaming.md
@@ -73,6 +73,8 @@ Script Installers
 
 For many games, installation is made easy with script installers.
 
-For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. We recommend using the WINE Standard version. Simply follow the instructions provided by the script.
+For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. Simply follow the instructions provided by the script. Generally, it is recommended to use Wine-GE for non-Steam games while Proton-GE, Proton-CachyOS and Proton-Experimental are excellent choices for Steam games. Try to not use Proton for non-Steam games as Proton relies on the Steam runtime.
+
+A couple of games require a specific, patched Wine-GE version to run (e.g. League of Legends).
 
 With this guide, you are now ready to start gaming on CachyOS. Enjoy!

--- a/home/Gaming.md
+++ b/home/Gaming.md
@@ -50,8 +50,6 @@ You can use Proton to play your Windows games on Linux.
 
 CachyOS provides various Proton versions for improved performance, including `proton-cachyos`, `proton-ge-custom`, `proton-tkg-git`, and the official Proton versions `proton-experimental` and `proton`.
 
-Additionally, [Protonup-qt](https://aur.archlinux.org/packages/protonup-qt) is a easy way to install and manage [Wine-GE](https://github.com/GloriousEggroll/wine-ge-custom) and [Proton-GE](https://github.com/gloriouseggroll/proton-ge-custom) installations depending on game launcher.
-
 Lutris
 ------
 

--- a/home/Gaming.md
+++ b/home/Gaming.md
@@ -50,6 +50,15 @@ You can use Proton to play your Windows games on Linux.
 
 CachyOS provides various Proton versions for improved performance, including `proton-cachyos`, `proton-ge-custom`, `proton-tkg-git`, and the official Proton versions `proton-experimental` and `proton`.
 
+Bottles
+-------
+
+Bottles is an application that allows you to easily manage Windows prefixes on your favorite Linux distribution. Bottles can also use different runners like Lutris and are manageable within the application. Bottles offers the option of a gaming-orientated prefix. You can install depedencies, add EXE files and use their one-click installers for gaming-related apps like EA App or Battle.net. To install Bottles, run the following command in the terminal:	
+```	
+sudo pacman -S bottles	
+```	
+For more information regarding Bottles, feel free to look through the [documentation](https://docs.usebottles.com/) of Bottles.
+
 Lutris
 ------
 
@@ -59,22 +68,11 @@ Lutris provides a central hub for all your games on your Linux distro. With Lutr
 sudo pacman -S lutris
 ```
 
-Bottles
--------
-Bottles is an application that allows you to easily manage Windows prefixes on your favorite Linux distribution. Bottles can also use different runners like Lutris and are manageable within the application. Bottles offers the option of a gaming-orientated prefix. You can install depedencies, add EXE files and use their one-click installers for gaming-related apps like EA App or Battle.net. To install Bottles, run the following command in the terminal:
-
-```
-sudo pacman -S bottles
-```
-For more information regarding Bottles, feel free to look through the [documentation](https://docs.usebottles.com/) of Bottles.
-
 Script Installers
 -----------------
 
 For many games, installation is made easy with script installers.
 
-For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. Simply follow the instructions provided by the script. Generally, it is recommended to use Wine-GE for non-Steam games while Proton-GE, Proton-CachyOS and Proton-Experimental are excellent choices for Steam games. Try to not use Proton for non-Steam games as Proton relies on the Steam runtime.
-
-A couple of games require a specific, patched Wine-GE version to run (e.g. League of Legends).
+For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. We recommend using the WINE Standard version. Simply follow the instructions provided by the script.
 
 With this guide, you are now ready to start gaming on CachyOS. Enjoy!

--- a/home/Gaming.md
+++ b/home/Gaming.md
@@ -73,8 +73,6 @@ Script Installers
 
 For many games, installation is made easy with script installers.
 
-For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. Simply follow the instructions provided by the script. Generally, it is recommended to use Wine-GE for non-Steam games while Proton-GE, Proton-CachyOS and Proton-Experimental are excellent choices for Steam games. Try to not use Proton for non-Steam games as Proton relies on the Steam runtime.
-
-A couple of games require a specific, patched Wine-GE version to run (e.g. League of Legends).
+For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. We recommend using the WINE Standard version. Simply follow the instructions provided by the script.
 
 With this guide, you are now ready to start gaming on CachyOS. Enjoy!

--- a/home/Gaming.md
+++ b/home/Gaming.md
@@ -75,7 +75,7 @@ Script Installers
 
 For many games, installation is made easy with script installers.
 
-For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. Simply follow the instructions provided by the script.
+For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. Simply follow the instructions provided by the script. Generally, it is recommended to use Wine-GE for non-Steam games while Proton-GE, Proton-CachyOS and Proton-Experimental are excellent choices for Steam games. Try to not use Proton for non-Steam games as Proton relies on the Steam runtime.
 
 A couple of games require a specific, patched Wine-GE version to run (e.g. League of Legends).
 

--- a/home/Gaming.md
+++ b/home/Gaming.md
@@ -50,6 +50,8 @@ You can use Proton to play your Windows games on Linux.
 
 CachyOS provides various Proton versions for improved performance, including `proton-cachyos`, `proton-ge-custom`, `proton-tkg-git`, and the official Proton versions `proton-experimental` and `proton`.
 
+Additionally, [Protonup-qt](https://aur.archlinux.org/packages/protonup-qt) is a easy way to install and manage [Wine-GE](https://github.com/GloriousEggroll/wine-ge-custom) and [Proton-GE](https://github.com/gloriouseggroll/proton-ge-custom) installations depending on game launcher.
+
 Lutris
 ------
 
@@ -73,6 +75,8 @@ Script Installers
 
 For many games, installation is made easy with script installers.
 
-For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. We recommend using the WINE Standard version. Simply follow the instructions provided by the script.
+For example, the [League Of Legends scripts](https://lutris.net/games/league-of-legends/) can be installed with minimal effort. Simply follow the instructions provided by the script.
+
+A couple of games require a specific, patched Wine-GE version to run (e.g. League of Legends).
 
 With this guide, you are now ready to start gaming on CachyOS. Enjoy!

--- a/home/Gaming.md
+++ b/home/Gaming.md
@@ -50,9 +50,6 @@ You can use Proton to play your Windows games on Linux.
 
 CachyOS provides various Proton versions for improved performance, including `proton-cachyos`, `proton-ge-custom`, `proton-tkg-git`, and the official Proton versions `proton-experimental` and `proton`.
 
-Bottles
--------
-
 Lutris
 ------
 
@@ -61,6 +58,15 @@ Lutris provides a central hub for all your games on your Linux distro. With Lutr
 ```
 sudo pacman -S lutris
 ```
+
+Bottles
+-------
+Bottles is an application that allows you to easily manage Windows prefixes on your favorite Linux distribution. Bottles can also use different runners like Lutris and are manageable within the application. Bottles offers the option of a gaming-orientated prefix. You can install depedencies, add EXE files and use their one-click installers for gaming-related apps like EA App or Battle.net. To install Bottles, run the following command in the terminal:
+
+```
+sudo pacman -S bottles
+```
+For more information regarding Bottles, feel free to look through the [documentation](https://docs.usebottles.com/) of Bottles.
 
 Script Installers
 -----------------

--- a/home/cachyos-kernels.md
+++ b/home/cachyos-kernels.md
@@ -53,7 +53,7 @@ Here is a list of features of Linux kernels prebuilt in the CachyOS repositories
 - Kernel Control Flow Integrity (kCFI) selectable when using `LLVM` - *patched llvm can be found in the cachyos-repositories.*
 
 ### :abacus: CPU enhancements
-- 5 Different scheduler are supported,`CFS`,`tt`,`bmq`,`bore`, and `pds` scheduler.
+- 6 Different scheduler are supported: `CFS`,`TT`,`BMQ`,`BORE`, `EEDVF` and `PDS` scheduler.
 - AMD PSTATE EPP and AMD PSTATE Guided Driver enabled by default and with enhancements patches/fixes.
 - Latency Nice Patchset included usuage with `ananicy-cpp` [feature branch](https://lore.kernel.org/lkml/20220925143908.10846-1-vincent.guittot@linaro.org/T/#t).
 - RCU fixes and improvements.

--- a/home/cachyos-kernels.md
+++ b/home/cachyos-kernels.md
@@ -30,9 +30,9 @@ dateCreated: 2021-11-25T07:07:09.929Z
 The Schedulers listed below are supported
 
 ## linux-cachyos
-We provided all of these CPU schedulers because each scheduler performs differently and depends on usage. Please test it and choose what suits your requirements.
-- **(BORE) - Burst-Oriented Response Enhancer** Scheduler by [firelzrd (BORE)](https://github.com/firelzrd/bore-scheduler)
-- **(EEVDF) - Earliest Eligiable Virtual Deadline First** [EEVDF](https://lwn.net/Articles/927530/) is a replacement for the CFS Scheduler from Peter Zijlstra
+We have provided all of these CPU schedulers because each scheduler performs differently depending on usage. We recommend testing each one to determine which best suits your specific requirements.
+- **(BORE) - Burst-Oriented Response Enhancer** Scheduler by [firelzrd (BORE)](https://github.com/firelzrd/bore-scheduler) `linux-bore` / `linux-cachyos-bore`
+- **(EEVDF) - Earliest Eligiable Virtual Deadline First** [EEVDF](https://lwn.net/Articles/927530/) is a replacement for the CFS Scheduler from Peter Zijlstra `linux-cachyos`
 - **(TT) - Task Type** Scheduler by [Hamad Marri](https://github.com/hamadmarri/TT-CPU-Scheduler) - `linux-cachyos-tt` / `linux-tt`
 - **(BMQ) - BitMap Queue** by Alfred Chen - `linux-cachyos-bmq`
 - **(PDS) - Priority and Deadline based Skiplist multiple queue** by Alfred Chen - `linux-cachyos-pds`
@@ -41,16 +41,15 @@ We provided all of these CPU schedulers because each scheduler performs differen
 ### :books: Archived schedulers
 - **CacULE and CacULE-RDB** by Hamad Marri, supported by CachyOS in the past as - `linux-cachyos-cacule`  
   ***ATTENTION:** Not supported after version 6.1. If you still want to use it, you can get it from the archive repository - [linux-cacule](https://github.com/ptr1337/linux-cacule)*
-> All kernels are prebuilt in two different march versions **(x86-64, x86-64-v3 and x86-64-v4)** and also with the **LTO-enabled** kernels in the cachyos repositories.
+> The CachyOS repositories provide prebuilt kernels in three different march versions: `x86-64`, `x86-64-v3`, and `x86-64-v4`. In addition, the repositories also offer LTO-enabled kernels.
 
 ## Features
-Here is a list of features of linux kernels prebuilt in `x86-64-v4`, `x86-64-v3` and `x86-64` in the CachyOS repositories.
-
+Here is a list of features of Linux kernels prebuilt in the CachyOS repositories for `x86-64-v4`, `x86-64-v3`, and `x86-64`.
 ### :hammer_and_wrench: Advanced building & compiling
 - Very customizable PKGBUILD with many features and improvements.
 - `GCC/CLANG` Optimization with automatically found CPU architecture or also selectable CPU architecture.
 - Choose between `LLVM/LTO & Thin-LTO` or `GCC` - *experimental GCC LTO support is available.*
-- Choose between 300Hz, 500Hz, 600 Hz ,750Hz and 1000Hz. Defaults to 500Hz for BORE/CFS and 1000Hz for other schedulers.
+- Choose between 300Hz, 500Hz, 600 Hz ,750Hz and 1000Hz. Defaults to 500Hz for BORE/CFS/EEVDF and 1000Hz for other schedulers.
 - Kernel Control Flow Integrity (kCFI) selectable when using `LLVM` - *patched llvm can be found in the cachyos-repositories.*
 
 ### :abacus: CPU enhancements
@@ -62,7 +61,7 @@ Here is a list of features of linux kernels prebuilt in `x86-64-v4`, `x86-64-v3`
 ### :bookmark_tabs: Filesystem & memory
 - Latest BTRFS/XFS/EXT4 improvements & fixes.
 - ZFS Filesystem Support and prebuilt in the repository.
-- Latest & improved ZSTD 1.5.4 patch-set.
+- Latest & improved ZSTD 1.5.5 patch-set.
 - UserKSM daemon from pf.
 - Improved BFQ Scheduler.
 - support for bcachefs.

--- a/home/cachyos-performance.md
+++ b/home/cachyos-performance.md
@@ -8,7 +8,7 @@ editor: markdown
 dateCreated: 2021-10-04T07:59:10.433Z
 ---
 
-# Linux Kernel with EEDVF scheduler is the default choice
+# Linux Kernel with EEDVF scheduler as the default scheduler
 
 An important aspect of optimization for CachyOS is the scheduler used in our default kernel. Let us explain why we have chosen the EEVDF as our default scheduler. There are many schedulers available, like BMQ or MuQSS, some of them you might already know. We have tested EEVDF and it resulted the one with the best performance results both in benchmarks and responsiveness tests. Please keep an eye out for any updates, as schedulers tend to change often and our default scheduler might change in the future.
 

--- a/home/cachyos-performance.md
+++ b/home/cachyos-performance.md
@@ -8,11 +8,11 @@ editor: markdown
 dateCreated: 2021-10-04T07:59:10.433Z
 ---
 
-# Linux Kernel with BORE scheduler is the default choice
+# Linux Kernel with EEDVF scheduler is the default choice
 
-Yes, this is a part of the optimization for CachyOS. ¿Why do we use that scheduler in particular?. Well... let us explain why!. There are so many schedulers like BMQ, MuQSS, that some of you might already know (or not), but we have tested BORE and it resulted the one with the best performance results both in benchmarks and responsiveness tests.
+An important aspect of optimization for CachyOS is the scheduler used in our default kernel. Let us explain why we have chosen the EEVDF as our default scheduler. There are many schedulers available, like BMQ or MuQSS, some of them you might already know. We have tested EEVDF and it resulted the one with the best performance results both in benchmarks and responsiveness tests. Please keep an eye out for any updates, as schedulers tend to change often and our default scheduler might change in the future.
 
-> It's important to note that the choice of BORE scheduler may not always result in improved performance for all hardware types.
+> It's important to note that the choice of EEVDF scheduler may not always result in improved performance for all hardware types.
 {.is-warning}
 
 # Huge repository with packages compiled with generic-v3

--- a/home/cachyos-performance.md
+++ b/home/cachyos-performance.md
@@ -10,7 +10,7 @@ dateCreated: 2021-10-04T07:59:10.433Z
 
 # Linux Kernel with EEDVF scheduler as the default scheduler
 
-An important aspect of optimization for CachyOS is the scheduler used in our default kernel. Let us explain why we have chosen the EEVDF as our default scheduler. There are many schedulers available, like BMQ or MuQSS, some of them you might already know. We have tested EEVDF and it resulted the one with the best performance results both in benchmarks and responsiveness tests. Please keep an eye out for any updates, as schedulers tend to change often and our default scheduler might change in the future.
+An important aspect of optimization for CachyOS is the scheduler used in our default kernel. Let us explain why we have chosen the EEVDF as our default scheduler. There are many schedulers available, like BORE and PDS, some of them you might already know. We have tested EEVDF and it resulted the one with the best performance results both in benchmarks and responsiveness tests. Please keep an eye out for any updates, as schedulers tend to change often and our default scheduler might change in the future.
 
 > It's important to note that the choice of EEVDF scheduler may not always result in improved performance for all hardware types.
 {.is-warning}


### PR DESCRIPTION
- Updated scheduler in kernel page and changed up the wording a bit
- Kernel page updated to latest information
- Add EEDVF in the supported scheduler list
- Add Bottles in Gaming section
- Add Protonup-qt as a manager for Wine and Proton
- Add clarification regarding different runners and when to use which

Feedback always welcome.