### PR TITLE
fix(general-tweaks): correct amd_prefcore statement

### DIFF
--- a/src/content/docs/general_info/General_System_Tweaks.mdx
+++ b/src/content/docs/general_info/General_System_Tweaks.mdx
@@ -143,13 +143,17 @@ This can result into a better performance and process handling.
 More information here:
 https://lore.kernel.org/linux-pm/20230808081001.2215240-1-li.meng@amd.com/
 
-To enable the AMD P-State Preferred Core Handling just add following to your kernel cmdline options:
-`amd_prefcore=enable`
+The AMD P-State Preferred Core Handling is now enabled by default. 
 
-You can check if it is enabled with following command:
+You can use the following command to check if your CPU supports it:
 ```sh
-cat /sys/devices/system/cpu/amd-pstate/prefcore_state
+cat /sys/devices/system/cpu/amd-pstate/prefcore
 ```
+or
+```sh
+cat /sys/devices/system/cpu/amd-pstate/status
+```
+to see if it is enabled 
 
 7\. Disabling Split Lock Mitigate
 ---------------------------------


### PR DESCRIPTION
The AMD P-state Prefcore is now enabled by default in the Linux kernel, I modified the commands to allow the user to check whether or not their CPU supports it and see if it is enabled or not.