### PR TITLE
fix: correct directory name for amd pstate status and prefcore

### DIFF
--- a/src/content/docs/general_info/General_System_Tweaks.mdx
+++ b/src/content/docs/general_info/General_System_Tweaks.mdx
@@ -147,11 +147,11 @@ The AMD P-State Preferred Core Handling is now enabled by default.
 
 You can use the following command to check if your CPU supports it:
 ```sh
-cat /sys/devices/system/cpu/amd-pstate/prefcore
+cat /sys/devices/system/cpu/amd_pstate/prefcore
 ```
 or
 ```sh
-cat /sys/devices/system/cpu/amd-pstate/status
+cat /sys/devices/system/cpu/amd_pstate/status
 ```
 to see if it is enabled 
 


### PR DESCRIPTION
the amd-pstate module is actually called amd_pstate