### PR TITLE
Update how_to_add_cachyos_repo.md

### DIFF
--- a/src/content/docs/cachyos_repositories/how_to_add_cachyos_repo.md
+++ b/src/content/docs/cachyos_repositories/how_to_add_cachyos_repo.md
@@ -13,6 +13,11 @@ We've made it easy for you! Simply run the following commands to use our helper 
 Run the following commands:
 1. Get archive with the script
 
+*method 1 (curl)*
+```sh
+curl https://mirror.cachyos.org/cachyos-repo.tar.xz -o cachyos-repo.tar.xz
+```
+*method 2 (wget)*
 ```sh
 wget https://mirror.cachyos.org/cachyos-repo.tar.xz
 ```


### PR DESCRIPTION
wiki-rework patch. 
I also looked again to make sure, curl is not standard on all systems, so it's not necessary but maybe it would be good for newbie users.