### PR TITLE
Fixes an incorrect Intel CPU code name in General_System_Tweaks.mdx

### DIFF
--- a/src/content/docs/general_info/General_System_Tweaks.mdx
+++ b/src/content/docs/general_info/General_System_Tweaks.mdx
@@ -49,7 +49,7 @@ A public speculative execution attack exploiting return instructions (retbleed) 
 The following CPU's are affected:
 
 *   AMD: Zen 1, Zen 1+, Zen 2
-*   Intel: 6th to 8th Generation, Skylake, Caby Lake, Coffee Lake
+*   Intel: 6th to 8th Generation, Skylake, Kaby Lake, Coffee Lake
 
 Check which mitigations your CPU is affected by using: `grep . /sys/devices/system/cpu/vulnerabilities/*`
 


### PR DESCRIPTION
7th gen Intel processor's code name is "Kaby Lake" not "Caby Lake" 
Source: https://en.wikipedia.org/wiki/Kaby_Lake