### PR TITLE
general_system_tweaks: nvidia_gsp: use /etc/ instead of /usr/lib/ for modprobe config

### DIFF
--- a/src/content/docs/configuration/general_system_tweaks.md
+++ b/src/content/docs/configuration/general_system_tweaks.md
@@ -241,9 +241,10 @@ rcutree.enable_rcu_lazy=1
 9\. NVIDIA GSP Firmware
 ---------------------------------
 
-The NVIDIA GSP Firmware can introduce in some cases a bit more worse performance, this has been mostly fixed with the 555.58.02 NVIDIA Driver, but it is still on some systems problematic.
+The NVIDIA GSP Firmware can introduce in some cases a bit more worse performance. This has been mostly fixed with the 555.58.02 NVIDIA Driver, but it is still
+problematic on some systems.
 If you are facing hiccups in KDE or bad performance in some cases, you can disable the GSP Firmware with following:
-`/usr/lib/modprobe.d/nvidia-gsp.conf`
+`/etc/modprobe.d/nvidia-gsp.conf`
 
 ```conf
 options nvidia NVreg_EnableGpuFirmware=0
@@ -255,4 +256,4 @@ sudo mkinitcpio -P
 ```
 
 Generally, it is suggested to retest this with every new NVIDIA Driver version again, since the GSP Firmware also brings a bunch of benefits.
-Also, NVIDIA starts to do mainly their QA Testing with GSP Firmware.
+Also, NVIDIA has mainly started to do their QA Testing with GSP Firmware.


### PR DESCRIPTION
Use `/etc/modprobe.d` instead of `/usr/lib/modprobe.d` since files that reside in `/usr/lib` mainly belong to packages and not user configuration. If a user configuration file is made here, it is also possible that they would also make some modifications to already existing files. These modifications would get overwritten with each subsequent package update, leading to users confused and ultimately complain why it gets overwritten everytime.

I also took the liberty of enchancing a few of the sentences in the section. :p 