### PR TITLE
gaming: rework game_performance to better reflect actual functionality

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -41,16 +41,24 @@ CachyOS provides various Proton versions for improved performance, including `pr
 
 ## Performance
 
-### automatic CPU governor switching
-CachyOS does provide a script to automatically switch to the performance governor profile, when starting the game.
+### Power Profile Switching on Demand
+CachyOS provides a wrapper script [`game-performance`](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/game-performance)
+which uses `power-profiles-daemon` to temporarily switch the current power profile to `performance`.
+The `performance` profile increases the system's power levels and changes the CPU governor to performance.
 
-The performance profile, will be set as long the game is running. If you close the game, then it will restore to the previous used profile.
-Gamemode does something equal, but since we are using ananicy-cpp, gamemode should not be used on CachyOS.
+When this script is used to run a game, the system will be set to use the `performance` profile as long as the game is running.
+The previously used power profile will be restored once the game is closed. [Feral's GameMode](https://github.com/FeralInteractive/gamemode)
+has similar behaviour but it should not be used as CachyOS ships with [`ananicy-cpp`](https://gitlab.com/ananicy-cpp/ananicy-cpp).
 
 Add following to the **Launch Options** in Steam:
 ```sh
 game-performance %command%
 ```
+
+:::note
+This behaviour is slightly different with `intel_pstate`. On Intel, the governor remains at powersave but the
+EPP/EPB values are set to performance.
+:::
 
 ### Proton-CachyOS
 


### PR DESCRIPTION
`game-performance` actually changes power profiles, the CPU governor changing is just a byproduct of that. I also added a note for `intel_pstate` because it sets EPP to performance and not the governor itself. This has confused a user in the past