### PR TITLE
secure_boot_setup: Update commands for new sbctl version.

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -93,6 +93,7 @@ Note that this is a one-time process as signing files with `-s` flag will save t
 sign all new files upon a kernel or boot loader update.
 
 ## Verify that Secure Boot is Enabled
+
 To check that secure boot is indeed enabled. You can run one of the following commands
 
 ```bash
@@ -112,6 +113,22 @@ System:
   Measured UKI: no
   Boot into FW: supported
 ```
+
+## Migration to newer sbctl version
+
+Starting from sbctl `0.15`, sbctl files have been moved from `/usr/share/secureboot` to `/var/lib/sbctl`. Due to this,
+a migration is necessary if users are using sbctl before `0.15`.
+
+```bash
+❯ sudo sbctl migrate
+```
+
+sbctl provides a migration command to move all files from old location to the new one.
+
+:::note
+This section isn't necessary for new sbctl users.
+:::
+
 
 ## Credits
 

--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -32,7 +32,7 @@ to the system
 ## Setting Up sbctl
 
 ```bash
-❯ sbctl status # If setup mode is enabled we can proceed to the next step
+❯ sudo sbctl status # If setup mode is enabled we can proceed to the next step
 Installed:      ✘ sbctl is not installed
 Setup Mode:     ✘ Enabled
 Secure Boot     ✘ Disabled
@@ -46,7 +46,7 @@ Secure boot keys created!
 Enrolling keys to EFI variables...✔
 Enrolled keys to the EFI variables!
 
-❯ sbctl status
+❯ sudo sbctl status
 # sbctl should now be installed and we can proceed to signing the kernel images and boot loader
 Installed:      ✔ sbctl is installed
 Owner GUID:     a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
@@ -97,7 +97,7 @@ sign all new files upon a kernel or boot loader update.
 To check that secure boot is indeed enabled. You can run one of the following commands
 
 ```bash
-❯ sbctl status
+❯ sudo sbctl status
 Installed:      ✓ sbctl is installed
 Owner GUID:     a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
 Setup Mode:     ✓ Disabled

--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -81,11 +81,10 @@ Verifying file database and EFI images in /boot...
 ```
 
 :::note
-For bootloaders like rEFInd and GRUB that has a separate boot and EFI partition,
-the kernel image might not detected when running `sudo sbctl verify` as it is outside the EFI partition.
+In some cases with rEFInd, the kernel image might not detected when running `sudo sbctl verify`.
 To sign the kernel image, you can just do `sudo sbctl sign -s /boot/vmlinuz-linux-cachyos`.
 The file name of the kernel image varies between kernel versions and there could be more than one if you have
-multiple kernel versions installed
+multiple kernel versions installed.
 :::
 
 Now that all the files are signed, we can reboot back to UEFI settings and enable secure boot.


### PR DESCRIPTION
Along with adding `sudo` to `sbctl status`. I also editted the note and removed any mentions of GRUB for now because there was a user that has the kernel image detected in /boot.