### PR TITLE
secure_boot_setup: Add secure boot pre-setup for GRUB

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -6,6 +6,7 @@ description: Set up secure boot with sbctl after installing CachyOS
 import ImageComponent from '~/components/image-component.astro';
 
 # sbctl
+
 [`sbctl`](https://github.com/Foxboron/sbctl) is a a user-friendly secure boot key manager capable of setting up secure boot,
 offer key management capabilities and keep track of files that needs to be signed in the boot chain.
 
@@ -16,6 +17,16 @@ offer key management capabilities and keep track of files that needs to be signe
 ```
 
 ## Pre-setup
+
+### GRUB Bootloader
+
+If you are using GRUB, run the following command to enable secure boot support on GRUB using CA Keys.
+
+```bash
+❯ sudo grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=cachyos --modules="tpm" --disable-shim-lock
+```
+
+### Entering Setup Mode in UEFI
 Firstly, we need to go to firmware settings and set secure boot mode to "Setup Mode". You can reboot from an
 already running system to firmware settings with following command.
 

--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -26,6 +26,11 @@ If you are using GRUB, run the following command to enable secure boot support o
 ❯ sudo grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=cachyos --modules="tpm" --disable-shim-lock
 ```
 
+:::note
+Loading unnecessary modules in your bootloader has the potential to present a security risk.
+Only run this command if you actually need secure boot.
+:::
+
 ### Entering Setup Mode in UEFI
 Firstly, we need to go to firmware settings and set secure boot mode to "Setup Mode". You can reboot from an
 already running system to firmware settings with following command.


### PR DESCRIPTION
Based on [UEFI/Secure_Boot](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Implementing_Secure_Boot) and one user using GRUB + secure boot, secure boot support within GRUB needs to be manually enabled.