### PR TITLE
feat: Adress why KDE Plasma is the only available option in the live environment in CachyOS ISOs

### DIFF
--- a/src/content/docs/support/faq.mdx
+++ b/src/content/docs/support/faq.mdx
@@ -8,6 +8,17 @@ import MultipleImageComponent from '~/components/multiple-images-component.astro
 # Frequently asked questions
 Here are some frequently asked questions. We recommend that users read this, especially those using CachyOS or Arch-based distributions.
 
+## Installation FAQ
+
+### Why is KDE Plasma the only available option in the live environment?
+
+KDE Plasma can be considered as our "flagship" desktop environment, therefore it gets the most maintenance. Other ISOs
+were maintained in a half-ass state, if at all so we decided to deprecate them so that we can focus our efforts to deliver
+the best user experience.
+
+We recommend installing CachyOS in a VM for testing out different desktop environments and window managers as the live ISO is only
+used for installation and recovering a broken install via [cachy-chroot](https://github.com/CachyOS/cachy-chroot).
+
 ## Software management FAQ
 Here are all the questions related to the management of software on your system.
 


### PR DESCRIPTION
Closes #46 

