### PR TITLE
sched-ext: Remove advice to use scx-scheds-git with linux-cachyos-rc

### DIFF
--- a/src/content/docs/kernel/sched-ext.md
+++ b/src/content/docs/kernel/sched-ext.md
@@ -32,8 +32,6 @@ Simply run following command to install the package:
 sudo pacman -Sy scx-scheds
 ```
 
-The `scx-scheds-git` package could have issues, when using it with the stable kernel due API or Feature changes. So the `scx-scheds-git` package should be best used together with the `linux-cachyos-rc` kernel.
-
 ### Starting the Scheduler
 
 The scheduler can be simply started in the terminal with following command:


### PR DESCRIPTION
CachyOS is always using the latest sched-ext patch in its default kernel. Therefore this sentence seems false and can lead to misinformation