### PR TITLE
Complete overhaul of Installation Prepare

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -100,6 +100,14 @@ export default defineConfig({
               },
               link: 'cachyos_basic/download',
             },
+            {
+              label: 'CachyOS Requirements & Installation Media',
+              translations: {
+                sk: 'PPožiadavky CachyOS a inštalačné médium',
+                cs: 'Požadavky CachyOS a instalační médium',
+              },
+              link: 'installation/installation_prepare',
+            },
           ],
         },
         {
@@ -109,14 +117,6 @@ export default defineConfig({
             cs: 'Instalace',
           },
           items: [
-            {
-              label: 'Installation Prepare',
-              translations: {
-                sk: 'Príprava na inštaláciu',
-                cs: 'Příprava Instalace',
-              },
-              link: 'installation/installation_prepare',
-            },
             {
               label: 'Boot Managers',
               translations: {

--- a/src/content/docs/installation/installation_prepare.mdx
+++ b/src/content/docs/installation/installation_prepare.mdx
@@ -1,108 +1,154 @@
 ---
-title: Installation Preparation
+title: Preparation steps
 description: How to prepare CachyOS for installation
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
-The following section will guide you through the steps to prepare all the elements for installing CachyOS.
+<Aside type="tip" title="Getting ready for CachyOS.">
+   The following section will guide you through the steps to prepare your USB drive with CachyOS ISO image for installation and the necessary requirements.
+</Aside>
 
 ## System Requirements
 
-Before you begin the installation, you need to make sure that your computer meets the following minimum system requirements:
+Before you begin with the preparation for installation, you need to make sure that your computer meets the following system requirements in order to run CachyOS:
 
-*   3 GB of memory
-*   30 GB of hard disk space
-*   1 GHz processor
-*   HD graphics card and monitor
-*   Broadband internet connection
+#### Minimum 
 
-For the best performance, it is recommended to have:
+*   3 GB RAM
+*   30 GB of Storage Space (HDD/SSD)
+*   Dual Core processor (64-bit)
+*   Integrated graphics card
+*   Stable internet connection
 
-*   4 GB of memory
-*   50 GB of hard disk space
-*   An x86-64-v3 supported processor
-*   50 Mbps or better internet connection
-*   A newer NVIDIA card (900+), AMD Graphics Card or Intel
+#### Recommended 
 
-
-## Preparing for the Installation
-
-Before installing CachyOS on your endpoint, you need a set of tasks to prepare.
-
-## Download the Image
-
-Download CachyOS as described in [Downloading CachyOS](/cachyos_basic/download/).
+*   4 GB RAM 
+*   50 GB of Storage Space (SSD/NVMe)
+*   [x86-64-v3](/cachyos_repositories/what_are_the_cachyos_repo) capable CPU (non v3 CPUs e.g AMD FX Series or an Intel i3 2100 can be used too)
+*   50 Mbps or better internet speed
+*   NVIDIA GPU (900+ - e.g: GTX 950), AMD +GCN 1.0 (e.g: AMD R7 240) or Intel (Integrated HD Graphics series or higher. Arc Series)
 
 ## Creating a Bootable CachyOS USB Drive
 
-There are several tools that you can use to create a bootable USB drive of CachyOS. The USB drive must be at least 8GB of size.
+There are several tools and methods that you can use to create a bootable USB drive of CachyOS. The USB drive must have at least 8GB of available space.
 
-### Balena Etcher
+### balenaEtcher
 
 <Steps>
 
-1. Download [Balena Etcher](https://etcher.balena.io/). Balena Etcher supports all 3 Linux, MacOS and Windows.
-
-   If you download the `.AppImage` file, assign executable permission by `chmod +x balenaEtcher-<version>-<arch>.AppImage` and run it by `./balenaEtcher-<version>-<arch>.AppImage`.
-
+1. Download [balenaEtcher](<https://etcher.balena.io/>). balenaEtcher supports flashing an image of Linux, MacOS and Windows.
+   If you downloaded the `.zip` file, extract it and execute the binary using the following commands:
+      ```sh
+      # Extract zip file:
+      bsdtar xvf <zip file name>
+      # cd to the new folder:
+      cd balenaEtcher-linux-x64/
+      # Execute balenaEtcher:
+      ./balena-etcher
+      ```
 2. Plug in your USB drive to your system.
-3. Click **Flash from file** and select the CachyOS ISO image file.
-4. Click **Select target** and choose the label of your plugged USB drive.
-5. Click **Flash** for starting the process.
+3. Select **Flash from file** and select the CachyOS ISO image file.
+4. Click **Select target** and choose the label that matches your USB drive.
+5. Press **Flash** to start the flashing process.
 
 </Steps>
 
 :::note
-You could be asked for administration privileges, so insert credentials and press **Authenticate**.
+You may be prompted for administrator privileges. If so, enter your password and click Authenticate.
 :::
 
 <br />
 
 <ImageComponent imgsrc={import('~/assets/images/etcher.png')} />
 
-At the end of flash process you will get a **Flash Completed!** message. Close Balena Etcher and reboot the system for booting into CachyOS.
+At the end of flash process you will get a **Flash Completed!** message. Close balenaEtcher and reboot your system to boot into CachyOS.
 :::note
-Be sure to have the USB drive **boot priority** over other drives in the BIOS.
+Be sure to have the USB drive **boot priority** over other drives in the BIOS/UEFI or boot it from your Boot Menu.
 :::
 
-### Command Line Interface
+
+### Command Line Interface (Linux & MacOS)
 
 <Steps>
 
-1. Plug your USB drive into your available USB port.
-2. Detect the drive device label of the plugged USB drive by `sudo fdisk -l` (i.e., it could be `/dev/sdX` where `X` is `a`, `b`, and so on) on Linux
-and `diskutil list` on MacOS (`/dev/diskY` where `Y` is 0, 1 and so on).
-3. Run `sudo dd bs=4M if=full_iso_name.iso of=/dev/<usbdrive> status=progress oflag=sync` (replace `<usbdrive>` by the drive device label of your plugged USB drive).
-
+1. Plug in your USB drive.
+2. Detect the plugged USB drive using the following commands:
+   ```sh
+   # Linux
+   # Your USB drive could be identified e.g: /dev/sda, by disk model and size.
+   sudo fdisk -l
+   
+   # MacOS
+   # USB drives are identified as "/dev/diskY" where "Y" could be 0,1 etc.
+   diskutil list 
+   ```
+3. Copy the iso contents to your USB drive by running:
+   ```sh
+   # Replace <usbdrive> with the label of your drive.
+   sudo dd bs=4M if=full_iso_name.iso of=/dev/<usbdrive> status=progress oflag=sync
+   ```
 </Steps>
 
-`dd` command will now copy the contents of the ISO file over to your USB drive. Once done, you’re ready to use the USB drive as CachyOS installation media. Reboot the system to boot into CachyOS.
+- `dd` will now copy the contents of the ISO file over to your USB drive. Once it's done, you will be ready to use the USB drive as the CachyOS installation media. Reboot your system to boot into CachyOS.
 :::note
-Be sure to have the USB drive **boot priority** over other drives in the BIOS.
+Be sure to have the USB drive **boot priority** over other drives in the BIOS/UEFI or boot it from your Boot Menu.
 :::
 
 ### Rufus (Windows Only)
 
 <Steps>
 
-1. Plug your USB drive into your available USB port.
-2. Download [Rufus](https://rufus.ie/) and install it, or run the portable version.
-3. On **Device**, click on the dropdown list and select your plugged USB drive.
+1. Plug in USB drive.
+2. Download [Rufus](<https://rufus.ie/>) and install it, or run the portable version.
+3. On **Device**, click on the dropdown list and select your USB drive.
 4. On **Boot selection**, click on **SELECT** and locate the CachyOS ISO image file.
 5. Click **START**.
 
 </Steps>
 
-### Ventoy
+### Ventoy (Linux & Windows)
+
+<Tabs>
+
+<TabItem label="Linux">
 
 <Steps>
 
-1. Plug your USB drive into your available USB port.
-2. Download [Ventoy](https://www.ventoy.net/en/download.html)
-3. **Select** your USB. Ventoy will now format your USB Stick.
-4. After **successful** formatting you will have a Partition called "Ventoy".
-5. The CachyOS image should be placed into the partition, the drive can then be booted from.
+1. Plug in your USB drive.
+2. Download [Ventoy](<https://www.ventoy.net/en/download.html>)
+3. Untar Ventoy using the following command:
+   ```sh
+   # Replace version with the correct one e.g: ventoy-1.0.99-linux.tar.gz
+   bsdtar xvf ventoy-version-linux.tar.gz
+   # cd to the new folder: (version might change)
+   cd ventoy-1.0.99/
+   ```
+4. Execute VentoyGUI.x86_64 by either double clicking on it or via terminal:
+   ```sh
+   # It will ask for administrative privileges, enter your credentials
+   ./VentoyGUI.x86_64
+   ```
+5. Select your USB drive by clicking on **Device**.
+6. Click on **Install**.
+7. After it finished installing Ventoy into your USB drive, you can now close the window and place the CachyOS ISO file into the new usable partition of the drive.
 
 </Steps>
+
+</TabItem>
+
+<TabItem label="Windows">
+
+<Steps>
+1. Plug in your USB drive.
+2. Download [Ventoy](<https://www.ventoy.net/en/download.html>)
+3. Run **Ventoy2Disk.exe**
+4. Select your USB drive by clicking on **Device**.
+5. Click on **Install**.
+6. After it finished installing Ventoy into your USB drive, you can now close the window and place the CachyOS ISO file into the new usable partition of the drive.
+</Steps>
+
+</TabItem>
+
+</Tabs>


### PR DESCRIPTION
I felt it was needed in order to be easier to follow and i deleted some non-needed parts too.

Some parts were reused but not many, and the reasoning on why i moved to Getting Started is because they're just preparations before installation and it didn't make much sense to have it on the "installation" index.