### PR TITLE
Installation on Root Overhaul & Tweaks

### DIFF
--- a/src/content/docs/installation/boot_managers.md
+++ b/src/content/docs/installation/boot_managers.md
@@ -3,8 +3,8 @@ title: Offered Boot Managers
 description: Description and recommendations for the currently offered boot managers
 ---
 
-To offer the best experience across a range of devices, CachyOS currently offers the following boot managers: systemd-boot, rEFInd and Grub.
-This wiki article will describe the featuresets of each boot manager and also includes our recommendations for when choosing them. For
+To offer the best experience across a range of devices, CachyOS currently offers the following boot managers: systemd-boot, rEFInd and GRUB.
+This wiki article will describe the feature set of each boot manager and also includes our recommendations for when choosing them. For
 configuration, please see [Boot Manager Configuration](/configuration/boot_manager_configuration).
 
 ## Preamble: Boot Manager != Boot Loader
@@ -34,12 +34,8 @@ Part of systemd family, systemd-boot was created to be as simple as possible, th
  - Only able to read boot images on EFI supported filesystems (FAT, FAT16, FAT32)
  - Inability to find boot images on partitions other than its own without manual intervention.
 
-### Partitioning layout
-- Minimum 1GB (2GB recommended) FAT32 EFI boot partition (/boot)
-- Minimum 5.5GB user selected root filesystem (/)
-
-### Recommendation:
-Systemd-boot is the recommended boot manager for CachyOS. Choose this one if you do not need any of the features specific to grub and rEFInd.
+### Recommendation
+Systemd-boot is the recommended boot manager for CachyOS. Choose this one if you do not need any of the features specific to GRUB and rEFInd.
 
 
 ## rEFInd
@@ -58,43 +54,29 @@ A fork of rEFIt, rEFInd was primarily made to make it easier for MacOS users to 
 - Does not support BIOS systems.
 - Slightly slower due to the autodetection feature.
 
-### Partitioning Layout
-- Minimum 50MB FAT32 EFI partition (/boot/efi)
-- Minimum 1GB (2GB recommended) ext4 boot partition (/boot)
-- Minimum 5.5GB user selected root filesystem (/)
-
 ### Recommendation
 rEFInd is the recommended boot manager for booting with multiple operating systems.
 
 
-## Grub
-Grub is the oldest of the available boot managers and consequently the only one that supports BIOS booting. It has a very large featureset, works on almost every machine and is the most commonly used Linux boot manager.
+## GRUB
+GRUB is the oldest of the available boot managers and consequently the only one that supports BIOS booting. It has a very large feature set, works on almost every machine and is the most commonly used Linux boot manager.
 The following is a list of its main pros and cons.
 
 ### Pros
 - Able to read boot images from almost all available linux filesystems.
 - Widely used and very easy to find information online.
 - Able to decrypt encrypted boot partitions.
-- The only boot*loader* offered allowing it to boot BIOS machines.
+- The only boot manager offered allowing it to boot BIOS machines.
 - Looks dated. However has great theme support to compensate.
 
 ### Cons
 - Bloated due to needing to support much older hardware and needing lots of filesystem drivers.
 - Slightly slower than other boot managers due to aforementioned bloat.
-- Complicated config that needs to be regenerated every time a kernel is updated. (However this is done automatically.)
-
-### Partitioning layout
-
-#### BIOS
-- Minimum 6.5GB user selected root filesystem (/)
-
-#### UEFI
-- Minimum 50MB EFI partition (/boot/efi)
-- Minimum 6.5GB user selected root filesystem (/)
+- Complicated config that needs to be regenerated every time a kernel is updated. (However this is done automatically).
 
 ### Recommendation
-Grub is the only available boot manager if your machine only supports BIOS booting. It is also the only boot manager that supports boot partition encryption (Different from disk encryption). If you do not fit those criteria alternative boot managers are recommended.
+GRUB is the only available boot manager if your machine only supports BIOS booting. It is also the only boot manager that supports boot partition encryption (Different from disk encryption). If you do not fit those criteria alternative boot managers are recommended.
 
 
 ## TL:DR
-Choose Grub if your machine is BIOS only, pick rEFInd if you plan on having multiple operating systems on your machine (Especially Windows), otherwise go with systemd-boot.
+Choose GRUB if your machine is BIOS only, pick rEFInd if you plan on having multiple operating systems on your machine (Especially Windows), otherwise go with systemd-boot.

--- a/src/content/docs/installation/boot_managers.md
+++ b/src/content/docs/installation/boot_managers.md
@@ -63,7 +63,7 @@ GRUB is the oldest of the available boot managers and consequently the only one 
 The following is a list of its main pros and cons.
 
 ### Pros
-- Able to read boot images from almost all available linux filesystems.
+- Able to read boot images from almost all available Linux filesystems.
 - Widely used and very easy to find information online.
 - Able to decrypt encrypted boot partitions.
 - The only boot manager offered allowing it to boot BIOS machines.

--- a/src/content/docs/installation/boot_managers.md
+++ b/src/content/docs/installation/boot_managers.md
@@ -66,7 +66,7 @@ The following is a list of its main pros and cons.
 - Able to read boot images from almost all available Linux filesystems.
 - Widely used and very easy to find information online.
 - Able to decrypt encrypted boot partitions.
-- The only boot manager offered allowing it to boot BIOS machines.
+- The only boot loader offered allowing it to boot BIOS machines.
 - Looks dated. However has great theme support to compensate.
 
 ### Cons

--- a/src/content/docs/installation/installation_on_root.mdx
+++ b/src/content/docs/installation/installation_on_root.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: How To Install CachyOS & Partition Guide
 description: Erase Disk Installation
 ---
 
@@ -25,7 +25,7 @@ The "Erase Disk" Option in Calamares will wipe the selected disk and install the
 
 5. Select **Erase Disk** and choose a [Filesystem](/installation/filesystem).
   
-6. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+6. Pick the **Desktop Environment** you'd like to use, see [Desktop Environments](/installation/desktop_environments).
 
 7. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
 
@@ -63,13 +63,13 @@ Depending on what [Boot Manager](/installation/boot_managers/) you have decided 
 
 6. Create another partition for ***root***:
     * Size: ***At least 20000MiB***
-    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Filesystem: Any, refer [Filesystem](/installation/filesystem)
     * Mount point: ***/***
     * Flags:
 
 7. Double check that ***Install boot loader on:*** is pointing to /boot
 
-8. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+8. Pick the **Desktop Environment** you'd like to use, see [Desktop Environments](/installation/desktop_environments).
 
 9. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
 
@@ -101,13 +101,13 @@ Depending on what [Boot Manager](/installation/boot_managers/) you have decided 
 
 6. Create another partition for ***root***:
     * Size: ***At least 20000MiB***
-    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Filesystem: Any, refer [Filesystem](/installation/filesystem)
     * Mount point: ***/***
     * Flags:
 
 7. Double check that ***Install boot loader on:*** is pointing to /boot/efi
 
-8. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+8. Pick the **Desktop Environment** you'd like to use, see [Desktop Environments](/installation/desktop_environments).
 
 9. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
 
@@ -145,13 +145,13 @@ Depending on what [Boot Manager](/installation/boot_managers/) you have decided 
 
 7. Create another partition for ***root***:
     * Size: ***At least 20000MiB***
-    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Filesystem: Any, refer [Filesystem](/installation/filesystem)
     * Mount point: ***/***
     * Flags:
 
 8. Double check that ***Install boot loader on:*** is pointing to /boot/efi
 
-9. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+9. Pick the **Desktop Environment** you'd like to use, see [Desktop Environments](/installation/desktop_environments).
 
 10. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
 
@@ -183,13 +183,13 @@ GRUB is the only boot manager available for a MBR/BIOS system.
 
 5. Create a new partition with the following:
     * Size: ***At least 20000MiB***
-    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Filesystem: Any, refer [Filesystem](/installation/filesystem)
     * Mount point: ***/***
     * Flags: 
 
 6. Double check that ***Install boot loader on:*** is pointing to your boot drive e.g: /dev/sda
 
-7. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+7. Pick the **Desktop Environment** you'd like to use, see [Desktop Environments](/installation/desktop_environments).
 
 8. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
 

--- a/src/content/docs/installation/installation_on_root.mdx
+++ b/src/content/docs/installation/installation_on_root.mdx
@@ -1,58 +1,225 @@
 ---
-title: Installation on Root
+title: Installation
 description: Erase Disk Installation
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
-CachyOS provides several ways to install the system.
+:::caution
+Secure boot must be disabled when installing CachyOS. To setup secure boot after install. Check [Secure Boot Setup.](/configuration/secure_boot_setup)
+:::
+
+## Erase Disk
+
 The "Erase Disk" Option in Calamares will wipe the selected disk and install then CachyOS to the target.
+
+<Steps>
+
+1. Boot into the ISO and click on **Launch Installer**.
+
+2. Select a **Boot Manager** that suits your preferences. Check the [Boot Managers](/installation/boot_managers) section for more information.
+
+3. Set your preferred **Language** and **Region/Timezone**.
+
+4. Configure your **Keyboard Layout**.
+
+5. Select **Erase Disk** and choose a [Filesystem](/installation/filesystem).
+  
+6. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+
+7. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
+
+8. Setup your login credentials.
+
+9. Review the installation summary on the Overview Page carefully. If all the settings look correct for you, proceed with the installation by clicking on ***Install Now***. Otherwise, go back and make any necessary changes.
+
+</Steps>
+
+## Manual Partitioning
+
+### UEFI/GPT
+
+Depending on what [Boot Manager](/installation/boot_managers/) you have decided to use. Please follow the instructions for each.
+
+<Tabs>
+
+<TabItem label='systemd-boot'>
 
 <Steps>
 
 1. Boot into the ISO and click the **Launch Installer** button
 
-2. Choose one among the three **boot manager** options that you are presented with. See [Boot Managers](/installation/boot_managers/)
-for a brief comparison between systemd-boot, rEFInd and GRUB
+2. Set your preferred **Language** and **Region/Timezone**.
 
-3. Choose your **Region**
+3. Configure your **Keyboard Layout**.
 
-4. Choose your **Keyboard Layout**
+4. Select **Manual partitioning**.
 
-5. Choose your **filesystem**. If you are not sure which one to choose, please take a look to [Filesystems](/installation/filesystem)
+5. Create a new partition with the following:
+    * Size: ***2048MiB***
+    * Filesystem: ***FAT32***
+    * Mount point: ***/boot***
+    * Flags: **boot**
 
-6. Choose your **Desktop Environment** you want to use, see [Desktop environments](/installation/desktop_environments)
+6. Create another partition for ***root***:
+    * Size: ***At least 20000MiB***
+    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Mount point: ***/***
+    * Flags:
 
-7. Tick or Untick further packages for the netinstallation.
+7. Double check that ***Install boot loader on:*** is pointing to /boot
 
-8. Check the **Summary Page** and proceed with the installation.
+8. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+
+9. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
+
+10. Setup your login credentials.
+
+11. Review the installation summary on the Overview Page carefully. If all the settings look correct for you, proceed with the installation by clicking on ***Install Now***. Otherwise, go back and make any necessary changes.
 
 </Steps>
 
+</TabItem>
+
+<TabItem label='GRUB'>
+
+<Steps>
+
+1. Boot into the ISO and click the **Launch Installer** button
+
+2. Set your preferred **Language** and **Region/Timezone**.
+
+3. Configure your **Keyboard Layout**.
+
+4. Select **Manual partitioning**.
+
+5. Create a new partition with the following:
+    * Size: ***At least 100MiB***
+    * Filesystem: ***FAT32***
+    * Mount point: ***/boot/efi***
+    * Flags: **boot**
+
+6. Create another partition for ***root***:
+    * Size: ***At least 20000MiB***
+    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Mount point: ***/***
+    * Flags:
+
+7. Double check that ***Install boot loader on:*** is pointing to /boot/efi
+
+8. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+
+9. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
+
+10. Setup your login credentials.
+
+11. Review the installation summary on the Overview Page carefully. If all the settings look correct for you, proceed with the installation by clicking ***Install Now***. Otherwise, go back and make any necessary changes.
+
+</Steps>
+
+</TabItem>
+
+<TabItem label='rEFInd'>
+
+<Steps>
+
+1. Boot into the ISO and click the **Launch Installer** button
+
+2. Set your preferred **Language** and **Region/Timezone**.
+
+3. Configure your **Keyboard Layout**.
+
+4. Select **Manual partitioning**.
+
+5. Create a new partition with the following:
+    * Size: ***At least 100MiB***
+    * Filesystem: ***FAT32***
+    * Mount point: ***/boot/efi***
+    * Flags: **boot**
+
+6. Create another partition:
+    * Size: ***2048MiB***
+    * Filesystem: ***EXT4***
+    * Mount point: ***/boot***
+    * Flags:
+
+7. Create another partition for ***root***:
+    * Size: ***At least 20000MiB***
+    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Mount point: ***/***
+    * Flags:
+
+8. Double check that ***Install boot loader on:*** is pointing to /boot/efi
+
+9. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+
+10. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
+
+11. Setup your login credentials.
+
+12. Review the installation summary on the Overview Page carefully. If all the settings look correct for you, proceed with the installation by clicking on ***Install Now***. Otherwise, go back and make any necessary changes.
+
+</Steps>
+
+</TabItem>
+
+</Tabs>
+
+### MBR/BIOS
+
 :::note
-Secure boot must be disabled when installing CachyOS. To setup secure boot after install, see: [Secure Boot Setup](/configuration/secure_boot_setup)
+GRUB is the only boot manager available for a MBR/BIOS system.
 :::
 
-Calamares will then proceed to install CachyOS into your drive. The drivers will already be configured and working correctly out of the box with the help of our Hardware Detection. There is no need to install additional drivers after the installation unless needed for some less supported hardware.
+<Steps>
 
-As soon as Calamares has finished installing CachyOS, you'll get a prompt to reboot your system.
+1. Boot into the ISO and click the **Launch Installer** button
 
-### Common Issues
+2. Set your preferred **Language** and **Region/Timezone**.
 
-#### Key was created in the future
+3. Configure your **Keyboard Layout**.
 
-The Installation does fail with following input:
-```
+4. Select **Manual partitioning**.
+
+5. Create a new partition with the following:
+    * Size: ***At least 20000MiB***
+    * Filesystem: Refer to [Filesystem](/installation/filesystem)
+    * Mount point: ***/***
+    * Flags: 
+
+6. Double check that ***Install boot loader on:*** is pointing to your boot drive e.g: /dev/sda
+
+7. Pick the **Desktop Environment** you'd like to use, see [Desktop environments](/installation/desktop_environments).
+
+8. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
+
+9. Setup your login credentials.
+
+10. Review the installation summary on the Overview Page carefully. If all the settings look correct for you, proceed with the installation by clicking on ***Install Now***. Otherwise, go back and make any necessary changes.
+
+</Steps>
+
+## Common Issues
+
+### Key was created in the future
+
+:::note
+This will be fixed in the September 2024 Release.
+:::
+
+The Installation fails with the following error log:
+```text
 gpg: key B1D99E8932D24EB5 was created 4785 seconds in the future (time warp or clock problem)
 ```
 
-This indicates that the hardware clock is not correctly synced.
-After the installation failed reboot into the ISO and run following commands:
+This problem is caused by an out-of-sync local time.
+To be specific, the pacman master key was created when a wrong time set in your OS. This may cause the timestamp of the pacman master key is in the future after you correct the time on your OS (possibly by ntp).
+
+After the installation failed, reboot again to the ISO and run the following commands:
 
 ```sh
 sudo rm -rf /etc/pacman.d/gnupg
 timedatectl set-ntp true
 ```
 
-After that, click on the **Launch Installer**  Button and proceed with the installation.
-This will be fixed in the September 2024 Release.
+Having done that, click on ***Launch Installer*** and proceed with the installation.


### PR DESCRIPTION
Now this section shows  how to navigate + install CachyOS by either using the "Erase Disk" method or through manual partitioning for systemd-boot, GRUB and rEFInd.

Partition layouts is removed from "Boot Managers" in favor of this rework to avoid having duplicates.
Minor wording changes to "Boot Managers"

Any suggestion or change, just let me know.