### PR TITLE
Fix typo in link pointing to a github issue

### DIFF
--- a/src/content/docs/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/configuration/general_system_tweaks.mdx
@@ -201,7 +201,7 @@ kernel.split_lock_mitigate=0
 For more information on split lock, see:
 
 - https://www.phoronix.com/news/Linux-Splitlock-Hurts-Gaming
-- https://github.com/doitsujin/dxvk/issues/2938\
+- https://github.com/doitsujin/dxvk/issues/2938
 
 7\. Enable RCU Lazy
 ---------------------------------


### PR DESCRIPTION
Fix typo in link, so it actually opens the issue instead of starting a search.