### PR TITLE
November Wiki Update

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -100,14 +100,6 @@ export default defineConfig({
               },
               link: 'cachyos_basic/download',
             },
-            {
-              label: 'CachyOS Requirements & Installation Media',
-              translations: {
-                sk: 'PPožiadavky CachyOS a inštalačné médium',
-                cs: 'Požadavky CachyOS a instalační médium',
-              },
-              link: 'installation/installation_prepare',
-            },
           ],
         },
         {
@@ -117,6 +109,14 @@ export default defineConfig({
             cs: 'Instalace',
           },
           items: [
+            {
+              label: 'Requirements & Preinstall Setup',
+              translations: {
+              sk: 'PPožiadavky CachyOS a inštalačné médium',
+              cs: 'Požadavky CachyOS a instalační médium',
+              },
+              link: 'installation/installation_prepare',
+            },
             {
               label: 'Boot Managers',
               translations: {

--- a/src/content/docs/cachyos_basic/why_cachyos.md
+++ b/src/content/docs/cachyos_basic/why_cachyos.md
@@ -44,10 +44,6 @@ We offer a variety of [desktop environments](/installation/desktop_environments/
 and [kernels](/features/kernel#variants) to choose from.
 You can choose what you need and deselect whatever you don't. Your system, your choices.
 
-:::caution[WARNING]
-Selecting multiple desktop environments is not allowed due to possible breakage. For example, KDE and GNOME. We recommend choosing a single desktop environment to avoid an installation error.
-:::
-
 ## User Friendly OS
 
 By default, we provide our own applications, such as CachyOS Hello or CachyOS Package Installer

--- a/src/content/docs/cachyos_basic/why_cachyos.md
+++ b/src/content/docs/cachyos_basic/why_cachyos.md
@@ -50,19 +50,22 @@ Our installer guarantees that users can have the choice of what system they want
 - [Filesystems](/installation/filesystem)
 - Custom Packages to install during the installation process
 
-## User Friendly OS
+## CachyOS Applications
 
 By default, we provide our own applications, such as CachyOS Hello or CachyOS Package Installer
 among others to simplify and enhance your Linux experience. For example, CachyOS Hello provides options to update your system, enable services and rank the mirrors. Package Installer will help you to install packages. Also some tweaks and quick access for fixes to the most common issues found in Arch e.G: removing pacman's db lock.
-CachyOS has a really good and friendly Discord community that like to help and assist each other. Join us at [Discord](https://discord.com/invite/cachyos-862292009423470592) or our [forum](https://discuss.cachyos.org/)
 
-CachyOS Applications
-
---------------------
+List of applications we develop and maintain:
 
 - **Cachy Browser**: Browser based on Firefox, with a more secure config and patches from Gentoo + Performance optimizations.
-- **cachyos-kernel-manager**: Easily install kernels from the repository or configure your own kernel and include your own patches and even manage the sched-ext framework via the [scx_loader](<https://github.com/sched-ext/scx/tree/main/rust/scx_loader>).
+- **CachyOS Kernel Manager**: Easily install kernels from the repository or configure your own kernel and include your own patches and even manage the sched-ext framework via the [scx_loader](<https://github.com/sched-ext/scx/tree/main/rust/scx_loader>).
 - **CachyOS Hello**: Application for controlling tweaks, applying fixes, package installation and more information about CachyOS.
-- **CachyOS-ApplicationInstaller**: GUI for an easy installation of commonly used applications.
+- **CachyOS Package Installer**: GUI for an easy installation of commonly used applications.
 - **cachyos-rate-mirrors**: Automatically rank Arch and CachyOS mirrors for optimal download speeds.
 - **systemd-boot-manager**: Automatically generates new entries for the systemd-boot-manager and can be easily configured in `/etc/sdboot-manage.conf`.
+
+## Friendly and Active Community
+
+Finally, our ever-growing community is the most important part of our highlight. Without the community, CachyOS would never be able to reach where it is now.
+The community assist each other and share tips and tricks for a better linux experience. If you would like to be part of our family, join us in our 
+[Discord](https://discord.com/invite/cachyos-862292009423470592) or our [forum](https://discuss.cachyos.org/).

--- a/src/content/docs/cachyos_basic/why_cachyos.md
+++ b/src/content/docs/cachyos_basic/why_cachyos.md
@@ -10,7 +10,13 @@ CachyOS offers a polished Arch experience, complete with a user-friendly install
 CachyOS offers optimized packages for various hardware configurations, including x86-64-v3, x86-64-v4, and Zen4+ systems to improve overall
 performance of the system. Additionally, we ship highly-requested [AUR](https://aur.archlinux.org/) packages from users for QoL improvements.
 
-For a better idea of the various packages we have optimized, learn more at our [optimized repositories page](/features/optimized_repos)
+For a better idea of the various packages we have optimized, learn more at our [optimized repositories page](/features/optimized_repos).
+
+## Custom Kernel Tuned for Performance and Stability
+
+Aside from our main patchset that tunes various kernel tunables to improve desktop responsivness, we also cherrypick promising patchsets that have not been
+mainlined or not in the stable revision of the kernel. These patches undergo internal testing before being shipped to users to ensure that stability isn't
+impacted. For a complete list of patches that we provide, visit [our kernel page](/features/kernel).
 
 ## Advanced CPU Scheduler Support
 

--- a/src/content/docs/cachyos_basic/why_cachyos.md
+++ b/src/content/docs/cachyos_basic/why_cachyos.md
@@ -3,15 +3,14 @@ title: Why CachyOS?
 description: Why CachyOS may be better for you
 ---
 
-CachyOS offers a polished Arch experience, complete with a user-friendly installer, pre-configured desktops, performance optimizations without compromising the user experience and security of the system.
-
-Besides performance changes, we provide a ready to go setup for NVIDIA GPUs, ZFS which is built into some of our kernels and miscellaneous tools.
+CachyOS offers a polished Arch experience, complete with a user-friendly installer, pre-configured desktops and performance optimizations without compromising the user experience and security of the system. Below are some of the highlight features that we provide to ensure an amazing desktop experience.
 
 ## Optimized Packages and Repositories
 
-CachyOS offers optimized packages for various hardware configurations, including x86-64, x86-64-v3, x86-64-v4, and Zen 4 to enhance performance and reduce latency.
+CachyOS offers optimized packages for various hardware configurations, including x86-64-v3, x86-64-v4, and Zen4+ systems to improve overall
+performance of the system. Additionally, we ship highly-requested [AUR](https://aur.archlinux.org/) packages from users for QoL improvements.
 
-Check out [this](/features/optimized_repos) page for a more detailed explanation of the optimized repositories that we provide.
+For a better idea of the various packages we have optimized, learn more at our [optimized repositories page](/features/optimized_repos)
 
 ## Advanced CPU Scheduler Support
 

--- a/src/content/docs/cachyos_basic/why_cachyos.md
+++ b/src/content/docs/cachyos_basic/why_cachyos.md
@@ -18,16 +18,23 @@ Aside from our main patchset that tunes various kernel tunables to improve deskt
 mainlined or not in the stable revision of the kernel. These patches undergo internal testing before being shipped to users to ensure that stability isn't
 impacted. For a complete list of patches that we provide, visit [our kernel page](/features/kernel).
 
-## Advanced CPU Scheduler Support
+## Custom CPU Scheduler Support
 
-Firstly let's understand what a CPU scheduler is. In the Linux Kernel, the CPU scheduler is a crucial component
-that manages how tasks (or processes) are executed on the system. It decides which task should run next,
-ensuring efficient use of system resources to allow multiple tasks to run simultaneously.
+CPU scheduling is an important part of the kernel to ensure all tasks are allocated CPU time fairly. The Linux kernel implements various scheduling classes
+to ensure that each and every task gets scheduled appropriately. The fair scheduling class, more well known as just "default scheduler" is based on the
+[EEVDF (Earliest Eligible Virtual Deadline First)](https://lwn.net/Articles/925371/) algorithm.
 
-By default CachyOS provides BORE (Burst-Oriented Response Enhancer) scheduler in the default kernel,
-an extended version of EEVDF + sched-ext, a framework to load userspace schedulers. We also provide other kernels with individual versions of EEVDF and the sched-ext framework separately. You can choose your preferred kernel variant and its corresponding scheduler using the kernel manager bundled with the installation.
+By default EEVDF is tuned to divide available CPU time fairly among all tasks and is mostly geared for throughput-oriented workloads. Our kernel
+[configures some EEVDF tunables](https://github.com/CachyOS/linux/blob/6.12/cachy/kernel/sched/fair.c#L76-L79) to prioritize desktop responsiveness over 
+sheer throughput, but there are limitations.
 
-For more information about the kernels that we offer, check out the [variants](/features/kernel#variants) page.
+With that in mind, we go one step further and patch our kernel with the [BORE (Burst-Oriented Response Enhancer)](https://github.com/firelzrd/bore-scheduler)
+that introduces an additional property to assign tasks requiring high responsiveness more CPU time compared to tasks that don't based on their "burstiness".
+
+In 6.12, we also have the ability to hotplug BPF schedulers and replace the fair scheduling class with a different scheduler. To facilitate this, we provide
+first-class support for [sched-ext schedulers](https://github.com/sched-ext/scx)
+
+For more information about the kernels that we offer and sched-ext schedulers, see [kernels](/features/kernels) and [sched-ext](/configuration/sched-ext/).
 
 ## Customizable Installation Process
 

--- a/src/content/docs/cachyos_basic/why_cachyos.md
+++ b/src/content/docs/cachyos_basic/why_cachyos.md
@@ -43,11 +43,12 @@ post-install setups from users.
 
 ## Customizable Installation Process
 
-Start your CachyOS journey by booting from the [bootable USB](/installation/installation_prepare/#creating-a-bootable-cachyos-usb-drive) that you created,
-You’ll be welcomed by our Hello program, a helpful introduction to CachyOS. Our customized Calamares installer provides a wide range of possibilities.
-We offer a variety of [desktop environments](/installation/desktop_environments/), [boot managers](/installation/boot_managers/)
-and [kernels](/features/kernel#variants) to choose from.
-You can choose what you need and deselect whatever you don't. Your system, your choices.
+Our installer guarantees that users can have the choice of what system they want. This customizability includes but is not limited to:
+- [Desktop Environments](/installation/desktop_environments/)
+- [Boot Managers](/installation/boot_managers/)
+- [Kernel Flavours](/features/kernel#variants)
+- [Filesystems](/installation/filesystem)
+- Custom Packages to install during the installation process
 
 ## User Friendly OS
 

--- a/src/content/docs/cachyos_basic/why_cachyos.md
+++ b/src/content/docs/cachyos_basic/why_cachyos.md
@@ -36,6 +36,11 @@ first-class support for [sched-ext schedulers](https://github.com/sched-ext/scx)
 
 For more information about the kernels that we offer and sched-ext schedulers, see [kernels](/features/kernels) and [sched-ext](/configuration/sched-ext/).
 
+## Hardware Detection
+
+Our own [hardware detection tool](https://github.com/CachyOS/chwd) correctly installs necessary packages and drivers for each system to lighten the burden of 
+post-install setups from users.
+
 ## Customizable Installation Process
 
 Start your CachyOS journey by booting from the [bootable USB](/installation/installation_prepare/#creating-a-bootable-cachyos-usb-drive) that you created,

--- a/src/content/docs/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/configuration/general_system_tweaks.mdx
@@ -5,67 +5,7 @@ description: Things you can do to tweak after installing
 
 import { Steps } from '@astrojs/starlight/components';
 
-1\. CPU mitigations
---------------------------------
-
-A public speculative execution attack exploiting return instructions (retbleed) was revealed in July 2022. This has been mitigated in the kernel, but it results in a significant performance regression (14-39%).
-
-The following CPU's are affected:
-
-*   AMD: Zen 1, Zen 1+, Zen 2
-*   Intel: 6th to 8th Generation, Skylake, Kaby Lake, Coffee Lake
-
-Check which mitigation affects your CPU by running the following command:
-
-```sh
-grep . /sys/devices/system/cpu/vulnerabilities/*
-```
-
-### Disabling mitigations
-
-While disabling the CPU mitigation's is going to increase performance, as a downside it introduces security risks.
-
-:::caution
-Do so at your own risk.
-:::
-
-
-Add the following to your kernel [command-line](/configuration/boot_manager_configuration/): `retbleed=off` or to disable all mitigation's: `mitigations=off`
-
-Edit the appropriate file to make the changes persistent:
-
-- **GRUB**: `/etc/default/grub`
-- **systemd boot**: `/etc/sdboot-manage.conf`
-- **rEFInd**: `/boot/refind_linux.conf`
-
-:::caution
-Disabling these mitigation's poses a security risk to your system.
-:::
-
-For more information about the impact on performance:
-
-*   https://www.phoronix.com/review/retbleed-benchmark
-*   https://www.phoronix.com/review/xeon-skylake-retbleed
-
-### Downfall
-
-Downfall is characterized as a vulnerability due to a memory optimization feature that unintentionally reveals internal hardware registers to software. With Downfall, untrusted software can access data stored by other programs that typically should be off-limits: the AVX GATHER instruction can leak the contents of the internal vector register file during speculative execution. Downfall was discovered by security researcher Daniel Moghimi of Google. Moghimi has written demo code for Downfall to show 128-bit and 256-bit AES keys being stolen from other users on the local system as well as the ability to steal arbitrary data from the Linux kernel.
-
-This affects the following CPU generations:
-- Ice Lake
-- Skylake
-- Kaby Lake
-- Coffee Lake
-- Comet Lake
-- Rocket Lake
-- Tiger Lake
-
-#### Disabling Downfall
-
-Add `gather_data_sampling=off` to your kernel cmdline parameters list.
-`mitigations=off` will also disable downfall.
-
-2\. AMD P-State Driver
+1\. AMD P-State Driver
 ---------------------------
 
 `amd-pstate` is the AMD CPU performance scaling driver that introduces a new CPU frequency control mechanism on modern AMD APU and CPU series in the Linux kernel. The new mechanism is based on Collaborative Processor Performance Control (CPPC) which provides finer grain frequency management than legacy ACPI hardware P-States. Current AMD CPU/APU platforms are using the ACPI P-states driver to manage CPU frequency and clocks with switching only in 3 P-states. CPPC replaces the ACPI P-states controls and allows a flexible, low-latency interface for the Linux kernel to directly communicate the performance hints to hardware.
@@ -103,7 +43,7 @@ For more information:
 *   [https://lore.kernel.org/lkml/20221110175847.3098728-1-Perry.Yuan@amd.com/](https://lore.kernel.org/lkml/20221110175847.3098728-1-Perry.Yuan@amd.com/)
 *   [https://lore.kernel.org/lkml/20230119115017.10188-1-wyes.karny@amd.com/](https://lore.kernel.org/lkml/20230119115017.10188-1-wyes.karny@amd.com/)
 
-3\. Using AMD P-State EPP
+2\. Using AMD P-State EPP
 ------------------------
 
 To use the P-State EPP, there are two CPU frequency scaling governors available: **powersave** and **performance**. It is recommended to use the powersave governor and set a preference.
@@ -122,7 +62,7 @@ Available preferences: `performance`, `power`, `balance_power`, `balance_perform
 Benchmarks for each preference can be found here:
 [https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/)
 
-5\. AMD 3D V Cache Optimizer
+3\. AMD 3D V-Cache Optimizer
 ---------------------------------
 
 AMD posted a patch to optimize the Cache Scheduling on Dual CCD 3D CPUs, like 7950X3D and 7900X3D.
@@ -150,7 +90,7 @@ After you changed the modes, the amd preffered core stats should provide a diffe
 grep -v /sys/devices/system/cpu/cpu*/cpufreq/amd_pstate_prefcore_ranking
 ```
 
-5\. AMD P-State Core Performance Boost
+4\. AMD P-State Core Performance Boost
 ---------------------------------
 
 AMD Core Performance Boost aka AMD Turbo Core is a dynamic frequency scaling technology by AMD that allows the
@@ -184,7 +124,7 @@ For more information see:
 - https://lore.kernel.org/linux-pm/1a78eeaa-fadd-4734-aaeb-2fe11e96e198@amd.com/T/#m4a0c8917ea8fb033504055bd61512c80c85410c8
 - https://lore.kernel.org/linux-pm/20240624213400.67773-1-mario.limonciello@amd.com/
 
-6\. Disabling Split Lock Mitigate
+5\. Disabling Split Lock Mitigate
 ---------------------------------
 
 In some cases, split lock mitigate can slow down performance in some applications and games. A patch is available to disable it via sysctl.
@@ -203,7 +143,7 @@ For more information on split lock, see:
 - https://www.phoronix.com/news/Linux-Splitlock-Hurts-Gaming
 - https://github.com/doitsujin/dxvk/issues/2938
 
-7\. Enable RCU Lazy
+6\. Enable RCU Lazy
 ---------------------------------
 
 RCU Lazy helps reducing the power usage at idle or lightly loaded systems. This can be useful for laptops and handheld devices.
@@ -215,7 +155,7 @@ To enable RCU Lazy, add the following parameter to your kernel [cmdline](/config
 rcutree.enable_rcu_lazy=1
 ```
 
-8\. NVIDIA GSP Firmware
+7\. NVIDIA GSP Firmware
 ---------------------------------
 
 The NVIDIA GSP Firmware can **"in some cases"** lead to decreased performance. While the 555.58.02 NVIDIA Driver has largely addressed this issue, it may persist on certain systems.
@@ -237,7 +177,7 @@ NVIDIA's [open kernel modules](https://github.com/NVIDIA/open-gpu-kernel-modules
 
 It's generally recommended to test the GSP firmware after each new NVIDIA driver installation, as it often introduces beneficial features. Moreover, NVIDIA primarily started conducting QA testing using the GSP firmware.
 
-9\. Disabling SDDM Wayland Backend
+8\. Disabling SDDM Wayland Backend
 ---------------------------------
 
 :::note
@@ -251,7 +191,7 @@ In order to revert this change. **Remove** cachyos-kde-settings:
 sudo pacman -R cachyos-kde-settings
 ```
 
-10\. Granting Realtime Privileges for the User
+9\. Granting Realtime Privileges for the User
 ---------------------------------
 
 :::note

--- a/src/content/docs/configuration/sched-ext.md
+++ b/src/content/docs/configuration/sched-ext.md
@@ -3,21 +3,9 @@ title: sched-ext Tutorial
 description: Tutorial how to use LAVD, Rusty, Rustland and bpfland
 ---
 
-`sched-ext` is a Linux kernel feature which enables implementing kernel thread schedulers in BPF (Berkeley Package Filter)
-and dynamically loading them. Essentially this allows end-users to change their schedulers in userspace without the need to
-build another kernel for a different scheduler.
-
-- Planned release for being an official kernel feature: 6.12
-
-## Installing a Kernel with sched-ext support
-
-CachyOS provides kernels, which have OOB support for the sched-ext framework.
-Following kernels are supported:
-
-- linux-cachyos (default kernel)
-- linux-cachyos-sched-ext (latest Stable release)
-- linux-cachyos-sched-ext-dbg (This is mainly for developers to develop and work on sched-ext)
-- linux-cachyos-rc (latest testing release with the latest features)
+Extensible Scheduler Class, or better known as `sched-ext` is a Linux kernel feature which enables implementing kernel thread schedulers in 
+BPF (Berkeley Package Filter) and dynamically loading them. Essentially this allows end-users to change their schedulers in userspace without 
+the need to build another kernel for a different scheduler.
 
 ## Starting and using the scx schedulers
 

--- a/src/content/docs/features/cachyos_settings.mdx
+++ b/src/content/docs/features/cachyos_settings.mdx
@@ -9,7 +9,7 @@ We also bundle in some helper scripts to for QoL improvements. All these configu
 
 ## sysctl Tweaks
 
-We provide a lot of sysctl tweaks that aims to improve overall desktop performance. Each sysctl entry is well documented 
+We provide a lot of sysctl tweaks that aims to improve overall desktop performance. Each sysctl entry is well documented
 in the file [`99-cachyos-settings.conf`](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/sysctl.d/99-cachyos-settings.conf)
 
 To make changes to any of these values, copy the original entry and make a new file under `/etc/sysctl.d/` for the modified value.
@@ -107,10 +107,8 @@ database
 
 ### Memory Usage Tweaks
 
-- Disable Zswap
 - THP Shrinker configuration (max_ptes_none = 409)
 - Set maximum size to 50MB for the systemd journal
-- Set Transparent Hugepage Defrag to `defer+madvise`
 - [ZRAM Generator](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/systemd/zram-generator.conf) - Sets ZRAM to the same size as RAM and use ZSTD for compression
 
 ### Ananicy-cpp Rules

--- a/src/content/docs/features/kernel.md
+++ b/src/content/docs/features/kernel.md
@@ -35,15 +35,15 @@ BORE is an enhancement for EEVDF resulting in a more capable scheduler at handli
 ### linux-cachyos (Default Kernel)
 
 The default kernel is our main recommendation in terms of scheduler choice and configuration. Currently, our default kernel
-is using the [BORE](https://github.com/firelzrd/bore-scheduler) scheduler as the default option, along with our **base patch set**. However, we also include the sched-ext framework, which enables switching to different schedulers at runtime. See our [sched-ext tutorial](/configuration/sched-ext)
-for recommendations of these schedulers.
+is using [BORE](https://github.com/firelzrd/bore-scheduler) scheduler as the default option, along with our **base patch set**. It is built
+with the [clang](https://clang.llvm.org/) C compiler with ThinLTO enabled to produce more optimized binaries.
 
 Feel free to open an issue in our [GitHub](https://github.com/CachyOS/linux-cachyos) or reach out
 to us in [Discord](https://discord.gg/cachyos-862292009423470592) for suggestions and improvements that should be added to the default kernel.
 
 ### linux-cachyos-autofdo
 
-Variant slightly more performant in some workloads, For example y-cruncher. It contains the same patch set as the default kernel + BORE/EEVDF Scheduler + sched-ext framework. For more information about AutoFDO, check out the links down below:
+Variant slightly more performant in some workloads, For example y-cruncher. It contains the same patch set as the default kernel + BORE/EEVDF Scheduler. For more information about AutoFDO, check out the links down below:
 
 - [Optimizing the Kernel with AutoFDO on CachyOS](https://cachyos.org/blog/2411-kernel-autofdo/)
 
@@ -52,7 +52,7 @@ Variant slightly more performant in some workloads, For example y-cruncher. It c
 
 ### linux-cachyos-bore
 
-This variant includes the CachyOS Base Patch set + BORE/EEVDF Scheduler with its default configuration but without including the sched-ext framework.
+This variant includes the CachyOS Base Patch set + BORE/EEVDF Scheduler with its default configuration.
 
 ### linux-cachyos-bmq
 
@@ -81,7 +81,7 @@ This kernel uses the BORE/EEVDF scheduler.
 
 The RC Kernel is based on the latest available Release Candidate. This contains the latest features and changes from upstream but can lead to a more unstable experience due to being experimental/bleeding edge.
 
-Additionally it also contains our CachyOS Base patch set, sched-ext Framework and the BORE/EEVDF Scheduler.
+Additionally it also contains our CachyOS Base patch set and the BORE/EEVDF Scheduler.
 
 ### linux-cachyos-rt-bore
 

--- a/src/content/docs/features/kernel.md
+++ b/src/content/docs/features/kernel.md
@@ -90,7 +90,8 @@ The RT (Real Time) kernel contains the CachyOS Base patch set, Real Time Patch a
 ### linux-cachyos-server
 
 The Server Kernel is targeted for servers and more throughput. **The kernel is NOT tuned for interactivity and is not suggested for desktop users**.
-The main differences here are a lower tickrate (300Hz), No Preemption and CONFIG_CACHY not applied. This kernel only contains the CachyOS Base patch set.
+The main differences here are a lower tickrate (300Hz), [Lazy Preemption](https://lwn.net/Articles/994322/) and CONFIG_CACHY not applied. 
+This kernel only contains the CachyOS Base patch set.
 
 ## FAQ
 

--- a/src/content/docs/features/kernel.md
+++ b/src/content/docs/features/kernel.md
@@ -87,14 +87,6 @@ Additionally it also contains our CachyOS Base patch set, sched-ext Framework an
 
 The RT (Real Time) kernel contains the CachyOS Base patch set, Real Time Patch and BORE/EEVDF Scheduler. RT Preemption enabled by default.
 
-### linux-cachyos-sched-ext
-
-:::note
-Soon to be deprecated because this framework is included in +6.12 Linux Kernel.
-:::
-
-The sched-ext kernel contains the CachyOS Base patch set and the sched-ext Framework + EEVDF as the base scheduler.
-
 ### linux-cachyos-server
 
 The Server Kernel is targeted for servers and more throughput. **The kernel is NOT tuned for interactivity and is not suggested for desktop users**.

--- a/src/content/docs/features/kernel.md
+++ b/src/content/docs/features/kernel.md
@@ -85,7 +85,7 @@ Additionally it also contains our CachyOS Base patch set, sched-ext Framework an
 
 ### linux-cachyos-rt-bore
 
-The RT (Real Time) kernel contains the CachyOS Base patch set, Real Time Patch and BORE/EEVDF Scheduler. RT Preemption enabled by default.
+Our default kernel but with `preempt=rt` enabled. **Intel GPUs are not supported**
 
 ### linux-cachyos-server
 

--- a/src/content/docs/features/kernel.md
+++ b/src/content/docs/features/kernel.md
@@ -105,6 +105,7 @@ Because it's expensive to build since it basically requires building the kernel 
 
 So for now it's another variant but it will become the default kernel in the near future. ETA (6.12.1 - 6.12.2)
 
-### I always heard that using the Real Time variant helps in Gaming!
+### I always heard that using the Real Time variant helps in Gaming! Is that true?
 
-Not really and on the other hand, it results in worse results with barely any benefit. The non Real Time kernels are more than enough & capable for Gaming (excluding Server & Hardened variants)
+Real time scheduling necessitates a task to be processed on a specified deadline. Gaming on the other hand spawns a lot of processes every second. Real time
+scheduling may cause these processes to end prematurely or even stall, leading to worse performance overall.

--- a/src/content/docs/features/optimized_repos.mdx
+++ b/src/content/docs/features/optimized_repos.mdx
@@ -5,10 +5,9 @@ description: Information about our optimized repositories
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
-Our aim to deliver a performance-optimized distribution necessitates recompiling essential Arch Linux packages for generic x86-64,
-x86-64-v3, x86-64-v4, and Zen4 architectures.
+Our aim to deliver a performance-optimized distribution necessitates recompiling essential Arch Linux packages for x86-64-v3, x86-64-v4
+and Zen4 architectures.
 
-- **x86-64:** While lacking AVX2 support found in x86-64-v3, this repository offers optimized packages. LTO and PGO techniques have boosted performance in several packages.
 - **x86-64-v3:** 5%-20% performance uplift compared to x86-64.
 - **x86-64-v4:** Delivers substantial performance gains through AVX512 support, depending on the workload.
 - **Zen 4/5:** In addition to the x86-64-v4 instruction set, the following are added:

--- a/src/content/docs/installation/filesystem.md
+++ b/src/content/docs/installation/filesystem.md
@@ -6,7 +6,7 @@ description: Description and recommendations for the available filesystems. (ext
 CachyOS offers 5 filesystems to allow the user to choose what best fits their needs. The following will go over advantages, disadvantages and recommendations for each filesystem. Each filesystem comes with its requirements/utilities preinstalled on CachyOS.
 
 :::note
-CachyOS defaults to BTRFS if no other filesystem is selected when installing.
+BTRFS is our default and recommended filesystem of choice. Choose that if unsure.
 :::
 
 ## XFS

--- a/src/content/docs/installation/installation_handheld.mdx
+++ b/src/content/docs/installation/installation_handheld.mdx
@@ -65,7 +65,3 @@ After the installation is completed. Calamares will prompt you to reboot the dev
 
 The first boot can take a bit of time, since Steam is getting downloaded and started.
 This process can take up to 2 minutes.
-
-## Installation with Secure Boot Support
-
-ToDo

--- a/src/content/docs/installation/installation_prepare.mdx
+++ b/src/content/docs/installation/installation_prepare.mdx
@@ -6,13 +6,13 @@ description: How to prepare CachyOS for installation
 import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
-<Aside type="tip" title="Getting ready for CachyOS.">
+<Aside type="tip" title="Getting Ready for CachyOS.">
    The following section will guide you through the steps to prepare your USB drive with CachyOS ISO image for installation and the necessary requirements.
 </Aside>
 
 ## System Requirements
 
-Before you begin with the preparation for installation, you need to make sure that your computer meets the following system requirements in order to run CachyOS.
+Before you begin with the preparation for installation, you need to make sure that your computer meets the following system requirements in order to run CachyOS. Bear in mind that our installation process uses online installation.
 
 <Tabs>
 
@@ -20,21 +20,19 @@ Before you begin with the preparation for installation, you need to make sure th
 
 *   3 GB RAM
 *   30 GB of Storage Space (HDD/SSD)
-*   [x86-64-v1 capable CPU](/installation/installation_prepare#x86_64-microarchitecture-level-support) (64-bit)
-*   Integrated graphics card
 *   Stable internet connection
 
-:::note
-An unstable internet can lead to installation issues and long waits.
+:::caution
+Unstable internet may cause prolonged period of installation or failed installs at worst
 :::
 
 </TabItem>
 
 <TabItem label="Recommended requirements">
 
-*   4 GB RAM (Ideally 8GB and more)
+*   8GB RAM
 *   50 GB of Storage Space (SSD/NVMe)
-*   [x86-64-v3 & v4 capable CPU](/installation/installation_prepare#x86_64-microarchitecture-level-support)
+*   [x86-64-v3 capable CPU](/installation/installation_prepare#x86_64-microarchitecture-level-support)
 *   50 Mbps or better internet speed
 *   NVIDIA GPU (900+ - e.g: GTX 950), AMD +GCN 1.0 (e.g: AMD R7 240) or Intel (Integrated HD Graphics series or higher. Arc Series)
 
@@ -125,10 +123,10 @@ Be sure to have the USB drive **boot priority** over other drives in the BIOS/UE
    # Linux
    # Your USB drive could be identified e.g: /dev/sda, by disk model and size.
    sudo fdisk -l
-   
+
    # MacOS
    # USB drives are identified as "/dev/diskY" where "Y" could be 0,1 etc.
-   diskutil list 
+   diskutil list
    ```
 3. Copy the iso contents to your USB drive by running:
    ```sh

--- a/src/content/docs/installation/installation_prepare.mdx
+++ b/src/content/docs/installation/installation_prepare.mdx
@@ -44,22 +44,12 @@ Unstable internet may cause prolonged period of installation or failed installs 
 
 <Tabs>
 
-<TabItem label="x86_64-v1 Compatible CPUs">
-
-- **Intel**
-   - Anything older than Haswell. For example: **Intel 3770k, Intel N2600**
-- AMD
-   - Anything older than Zen. For example: **AMD FX Series**
-
-</TabItem>
-
 <TabItem label="x86_64-v3 Compatible CPUs">
 
 - **Intel**
-  - Haswell and later generations **(e.g., Broadwell, Skylake, Coffee Lake, Cascade Lake, Ice Lake, Tiger Lake, Alder Lake, Raptor Lake, Meteor Lake, Lunar Lake)**
+  - Haswell and later generations **(e.g., Broadwell, Skylake, Coffee Lake, etc)**
 - **AMD**
-  - **Ryzen 1st, 2nd, 3rd, 4th, 5th, 7th, and 9th generations**
-  - **EPYC 1st-3rd Gen**
+  - **Ryzen Series**
 
 </TabItem>
 
@@ -68,7 +58,7 @@ Unstable internet may cause prolonged period of installation or failed installs 
 - **Intel**
   - **Knights Landing (Xeon Phi x200), Knights Mill (Xeon Phi x205), Skylake-SP, Skylake-X, Cannon Lake, Cascade Lake, Cooper Lake, Ice Lake, Rocket Lake, Tiger Lake and Sapphire Rapids**
 - **AMD**
-  - **Zen 4, Zen 5, AMD EPYC 4th Generation (Genoa) and 5th Generation (Siena)**
+  - **Zen4+ CPUs**
 
 </TabItem>
 


### PR DESCRIPTION
This updates the wiki to sync information that is relevant as of now. This includes:
- sched-ext being mainlined in 6.12 - It's not a shiny feature that's exclusive to CachyOS anymore :(
- Update kernel options
- Remove redundant features - updates to the related packages are coming soon
- Rewrite some sections
- Remove disabling CPU mitigations as a system tweak

Refer to individual commits for details. If information is missing from a specific commit, please let me know.