### PR TITLE
Remove Dangerous Recommendation from the FAQ

### DIFF
--- a/src/content/docs/support/faq.mdx
+++ b/src/content/docs/support/faq.mdx
@@ -92,7 +92,7 @@ sudo pacman -Syuu
 
 ```code
 # Example
-sudo pacman -S telegram-desktop    
+sudo pacman -S telegram-desktop
 resolving dependencies...
 looking for conflicting packages...
 
@@ -110,7 +110,7 @@ error: failed retrieving file 'telegram-desktop-2.5.1-1-x86_64.pkg.tar.zst' from
 This means that your local database is outdated therefore the package you're asking for can't be downloaded. Run the following command to update your local database:
 
 ```sh
-sudo pacman -Sy
+sudo pacman -Syu
 # Then try to install the package you want again.
 ```
 

--- a/src/content/docs/support/faq.mdx
+++ b/src/content/docs/support/faq.mdx
@@ -107,7 +107,7 @@ Total Installed Size:  67.51 MiB
 error: failed retrieving file 'telegram-desktop-2.5.1-1-x86_64.pkg.tar.zst' from archlinux.mailtunnel.eu : The requested URL returned error: 404
 ```
 
-This means that your local database is outdated therefore the package you're asking for can't be downloaded. Run the following command to update your local database:
+This means that your local database is outdated therefore the package you're asking for can't be downloaded. Run the following command to refresh the package database and do a full upgrade:
 
 ```sh
 sudo pacman -Syu


### PR DESCRIPTION
This gets rid of the `sudo pacman -Sy` instruction in the FAQ. This is a dangerous operation and should basically never be used on Arch. Recommending this **will** lead to broken installs sooner rather than later. For more information, see [the Arch Wiki](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported).

> That is why partial upgrades are not supported. Do not use:
> 
> - `pacman -Sy package`
> - `pacman -Sy` followed by `pacman -S package` (Note the absence of `-Su` in the installation of the package.)