### PR TITLE
Clearify users and redistribution

### DIFF
--- a/src/content/docs/policy/repository_policy.md
+++ b/src/content/docs/policy/repository_policy.md
@@ -6,47 +6,79 @@ CachyOS Repository Usage Policy
 
 ## 1. Introduction
 
-The CachyOS repository is designed to provide high-quality, optimized packages for users of the CachyOS and ArchLinux distributions. This policy outlines the terms and conditions for the use of the CachyOS repository.
+The CachyOS repository is designed to provide high-quality, optimized packages for users of the CachyOS and ArchLinux distributions. This policy outlines the terms and conditions for the use of the CachyOS repository. 
 
-## 2. Authorized Users
+## 2. Disclaimer of Warranty
 
-The CachyOS repository is exclusively available for the following users:
+Unless required by applicable law or agreed to in writing, the CachyOS team provides the repository on an **"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND**, either express or implied, including, without limitation, 
+any warranties or conditions of **TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE**. You, as repository users, are solely responsible for determining the appropriateness of using the repository and assume
+any risks associated with your exercise of permissions.
 
-CachyOS Users
-ArchLinux Users
+## 3. Limitation of Liability
 
-## 3. Unauthorized Use
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall the CachyOS team 
+be liable to repository users for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this policy or out of the use or inability to use the repository 
+(including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if the CachyOS team has been advised of the possibility of such damages.
 
-Use of the CachyOS repository by any other Linux distributions, including other Arch-based distributions, is strictly prohibited. This includes, but is not limited to:
+## 4. User Scope
 
-Manjaro
-EndeavourOS
-ArcoLinux
-Parabola
-Any other Linux distribution not explicitly mentioned in the "Authorized Users" section
+The CachyOS repository (and its mirrors) is designed exclusively for the following users:
 
-# 4.Mirror
+- CachyOS Users
+- ArchLinux Users
+
+## 5. Unsupported Users
+
+Users from other distributions are **NOT SUPPORTED** and **HIGHLY DISCOURAGED** to use the CachyOS repository (and its mirrors). This includes, but is not limited to:
+
+- Manjaro
+- EndeavourOS
+- ArcoLinux
+- Parabola
+- Users of any other Linux distribution not explicitly mentioned in the "User Scope" section.
+
+## 5. Redistribution of the Repository
+
+By "redistribution", we mean the behaviors of inclusion of the CachyOS repository (and its mirrors) or packages obtained from the CachyOS repository as a part of the distributed image of the operating system. 
+This also applies to the behaviors of providing the utilities that enable CachyOS repository by users' choice, or providing any distributed or official document that guide users to enable CachyOS 
+repository (and its mirrors) by their means. 
+
+The CachyOS repository is exclusively authorized for redistribution in the following distributions:
+
+- CachyOS
+- ArchLinux
+
+## 6. Prohibited Redistribution
+Redistribution of the CachyOS repository (and its mirrors) in any unauthorized Linux distribution, including other Arch-based distributions, is strictly **STRICTLY PROHIBITED**. This includes, but is not limited to:
+
+- Manjaro
+- EndeavourOS
+- ArcoLinux
+- Parabola
+- Any other Linux distribution not explicitly mentioned in the "Redistribution of the Repository" section.
+
+## 7.Mirror
 It is allowed to mirror the repository via rsync and syncthing. Third-party mirrors are permitted to mirror the repository and provide a web server for it, as long as they ensure that the repository data remains unchanged.
 
-## 5. Compliance and Monitoring
+## 8. Compliance and Monitoring
 
 We reserve the right to monitor the usage of our repository to ensure compliance with this policy. Any unauthorized use may result in access being revoked.
 
-## 6. Reporting Violations
+## 9. Reporting Violations
 
 If you suspect that this policy is being violated, please report it to us at [admin@cachyos.org].
 
-## 7. Policy Changes
+## 10. Policy Changes
 
 CachyOS reserves the right to modify this policy at any time. Changes will be communicated through our official channels.
 
-## 8. Contact Information
+## 11. Contact Information
 
 For any questions or concerns regarding this policy, please contact us at:
 
 - Email: admin@cachyos.org
 - Website: https://cachyos.org
 
-## 8. Acknowledgment
+## 12. Acknowledgment
 
-By using the CachyOS repository, you acknowledge that you have read, understood, and agree to comply with this policy.
+By using the CachyOS repository (and its mirrors), you acknowledge that you have read, understood, and agree to comply with this policy.

--- a/src/content/docs/policy/repository_policy.md
+++ b/src/content/docs/policy/repository_policy.md
@@ -20,9 +20,9 @@ In no event and under no legal theory, whether in tort (including negligence), c
 be liable to repository users for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this policy or out of the use or inability to use the repository 
 (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if the CachyOS team has been advised of the possibility of such damages.
 
-## 4. User Scope
+## 4. Supported Users
 
-The CachyOS repository (and its mirrors) is designed exclusively for the following users:
+The CachyOS repository (and its mirrors) provides support exclusively for the following users:
 
 - CachyOS Users
 - ArchLinux Users
@@ -35,21 +35,21 @@ Users from other distributions are **NOT SUPPORTED** and **HIGHLY DISCOURAGED** 
 - EndeavourOS
 - ArcoLinux
 - Parabola
-- Users of any other Linux distribution not explicitly mentioned in the "User Scope" section.
+- Users of any other Linux distribution not explicitly mentioned in the "Supported Users" section.
 
 ## 5. Redistribution of the Repository
 
-By "redistribution", we mean the behaviors of inclusion of the CachyOS repository (and its mirrors) or packages obtained from the CachyOS repository as a part of the distributed image of the operating system. 
-This also applies to the behaviors of providing the utilities that enable CachyOS repository by users' choice, or providing any distributed or official document that guide users to enable CachyOS 
+This policy defines "redistribution" as the behaviors of inclusion of the CachyOS repository (and its mirrors) or packages obtained from the CachyOS repository as a part of the distributed image of the operating system or sysroots. 
+Redistribution also includes the behaviors of providing the utilities that enable CachyOS repository by users' choice, or providing any distributed or official document that guide users to enable CachyOS 
 repository (and its mirrors) by their means. 
 
-The CachyOS repository is exclusively authorized for redistribution in the following distributions:
+Redistribution of CachyOS repository is exclusively authorized to the following distributions:
 
 - CachyOS
 - ArchLinux
 
 ## 6. Prohibited Redistribution
-Redistribution of the CachyOS repository (and its mirrors) in any unauthorized Linux distribution, including other Arch-based distributions, is strictly **STRICTLY PROHIBITED**. This includes, but is not limited to:
+Redistribution of the CachyOS repository (and its mirrors) in any unauthorized Linux distribution, including other Arch-based distributions, is **STRICTLY PROHIBITED**. This includes, but is not limited to:
 
 - Manjaro
 - EndeavourOS

--- a/src/content/docs/policy/repository_policy.md
+++ b/src/content/docs/policy/repository_policy.md
@@ -43,10 +43,7 @@ This policy defines "redistribution" as the behaviors of inclusion of the CachyO
 Redistribution also includes the behaviors of providing the utilities that enable CachyOS repository by users' choice, or providing any distributed or official document that guide users to enable CachyOS 
 repository (and its mirrors) by their means. 
 
-Redistribution of CachyOS repository is exclusively authorized to the following distributions:
-
-- CachyOS
-- ArchLinux
+Redistribution of CachyOS repository is exclusively authorized to the CachyOS team only.
 
 ## 6. Prohibited Redistribution
 Redistribution of the CachyOS repository (and its mirrors) in any unauthorized Linux distribution, including other Arch-based distributions, is **STRICTLY PROHIBITED**. This includes, but is not limited to:


### PR DESCRIPTION
This patch addresses some concerns by third-party mirrors:

- we explicitly waive the liability and warranty of the repository
- change the policy to forbid redistribution of the repo in other os distributions, instead of "forbidding" the use of certain group of users.
