### PR TITLE
T2 Installation: Add link to t2linux preinstall guide

### DIFF
--- a/src/content/docs/installation/installation_t2macbook.mdx
+++ b/src/content/docs/installation/installation_t2macbook.mdx
@@ -20,6 +20,8 @@ See [installation of the firmware](#installation-of-the-firmware)
 Follow the instructions in [Installation Prepare](/installation/installation_prepare#creating-a-bootable-cachyos-usb-drive) on how to download
 the ISO and create a bootable USB drive.
 
+You need to follow additional steps to prepare a T2 MacBook for installing Linux such as partitioning your disk using macOS and disabling secure boot. You can follow the [t2linux Preinstall guide](https://wiki.t2linux.org/guides/preinstall/) for instructions.
+
 Refer to [Installation on Root](/installation/installation_on_root) after creating a bootable USB drive.
 CachyOS applies necessary boot parameters and configurations to the user's T2 MacBook with [CachyOS Hardware Detection](/features/chwd).
 


### PR DESCRIPTION
The wiki doesn't seem to have instructions on partitioning and disabling secure boot, which are needed for T2 Macs.