### PR TITLE
Fix punctuation error in gaming.mdx

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -30,7 +30,7 @@ The `cachyos-gaming-meta` package installs all the important libraries, packages
 
 ## Steam
 
-For Steam users, playing games on CachyOS is a breeze!. Open Steam and follow the [Proton guide](/configuration/gaming#how-to-enable-proton-support-in-steam) and you're ready to enjoy your games.
+For Steam users, playing games on CachyOS is a breeze! Open Steam and follow the [Proton guide](/configuration/gaming#how-to-enable-proton-support-in-steam) and you're ready to enjoy your games.
 
 :::note
 Laptop users with discrete NVIDIA GPUs should refer to the following [guide](https://wiki.cachyos.org/configuration/dual_gpu/)


### PR DESCRIPTION
Previously, a sentence in 'gaming.mdx' read "playing games on CachyOS is a breeze!.".

Instead, I have changed this to "playing games on CachyOS is a breeze!", as a full stop is not needed directly after an exclamation mark.