### PR TITLE
Fix to the hyprland.md documentation

### DIFF
--- a/src/content/docs/desktop_environments/hyprland.md
+++ b/src/content/docs/desktop_environments/hyprland.md
@@ -55,7 +55,7 @@ Most of the key combinations require the use of the mod key which in our case is
 
 ### Open Rofi (Program Launcher)
 
-* CTRL + Space
+* SUPER + Space
   
 ### Close focused window
 


### PR DESCRIPTION
To use the app launcher (rofi is the default), the actual keybinds inside .config/hypr/config/keybinds.conf is actually super + space, instead of ctrl + space in the wiki.