### PR TITLE
desktop_environment: kde: Remove Disable KWallet FAQ

### DIFF
--- a/src/content/docs/desktop_environments/kde.mdx
+++ b/src/content/docs/desktop_environments/kde.mdx
@@ -8,19 +8,6 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 ## FAQ
 
-### KDE keeps asking me for entering a password every time i open Discord, Brave or similar programs
-
-**This is due to KWallet being enabled by default. You'll need to disable it in order to avoid entering the password.**
-- What is the purpose of this "Wallet"?
-  - **Quote from Arch Wiki:** *"A wallet (in the KDE's terminology, sometimes called vault or keyring) is an encrypted volume protected by a user-defined password where user and/or software can store secrets (often, credentials when the user checked "Remember the account" in an application)."*
-
-Follow the steps from the [guide](https://wiki.archlinux.org/title/KDE_Wallet#Disable_KWallet) in the Arch Wiki in order to disable it.
-
-Once you have followed the guide. **Reboot or log out from KDE Plasma.**
-
-- **After disabling KWallet i had to relogin from all the services. Is that normal?**
-  - Yes. That usually happens when you have already created a password for the KWallet. Just log in to your accounts again and the credentials will then be saved without the password prompt.
-
 ### How can i get the same look as the one shown in the KDE Screenshots? named as "Emerald"
 
 - **It's a combination of the Emerald Theme + Qogir Icon Theme which they're not installed by default.**


### PR DESCRIPTION
Disabling this on KDE without a fallback secrets service can cause unwanted behaviour. We don't want any users from reporting issues due to KWallet being disabled.

Another option instead of outright removing this is to make it so that KWallet is configured correctly, that is for it to have the same password as the user so it's auto logged-in by SDDM.

Related: #99 