### PR TITLE
feat(configuration): add wireless-regdb to post install setup

### DIFF
--- a/src/content/docs/configuration/post_install_setup.mdx
+++ b/src/content/docs/configuration/post_install_setup.mdx
@@ -251,7 +251,7 @@ The `wireless-regdb` package includes a **database of wireless rules** (allowed 
    sudo micro /etc/conf.d/wireless-regdom
    ```
 2. **Set your country:**
-   Uncomment the line with your **two-letter ISO country code** (e.g., `WIRELESS_REGDOM="US"`). Ensure only one country is uncommented.
+   Uncomment the line with your **two-letter [ISO country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)** (e.g., `WIRELESS_REGDOM="US"`). Ensure only one country is uncommented.
 3. **Reboot:**
    A reboot is typically required for the change to take effect .
 
@@ -260,10 +260,38 @@ The `wireless-regdb` package includes a **database of wireless rules** (allowed 
 To **check the currently applied regulatory domain**, use the command :
 
 ```bash
-iw reg get
+❯ iw reg get
+global
+country 00: DFS-UNSET # Country 00 uses global defaults
+	(755 - 928 @ 2), (N/A, 20), (N/A), PASSIVE-SCAN
+	(2402 - 2472 @ 40), (N/A, 20), (N/A)
+	(2457 - 2482 @ 20), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
+	(2474 - 2494 @ 20), (N/A, 20), (N/A), NO-OFDM, PASSIVE-SCAN
+	(5170 - 5250 @ 80), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
+	(5250 - 5330 @ 80), (N/A, 20), (0 ms), DFS, AUTO-BW, PASSIVE-SCAN
+	(5490 - 5730 @ 160), (N/A, 20), (0 ms), DFS, PASSIVE-SCAN
+	(5735 - 5835 @ 80), (N/A, 20), (N/A), PASSIVE-SCAN
+	(57240 - 63720 @ 2160), (N/A, 0), (N/A)
 ```
 
 Look for the `country XX:` line, where `XX` should match the code you set. If it shows `country 00:`, the system might be using default restrictions or hasn't yet determined the region.
+
+```bash
+❯ iw reg get
+global
+country US: DFS-FCC # Country correctly shows as US
+	(902 - 904 @ 2), (N/A, 30), (N/A)
+	(904 - 920 @ 16), (N/A, 30), (N/A)
+	(920 - 928 @ 8), (N/A, 30), (N/A)
+	(2400 - 2472 @ 40), (N/A, 30), (N/A)
+	(5150 - 5250 @ 80), (N/A, 23), (N/A), AUTO-BW
+	(5250 - 5350 @ 80), (N/A, 24), (0 ms), DFS, AUTO-BW
+	(5470 - 5730 @ 160), (N/A, 24), (0 ms), DFS
+	(5730 - 5850 @ 80), (N/A, 30), (N/A), AUTO-BW
+	(5850 - 5895 @ 40), (N/A, 27), (N/A), NO-OUTDOOR, AUTO-BW, PASSIVE-SCAN
+	(5925 - 7125 @ 320), (N/A, 12), (N/A), NO-OUTDOOR, PASSIVE-SCAN
+	(57240 - 71000 @ 2160), (N/A, 40), (N/A)
+```
 
 ## Enabling Global Menu
 For some apps like Visual Studio Code, the global menu may not work or may be attached to the parent app instead of the panel.

--- a/src/content/docs/configuration/post_install_setup.mdx
+++ b/src/content/docs/configuration/post_install_setup.mdx
@@ -239,6 +239,32 @@ Be careful when configuring firewall rules, as improperly configured rules can l
 You can also configure it graphically using "Firewall" section in the KDE Plasma settings.
 :::
 
+## Configure Wi-Fi Regulatory Domain
+
+The `wireless-regdb` package includes a **database of wireless rules** (allowed frequencies, channels, power limits) for various countries. Setting the right region for your location **can unlock specific Wi-Fi channels** (such as channels 12/13 or 5GHz/6GHz bands) that may be limited by default, helping to **improve your Wi-Fi performance and connection quality**.
+
+**Configuration:**
+
+1. **Edit the configuration:**
+   Open `/etc/conf.d/wireless-regdom` with root privileges .
+   ```bash
+   sudo micro /etc/conf.d/wireless-regdom
+   ```
+2. **Set your country:**
+   Uncomment the line with your **two-letter ISO country code** (e.g., `WIRELESS_REGDOM="US"`). Ensure only one country is uncommented.
+3. **Reboot:**
+   A reboot is typically required for the change to take effect .
+
+**Verification:**
+
+To **check the currently applied regulatory domain**, use the command :
+
+```bash
+iw reg get
+```
+
+Look for the `country XX:` line, where `XX` should match the code you set. If it shows `country 00:`, the system might be using default restrictions or hasn't yet determined the region.
+
 ## Enabling Global Menu
 For some apps like Visual Studio Code, the global menu may not work or may be attached to the parent app instead of the panel.
 


### PR DESCRIPTION
Add some info about configuring Wi-Fi `wireless-regdb`.

Closes #93