### PR TITLE
fix(theme): update light theme chevron color to be less bright

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -136,7 +136,7 @@
 
   /* Arrows */
 [data-theme="light"] sl-sidebar-state-persist > ul > li > details { 
-  color: rgb(0, 255, 255);
+  color: rgb(0, 125, 111);
 }
 
   /* Current active page */


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4c74763e-090a-48ca-a498-0caa6cc6872a)
vs
![image](https://github.com/user-attachments/assets/ec632878-2bd8-4270-911a-b9d22914fe4b)
