### PR TITLE
fix: installation instructions for bottles 

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -352,7 +352,7 @@ Now you can install bottles using flatpak:
 sudo flatpak install bottles
 ```
 
-*If you want to know more about it, check out their [documentation](https://docs.usebottles.com/).*
+*If you want to learn more about bottles, check out their [documentation](https://docs.usebottles.com/).*
 
 ## Lutris Introduction & Tips
 

--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -339,12 +339,14 @@ Bottles can also make use of different runners like Lutris and are all manageabl
 You can also install dependencies, add EXE files, and use their one-click installers for gaming-related apps like EA App or Battle.net.
 
 To install bottles, you first need to install [flatpak](https://flatpak.org/):
-```sh title="How to install Flatpak
+
+```sh title="How to install Flatpak"
 # Open a terminal and run the following command:
 sudo pacman -S flatpak
 ```
 
 Now you can install bottles using flatpak:
+
 ```sh title="How to install Bottles"
 # Open a terminal and run the following command:
 sudo flatpak install bottles

--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -338,9 +338,16 @@ Bottles can also make use of different runners like Lutris and are all manageabl
 
 You can also install dependencies, add EXE files, and use their one-click installers for gaming-related apps like EA App or Battle.net.
 
+To install bottles, you first need to install [flatpak](https://flatpak.org/):
+```sh title="How to install Flatpak
+# Open a terminal and run the following command:
+sudo pacman -S flatpak
+```
+
+Now you can install bottles using flatpak:
 ```sh title="How to install Bottles"
 # Open a terminal and run the following command:
-sudo pacman -S bottles
+sudo flatpak install bottles
 ```
 
 *If you want to know more about it, check out their [documentation](https://docs.usebottles.com/).*


### PR DESCRIPTION
The page at https://wiki.cachyos.org/configuration/gaming says that to install bottles you need to run `sudo pacman -S bottles`, which doesn't actually work because bottles isn't in the arch repositories.

The Bottles documentation [says](https://docs.usebottles.com/getting-started/installation) the only supported way of installing bottles is through flatpak, so this PR adds a command for installing flatpak (`sudo pacman -S flatpak`) and a command for installing bottles (`flatpak install bottles`)