### PR TITLE
refactor(desktop_environments): restructure keybinds in articles

### DIFF
--- a/src/content/docs/desktop_environments/hyprland.mdx
+++ b/src/content/docs/desktop_environments/hyprland.mdx
@@ -24,124 +24,84 @@ Take a look into our [Hyprland FAQ.](/desktop_environments/hyprland#faq)
 
 ## Keybinds
 
-Most of the key combinations require the use of the mod key which in our case is the Windows key (referenced as SUPER),  you can change it on the config file.
+Most of the key combinations require the use of the mod key which in our case is the Windows key (referenced as SUPER), you can change it on the config file.
 
-### Open terminal
+### Application Control
 
-* <Kbd linux="Super+Return" />
+| Description | Key |
+|-------------|-----|
+| Open terminal | <Kbd linux="Super+Return" /> |
+| Open Rofi (Program Launcher) | <Kbd linux="Super+Space" /> |
+| Open file manager | <Kbd linux="Super+E" /> |
+| Close focused window | <Kbd linux="Super+Q" /> |
 
-### Go to workspace (1-9)
+### Workspace Navigation
 
-* <Kbd linux="Super+1" /> through <Kbd linux="Super+9" /> (Number row, number pad does not count)
+| Description | Key |
+|-------------|-----|
+| Go to workspace (1-9) | <Kbd linux="Super+1" /> through <Kbd linux="Super+9" /> |
+| Next workspace | <Kbd linux="Super+Period" /> |
+| Previous workspace | <Kbd linux="Super+Comma" /> |
+| Move between workspaces with scroll wheel | <Kbd linux="Super+Scroll" /> |
 
-### Change focus to (Left,Right,Up,Down)
+### Window Navigation
 
-* <Kbd linux="Super+ArrowUp" />
-* <Kbd linux="Super+ArrowDown" />
-* <Kbd linux="Super+ArrowLeft" />
-* <Kbd linux="Super+ArrowRight" />
+| Description | Key |
+|-------------|-----|
+| Focus window up | <Kbd linux="Super+ArrowUp" /> |
+| Focus window down | <Kbd linux="Super+ArrowDown" /> |
+| Focus window left | <Kbd linux="Super+ArrowLeft" /> |
+| Focus window right | <Kbd linux="Super+ArrowRight" /> |
+| Change active group | <Kbd linux="Super+Tab" /> |
 
-### Move between workspaces with the scroll wheel
+### Window Management
 
-* <Kbd linux="Super+Scroll" />
+| Description | Key |
+|-------------|-----|
+| Move window to workspace (1-9) without switching | <Kbd linux="Super+Shift+1" /> through <Kbd linux="Super+Shift+9" /> |
+| Move window to workspace (1-9) and switch to it | <Kbd linux="Super+Control+1" /> through <Kbd linux="Super+Control+9" /> |
+| Move window up | <Kbd linux="Super+Shift+ArrowUp" /> |
+| Move window down | <Kbd linux="Super+Shift+ArrowDown" /> |
+| Move window left | <Kbd linux="Super+Shift+ArrowLeft" /> |
+| Move window right | <Kbd linux="Super+Shift+ArrowRight" /> |
+| Toggle window fullscreen | <Kbd linux="Super+F" /> |
+| Toggle window floating | <Kbd linux="Super+V" /> |
+| Pin window to all workspaces (floating) | <Kbd linux="Super+Y" /> |
+| Toggle window to group | <Kbd linux="Super+K" /> |
 
-### Move between workspaces with comma and period
+### Window Resizing
 
-* <Kbd linux="Super+Period" /> (Next workspace)
-* <Kbd linux="Super+Comma" /> (Previous workspace)
+| Description | Key |
+|-------------|-----|
+| Enter resize mode (use H,J,K,L or arrows, Escape to exit) | <Kbd linux="Super+R" /> |
+| Resize window down | <Kbd linux="Super+Control+Shift+J" /> or <Kbd linux="Super+Control+Shift+ArrowDown" /> |
+| Resize window up | <Kbd linux="Super+Control+Shift+K" /> or <Kbd linux="Super+Control+Shift+ArrowUp" /> |
+| Resize window left | <Kbd linux="Super+Control+Shift+H" /> or <Kbd linux="Super+Control+Shift+ArrowLeft" /> |
+| Resize window right | <Kbd linux="Super+Control+Shift+L" /> or <Kbd linux="Super+Control+Shift+ArrowRight" /> |
 
-### Move focused window to workspace (1-9) but don't go there
+### Mouse Controls
 
-* <Kbd linux="Super+Shift+1" /> through <Kbd linux="Super+Shift+9" />
+| Description | Key |
+|-------------|-----|
+| Move window with mouse | <Kbd linux="Super+LeftClick" /> |
+| Resize window with mouse | <Kbd linux="Super+RightClick" /> |
 
-### Same as above but also switch to said workspace
+### System Controls
 
-* <Kbd linux="Super+Control+1" /> through <Kbd linux="Super+Control+9" />
+| Description | Key |
+|-------------|-----|
+| Take screenshot | <Kbd linux="PrintScreen" /> |
+| Reload Waybar | <Kbd linux="Super+O" /> |
+| Lower gap between windows | <Kbd linux="Super+G" /> |
+| Reset gaps to default | <Kbd linux="Super+Shift+G" /> |
 
-### Open Rofi (Program Launcher)
+### Media Controls
 
-* <Kbd linux="Super+Space" />
-  
-### Close focused window
-
-* <Kbd linux="Super+Q" />
-
-### Move focused window to direction (Up,Down,Left,Right)
-
-* <Kbd linux="Super+Shift+ArrowUp" />
-* <Kbd linux="Super+Shift+ArrowDown" />
-* <Kbd linux="Super+Shift+ArrowLeft" />
-* <Kbd linux="Super+Shift+ArrowRight" />
-
-### Resize focused window
-
-* <Kbd linux="Super+Control+Shift+J" /> (Downwards)
-* <Kbd linux="Super+Control+Shift+K" /> (Upwards)
-* <Kbd linux="Super+Control+Shift+H" /> (Left)
-* <Kbd linux="Super+Control+Shift+L" /> (Right)
-
-Or using arrow keys
-* <Kbd linux="Super+Control+Shift+ArrowUp" />
-* <Kbd linux="Super+Control+Shift+ArrowDown" />
-* <Kbd linux="Super+Control+Shift+ArrowLeft" />
-* <Kbd linux="Super+Control+Shift+ArrowRight" />
-
-### Toggle focused window into Floating or Fullscreen state
-
-* <Kbd linux="Super+F" /> (Fullscreen)
-* <Kbd linux="Super+V" /> (Floating)
-
-### Enter resize submap state (Allows resizing), H,J,K,L or via arrow keys
-
-* <Kbd linux="Super+R" />
-* <Kbd linux="Escape" /> to exit
-
-### Move window dragging the mouse
-
-* <Kbd linux="Super+LeftClick" />
-
-### Resize window
-
-* <Kbd linux="Super+RightClick" /> (keep it pressed and drag your cursor on any direction)
-
-### Volume control (Multimedia keys) such as VolUP, VolDOWN and MUTE
-
-### Brightness control should work depending on Hardware
-
-### Playback control for pausing, playing, next and previous via multimedia keys (Laptop or keyboard)
-
-### Pin focused window so it shows on all workspaces (Floating)
-
-* <Kbd linux="Super+Y" />
-
-### Toggle current window to a group
-
-* <Kbd linux="Super+K" />
-
-### Change active group
-
-* <Kbd linux="Super+Tab" />
-
-### Reload Waybar
-
-* <Kbd linux="Super+O" />
-
-### Lower gap between windows
-
-* <Kbd linux="Super+G" />
-
-### Reset gaps to default value
-
-* <Kbd linux="Super+Shift+G" />
-
-### Open file manager (Variable not configured by default)
-
-* <Kbd linux="Super+E" />
-
-### Screenshot
-
-* <Kbd linux="PrintScreen" />
-
+| Description | Key |
+|-------------|-----|
+| Volume control | Multimedia keys: <Kbd linux="VolUp" /> <Kbd linux="VolDown" /> <Kbd linux="Mute" /> |
+| Brightness control | Multimedia keys: depends on hardware |
+| Playback control | Multimedia keys:  <Kbd linux="Play/Pause" /> <Kbd linux="Next" /> <Kbd linux="Previous" /> |
 ## FAQ
 
 ### Why does my Discord, Thunar and Nautilus have a weird background?

--- a/src/content/docs/desktop_environments/i3.mdx
+++ b/src/content/docs/desktop_environments/i3.mdx
@@ -13,104 +13,71 @@ Credits go to [vnepogodin](https://github.com/vnepogodin) for making this simple
 
 Most of the key combinations require the use of the mod key which in our case is the Windows key (referenced as SUPER), you can change it on the config file.
 
-### Open terminal
+### Application Control
 
-* <Kbd linux="Super+Return" />
+| Description | Key |
+|-------------|-----|
+| Open terminal | <Kbd linux="Super+Return" /> |
+| Open Rofi (Program launcher) | <Kbd linux="Control+Space" /> |
+| Kill focused window | <Kbd linux="Super+Q" /> |
 
-### Kill focused window
+### Workspace Navigation
 
-* <Kbd linux="Super+Q" />
+| Description | Key |
+|-------------|-----|
+| Go to workspace (1-9) | <Kbd linux="Super+1" /> through <Kbd linux="Super+9" /> |
 
-### Go to workspace (1-9)
+### Window Navigation
 
-* <Kbd linux="Super+1" /> through <Kbd linux="Super+9" /> (Number row, number pad does not count)
+| Description | Key |
+|-------------|-----|
+| Change focus left | <Kbd linux="Super+ArrowLeft" /> |
+| Change focus right | <Kbd linux="Super+ArrowRight" /> |
+| Change focus up | <Kbd linux="Super+ArrowUp" /> |
+| Change focus down | <Kbd linux="Super+ArrowDown" /> |
+| Focus last floating/tiling container | <Kbd linux="Super+Space" /> |
 
-### Open Rofi (Program launcher)
+### Window Management
 
-* <Kbd linux="Control+Space" />
+| Description | Key |
+|-------------|-----|
+| Move focused window to workspace (1-9) | <Kbd linux="Super+Shift+1" /> through <Kbd linux="Super+Shift+9" /> |
+| Move focused window left | <Kbd linux="Super+Shift+ArrowLeft" /> |
+| Move focused window right | <Kbd linux="Super+Shift+ArrowRight" /> |
+| Move focused window up | <Kbd linux="Super+Shift+ArrowUp" /> |
+| Move focused window down | <Kbd linux="Super+Shift+ArrowDown" /> |
+| Toggle fullscreen mode | <Kbd linux="Super+F" /> |
+| Toggle floating mode | <Kbd linux="Super+Shift+Space" /> |
 
-### Change focus to (Left,Right,Up,Down)
+### Layout Control
 
-* <Kbd linux="Super+ArrowLeft" />
-* <Kbd linux="Super+ArrowRight" />
-* <Kbd linux="Super+ArrowUp" />
-* <Kbd linux="Super+ArrowDown" />
+| Description | Key |
+|-------------|-----|
+| Split layout horizontally | <Kbd linux="Super+H" /> |
+| Split layout vertically | <Kbd linux="Super+V" /> |
+| Split toggle | <Kbd linux="Super+T" /> |
+| Change container layout to stacking | <Kbd linux="Super+S" /> |
+| Change container layout to tabbed | <Kbd linux="Super+W" /> |
 
-### Move focused window to (Left,Right,Up,Down)
+### Resize Mode
 
-* <Kbd linux="Super+Shift+ArrowLeft" />
-* <Kbd linux="Super+Shift+ArrowRight" />
-* <Kbd linux="Super+Shift+ArrowUp" />
-* <Kbd linux="Super+Shift+ArrowDown" />
+| Description | Key |
+|-------------|-----|
+| Enter resize mode | <Kbd linux="Super+R" /> |
+| Resize left (in resize mode) | <Kbd linux="ArrowLeft" /> |
+| Resize right (in resize mode) | <Kbd linux="ArrowRight" /> |
+| Resize up (in resize mode) | <Kbd linux="ArrowUp" /> |
+| Resize down (in resize mode) | <Kbd linux="ArrowDown" /> |
+| Exit resize mode | <Kbd linux="Return" /> / <Kbd linux="Escape" /> / <Kbd linux="Super+R" /> |
 
-### Move focused window to workspace (1-9)
+### System Controls
 
-* <Kbd linux="Super+Shift+1" /> through <Kbd linux="Super+Shift+9" /> (Number row, number pad does not count)
-
-### Split layout in a horizontal orientation
-
-* <Kbd linux="Super+H" />
-
-### Split layout in a vertical orientation
-
-* <Kbd linux="Super+V" />
-
-### Split toggle
-
-* <Kbd linux="Super+T" />
-
-### Toggle fullscreen mode in focused window
-
-* <Kbd linux="Super+F" />
-
-### Focus last floating/tiling container
-
-* <Kbd linux="Super+Space" />
-
-### Toggle floating mode in focused window
-
-* <Kbd linux="Super+Shift+Space" />
-
-### Change container layout to (stacking,tabbed)
-
-* <Kbd linux="Super+S" /> (stacking)
-* <Kbd linux="Super+W" /> (tabbed)
-
-### Restart i3 in place (ie after an i3wm update or bug)
-
-* <Kbd linux="Super+Shift+R" />
-
-### Reload i3 configuration file
-
-* <Kbd linux="Super+Shift+C" />
-
-### Exit i3 (end running X session)
-
-* <Kbd linux="Super+Shift+E" />
-
-### Lock your screen
-
-To unlock it, type your user password and press Return.
-
-* <Kbd linux="Super+L" />
-
-### Enter resize mode
-
-* <Kbd linux="Super+R" />
-
-### Resize focused window while being on resize mode
-
-* <Kbd linux="ArrowLeft" />
-* <Kbd linux="ArrowRight" />
-* <Kbd linux="ArrowUp" />
-* <Kbd linux="ArrowDown" />
-
-### Exit resize mode
-
-* <Kbd linux="Return" />
-* <Kbd linux="Escape" />
-* <Kbd linux="Super+R" />
-
+| Description | Key |
+|-------------|-----|
+| Lock screen | <Kbd linux="Super+L" /> |
+| Reload i3 configuration | <Kbd linux="Super+Shift+C" /> |
+| Restart i3 in place | <Kbd linux="Super+Shift+R" /> |
+| Exit i3 (end X session) | <Kbd linux="Super+Shift+E" /> |
 ## FAQ
 
 ### How can create an autostart for a program? for example "set a wallpaper at start"

--- a/src/content/docs/desktop_environments/qtile.mdx
+++ b/src/content/docs/desktop_environments/qtile.mdx
@@ -14,100 +14,81 @@ Credits go to [Shendisx](https://github.com/Shendisx) for making this Qtile setu
 Most of the key combinations require the use of the mod key which in our case is the Windows key (referenced as SUPER), you can change it on the config file.
 Some of them might make use of mod1 (ALT key).
 
-### Open terminal
+### Application Control
 
-* <Kbd linux="Super+Return" />
+| Description | Key |
+|-------------|-----|
+| Open terminal | <Kbd linux="Super+Return" /> |
+| Open Rofi (Program launcher) | <Kbd linux="Alt+Space" /> |
+| Open file manager (Thunar) | <Kbd linux="Super+E" /> |
+| Kill focused window | <Kbd linux="Super+Q" /> |
 
-### Kill focused window
+### Workspace Navigation
 
-* <Kbd linux="Super+Q" />
+| Description | Key |
+|-------------|-----|
+| Go to workspace (1-9) | <Kbd linux="Super+1" /> through <Kbd linux="Super+9" /> |
 
-### Go to workspace (1-9)
+### Window Navigation
 
-* <Kbd linux="Super+1" />-<Kbd linux="Super+9" /> (Number row, number pad does not count)
+| Description | Key |
+|-------------|-----|
+| Move focus left | <Kbd linux="Super+H" /> |
+| Move focus right | <Kbd linux="Super+L" /> |
+| Move focus down | <Kbd linux="Super+J" /> |
+| Move focus up | <Kbd linux="Super+K" /> |
+| Move windows between columns or up/down in stack | <Kbd linux="Super+Space" /> |
 
-### Open Rofi (Program launcher)
+### Window Management
 
-* <Kbd linux="Alt+Space" />
+| Description | Key |
+|-------------|-----|
+| Move focused window left | <Kbd linux="Super+Shift+H" /> |
+| Move focused window right | <Kbd linux="Super+Shift+L" /> |
+| Move focused window down | <Kbd linux="Super+Shift+J" /> |
+| Move focused window up | <Kbd linux="Super+Shift+K" /> |
+| Toggle fullscreen | <Kbd linux="Super+F" /> |
+| Toggle floating | <Kbd linux="Super+V" /> |
+| Stick window (follow between workspaces) | <Kbd linux="Super+S" /> |
 
-### Move focus to (Left,Right,Down,Up)
+### Window Resizing
 
-* <Kbd linux="Super+H" /> (Left)
-* <Kbd linux="Super+L" /> (Right)
-* <Kbd linux="Super+J" /> (Down)
-* <Kbd linux="Super+K" /> (Up)
-* <Kbd linux="Super+Space" /> (Move windows between left/right columns or move up/down in current stack)
+| Description | Key |
+|-------------|-----|
+| Grow focused window left | <Kbd linux="Super+Control+H" /> |
+| Grow focused window right | <Kbd linux="Super+Control+L" /> |
+| Grow focused window down | <Kbd linux="Super+Control+J" /> |
+| Grow focused window up | <Kbd linux="Super+Control+K" /> |
+| Reset all window sizes to original | <Kbd linux="Super+N" /> |
 
-### Move focused window to (Left,Right,Down,Up)
+### Layout Control
 
-* <Kbd linux="Super+Shift+H" /> (Left)
-* <Kbd linux="Super+Shift+L" /> (Right)
-* <Kbd linux="Super+Shift+J" /> (Down)
-* <Kbd linux="Super+Shift+K" /> (Up)
+| Description | Key |
+|-------------|-----|
+| Toggle between split and unsplit sides of stack | <Kbd linux="Super+Shift+Return" /> |
+| Toggle between layouts | <Kbd linux="Super+Tab" /> |
 
-### Grow focused window to (Left,Right,Down,Up)
+### Mouse Controls
 
-* <Kbd linux="Super+Control+H" /> (Left)
-* <Kbd linux="Super+Control+L" /> (Right)
-* <Kbd linux="Super+Control+J" /> (Down)
-* <Kbd linux="Super+Control+K" /> (Up)
+| Description | Key |
+|-------------|-----|
+| Drag floating window | <Kbd linux="Super+Left_Click" /> |
+| Resize floating window | <Kbd linux="Super+Right_Click" /> |
+| Bring window to front | <Kbd linux="Super+Scroll_Wheel_Button" /> |
 
-### Reset all window sizes of current workspace to their original size
+### Screenshot
 
-* <Kbd linux="Super+N" />
+| Description | Key |
+|-------------|-----|
+| Execute Flameshot (screenshot utility) | <Kbd linux="Print" /> |
+| Capture full-screen screenshot (saved in ~/Pictures) | <Kbd linux="Control+Print" /> |
 
-### Toggle Fullscreen in focused window
+### System Controls
 
-* <Kbd linux="Super+F" />
-
-### Toggle floating in focused window
-
-* <Kbd linux="Super+V" />
-
-### Toggle between split and unsplit sides of stack
-
-* <Kbd linux="Super+Shift+Return" />
-
-### Toggle between layouts
-
-* <Kbd linux="Super+Tab" />
-
-### Reload Qtile configuration file
-
-* <Kbd linux="Super+Control+R" />
-
-### Exit Qtile (end running X session)
-
-* <Kbd linux="Super+Control+Q" />
-
-### Execute Flameshot (Utility for taking screenshots)
-
-* <Kbd linux="Print" />
-
-### Capture a full-screen screenshot (Saved in $HOME/Pictures)
-
-* <Kbd linux="Control+Print" />
-
-### Open File Manager (Thunar by default)
-
-* <Kbd linux="Super+E" />
-
-### Drag a floating window around with your mouse
-
-* <Kbd linux="Super+Left_Click" />
-
-### Grow a floating window with your mouse
-
-* <Kbd linux="Super+Right_Click" />
-
-### Bring window to the front with your mouse
-
-* <Kbd linux="Super+Scroll_Wheel_Button" />
-
-### Stick window (For example sticking Firefox PIP will now follow you between workspaces)
-
-* <Kbd linux="Super+S" />
-
+| Description | Key |
+|-------------|-----|
+| Reload Qtile configuration | <Kbd linux="Super+Control+R" /> |
+| Exit Qtile (end X session) | <Kbd linux="Super+Control+Q" /> |
 ## FAQ
 
 ### Why is the volume widget showing an error or it's stuck at 0%?


### PR DESCRIPTION
Used tables to make it more compact and restructured by categories so it follows more or less similar pattern between each article.

<img width="863" height="933" alt="image" src="https://github.com/user-attachments/assets/44e16057-d082-4cb0-b842-8a2950eabb09" />

Closes: #152 