### PR TITLE
ci(i18): clone whole git history for lunaria

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Required for Lunaria. Ensures the full git history is cloned.
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
Should hopefully fix the issue https://github.com/CachyOS/wiki/actions/runs/16680200404/job/47216753119

According to how it's set up here https://github.com/withastro/starlight/blob/cfd51859ffc01ad701027b1c4824027404d3aa25/.github/workflows/lunaria.yml#L27