### PR TITLE
Add "increasing shader cache size" in gaming section

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -196,7 +196,8 @@ To avoid long loading times and stuttering, we can increase the global shader ca
 	# Increase Nvidia's shader cache size to 12GB
 	export __GL_SHADER_DISK_CACHE_SIZE=12000000000
 	```
-4. Save the file and restart your device.
+4. Save the file by pressing `CTRL+X`, `Y`, then `Enter`.
+5. Restart your device.
 </Steps>
 
 </TabItem>
@@ -217,7 +218,8 @@ To avoid long loading times and stuttering, we can increase the global shader ca
 	# Increase AMD's shader cache size to 12GB
 	export MESA_SHADER_CACHE_MAX_SIZE=12G
 	```
-4. Save the file and restart your device.
+4. Save the file by pressing `CTRL+X`, `Y`, then `Enter`.
+5. Restart your device.
 </Steps>
 
 </TabItem>

--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -197,7 +197,7 @@ To avoid long loading times and stuttering, we can increase the global shader ca
 	export __GL_SHADER_DISK_CACHE_SIZE=12000000000
 	```
 4. Save the file by pressing `CTRL+X`, `Y`, then `Enter`.
-5. Restart your device.
+5. Restart your system.
 </Steps>
 
 </TabItem>
@@ -219,7 +219,7 @@ To avoid long loading times and stuttering, we can increase the global shader ca
 	export MESA_SHADER_CACHE_MAX_SIZE=12G
 	```
 4. Save the file by pressing `CTRL+X`, `Y`, then `Enter`.
-5. Restart your device.
+5. Restart your system.
 </Steps>
 
 </TabItem>

--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -173,6 +173,59 @@ has similar a behavior but it should **not** be used as CachyOS already ships wi
 
 </Tabs>
 
+### Increase maximum shader cache size
+
+Game shaders are compiled automatically while playing, which may cause long loading times and stuttering the first time you encounter them. These shaders are stored on your system to be re-used when needed.
+
+However, there is a maximum limit to the shader cache's file size, causing old shaders to be forgotten when exceeding the default size. This can be an issue since large games can have shaders over 1GB in size, causing them to re-compile shaders every launch.
+
+To avoid long loading times and stuttering, we can increase the global shader cache size:
+
+<Tabs>
+
+<TabItem label='Nvidia GPU'>
+
+<Steps>
+1. Open the terminal.
+2. Enter this command:
+	```sh
+	sudo nano /etc/profile.d/increase-shadercache.sh
+	```
+3. Paste the following into the file:
+	```sh
+	# Increase Nvidia's shader cache size to 12GB
+	export __GL_SHADER_DISK_CACHE_SIZE=12000000000
+	```
+4. Save the file and restart your device.
+</Steps>
+
+</TabItem>
+
+<TabItem label='AMD GPU'>
+
+<Steps>
+1. Open the terminal.
+2. Enter this command:
+	```sh
+	sudo nano /etc/profile.d/increase-shadercache.sh
+	```
+3. Paste the following into the file:
+	```sh
+	# Enforces RADV Vulkan implementation
+	export AMD_VULKAN_ICD=RADV
+    
+	# Increase AMD's shader cache size to 12GB
+	export MESA_SHADER_CACHE_MAX_SIZE=12G
+	```
+4. Save the file and restart your device.
+</Steps>
+
+</TabItem>
+
+</Tabs>
+
+After restarting, the maximum shader cache size should be permanently increased. Thanks to [psygreg's shader booster](https://github.com/psygreg/shader-booster/) for helping this guide.
+
 ## Proton-CachyOS
 
 :::caution


### PR DESCRIPTION
Adds a note to improve gaming performance by increasing the shader cache size limit. I spent a while figuring out why my games were re-compiling shaders each launch, and increasing the shader cache size fixed it perfectly.

AFAIK this is something that some gaming distros do by default, and is a relatively safe fix.