### PR TITLE
Make the flag longer so people can actually see it

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -58,7 +58,7 @@ Created Owner UUID a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
 Creating secure boot keys...✔
 Secure boot keys created!
 
-❯ sudo sbctl enroll-keys -m # Enroll your keys with Microsoft's keys
+❯ sudo sbctl enroll-keys --microsoft # Enroll your keys with Microsoft's keys
 Enrolling keys to EFI variables...✔
 Enrolled keys to the EFI variables!
 


### PR DESCRIPTION
Its short length + the color in dark mode (all other commands are in yellow only) make it hard to see.

<img width="582" height="82" alt="Screenshot_20250805_040743 cleaned" src="https://github.com/user-attachments/assets/37de570b-e6fa-4826-8d33-e5b1928cbe3c" />

