### PR TITLE
refactor: cleanup css

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.customData": [".vscode/tailwind.json"]
+}

--- a/.vscode/tailwind.json
+++ b/.vscode/tailwind.json
@@ -1,0 +1,95 @@
+{
+  "version": 1.1,
+  "atDirectives": [
+    {
+      "name": "@theme",
+      "description": "Use the `@theme` directive to define your project's custom design tokens, like fonts, colors, and breakpoints.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#theme-directive"
+        }
+      ]
+    },
+    {
+      "name": "@source",
+      "description": "Use the `@source` directive to explicitly specify source files that aren't picked up by Tailwind's automatic content detection.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#source-directive"
+        }
+      ]
+    },
+    {
+      "name": "@utility",
+      "description": "Use the `@utility` directive to add custom utilities to your project that work with variants like `hover`, `focus` and `lg`.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#utility-directive"
+        }
+      ]
+    },
+    {
+      "name": "@variant",
+      "description": "Use the `@variant` directive to apply a Tailwind variant to styles in your CSS.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#variant-directive"
+        }
+      ]
+    },
+    {
+      "name": "@custom-variant",
+      "description": "Use the `@custom-variant` directive to add a custom variant in your project.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#custom-variant-directive"
+        }
+      ]
+    },
+    {
+      "name": "@apply",
+      "description": "Use the `@apply` directive to inline any existing utility classes into your own custom CSS.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#apply-directive"
+        }
+      ]
+    },
+    {
+      "name": "@reference",
+      "description": "If you want to use `@apply` or `@variant` in the `<style>` block of a Vue or Svelte component, or within CSS modules, you will need to import your theme variables, custom utilities, and custom variants to make those values available in that context.\n\nTo do this without duplicating any CSS in your output, use the `@reference` directive to import your main stylesheet for reference without actually including the styles.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#reference-directive"
+        }
+      ]
+    },
+    {
+      "name": "@config",
+      "description": "Use the `@config` directive to load a legacy JavaScript-based configuration file.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#config-directive"
+        }
+      ]
+    },
+    {
+      "name": "@plugin",
+      "description": "Use the `@plugin` directive to load a legacy JavaScript-based plugin.",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#plugin-directive"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -88,7 +88,7 @@ starlight-tabs {
 
     /* Content header */
     :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
-      color: rgba(255 255 255 / 0.8);
+      color: #ffffffcc;
     }
   }
 
@@ -107,12 +107,12 @@ starlight-tabs {
       color: cyan;
     }
     &:hover [role='tab'][aria-selected='false'] {
-      background-color: rgba(0, 248, 236, 0.494);
+      background-color: #00f8ec7e;
       @apply text-white font-semibold;
     }
     [role='tab'][aria-selected='true'] {
       @apply border-2 border-accent-200;
-      background-color: rgba(45, 140, 143, 0.514);
+      background-color: #2d8c8f83;
     }
   }
 
@@ -135,7 +135,7 @@ starlight-tabs {
       color: cyan;
     }
     & > nav > ul > li > ul > li > a > span {
-      color: rgba(255, 255, 255, 0.527);
+      color: #ffffff86;
       @apply font-medium;
     }
     & > nav > ul > li > ul > li > a:hover > span {
@@ -144,19 +144,19 @@ starlight-tabs {
     }
     /* Current active sidebar item */
     & > nav > ul > li > a[aria-current='true'] {
-      background-color: rgba(102 173 160 / 0.26);
+      background-color: #66ada042;
     }
     & > nav > ul > li > a[aria-current='true'] > span {
-      background-color: rgba(102 173 160 / 0);
+      background-color: #66ada000;
       color: cyan;
     }
     /*Current active nested item*/
     & > nav > ul > li > ul > li > a[aria-current='true'] {
-      background-color: rgba(102 173 160 / 0.26);
+      background-color: #66ada042;
     }
     & > nav > ul > li > ul > li > a[aria-current='true'] > span {
       color: cyan;
-      background-color: rgba(102 173 160 / 0);
+      background-color: #66ada000;
     }
   }
 
@@ -166,7 +166,7 @@ starlight-tabs {
       @apply text-gray-300 font-medium;
     }
     details > ul > li > details > ul > li > a:hover[aria-current='false'] {
-      background-color: rgba(0, 123, 127, 0.774);
+      background-color: #007b7fc5;
     }
   }
 
@@ -177,7 +177,7 @@ starlight-tabs {
     }
     /* Current active page */
     & > ul > li > details > ul > li > a[aria-current='page'] {
-      background-color: rgba(82 230 202 / 0.84);
+      background-color: #52e6cad6;
     }
     & > ul > li > details > ul > li > a:hover[aria-current='page'] {
       @apply bg-accent-200 text-black;
@@ -193,7 +193,7 @@ starlight-tabs {
     /* Color when hovering outside the text */
     & > ul > li > details > ul > li > a:hover {
       @apply text-white;
-      background-color: rgba(0, 123, 127, 0.774);
+      background-color: #007b7fc5;
     }
     /* Affects all text of the sidebar */
     & > ul > li > details > ul > li > a {
@@ -209,7 +209,7 @@ starlight-tabs {
       @apply text-black font-normal;
     }
     details > ul > li > details > ul > li > a:hover[aria-current='false'] {
-      background-color: rgba(4, 156, 161, 0.63);
+      background-color: #049ca1a1;
     }
   }
 
@@ -236,7 +236,7 @@ starlight-tabs {
     /* Color when hovering outside the text */
     & > ul > li > details > ul > li > a:hover {
       @apply text-black font-semibold;
-      background-color: rgba(4, 156, 161, 0.63);
+      background-color: #049ca1a1;
     }
     /* Affects all text of the sidebar */
     & > ul > li > details > ul > li > a {
@@ -265,7 +265,7 @@ starlight-tabs {
       background-color: #60c0c3;
     }
     & > nav > ul > li > ul > li > a > span {
-      color: rgba(0, 0, 0, 0.637);
+      color: #000000a2;
       @apply font-medium;
     }
     & > nav > ul > li > ul > li > a:hover > span {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -21,6 +21,10 @@
   --color-gray-900: #111826;
 }
 
+:root {
+  --sl-color-text: var(--color-white);
+}
+
 .hero {
   @apply py-10;
   /* Hero Buttons */
@@ -76,257 +80,242 @@ starlight-tabs {
 }
 
 [data-theme='dark'] {
-  /* Content text */
-  body {
-    font-family: var(--__sl-font);
-    line-height: var(--sl-line-height);
-    -webkit-font-smoothing: antialiased;
-    color: white;
-    background-color: var(--sl-color-bg);
-  }
+  .sl-markdown-content {
+    /* Code */
+    code:not(:where(.not-content *)) {
+      font-size: 1rem;
+    }
 
-  /* Code */
-  .sl-markdown-content code:not(:where(.not-content *)) {
-    font-size: 1rem;
-  }
-
-  /* Content header */
-  .sl-markdown-content :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
-    color: rgba(255 255 255 / 0.8);
+    /* Content header */
+    :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
+      color: rgba(255 255 255 / 0.8);
+    }
   }
 
   /* Strong tag style */
-  aside.starlight-aside.starlight-aside--caution
-    > div.starlight-aside__content
-    > ul
-    > li
-    > p
-    > strong {
-    color: #e5ff00;
-  }
-  aside.starlight-aside.starlight-aside--caution > div.starlight-aside__content > p > strong {
+  .starlight-aside--caution strong {
     color: #e5ff00;
   }
   strong {
     color: #82dccc;
   }
 
-  /* Tabbed interface */
-  .tab [role='tab'][aria-selected='false'] {
-    transition: background-color 0.3s ease;
-    font-size: 1.063rem;
-    color: #00ffff;
-  }
-  .tab:hover [role='tab'][aria-selected='false'] {
-    background-color: rgba(0, 248, 236, 0.494);
-    color: white;
-    font-weight: 600;
-  }
-  .tab [role='tab'][aria-selected='true'] {
-    border: 2px solid #82dccc;
-    background-color: rgba(45, 140, 143, 0.514);
-  }
-  .tab [role='tab'][aria-selected='false'] {
-    transition: background-color 0.3s ease;
-    font-size: 1.063rem;
-    color: #00ffff;
-  }
-  .tab:hover [role='tab'][aria-selected='false'] {
-    background-color: rgba(0, 248, 236, 0.494);
-    color: white;
-    font-weight: 600;
-  }
-  .tab [role='tab'][aria-selected='true'] {
-    border: 2px solid #82dccc;
-    background-color: rgba(45, 140, 143, 0.514);
+  .tab {
+    [role='tab'][aria-selected='false'] {
+      transition: background-color 0.3s ease;
+      font-size: 1.063rem;
+      color: #00ffff;
+    }
+    &:hover [role='tab'][aria-selected='false'] {
+      background-color: rgba(0, 248, 236, 0.494);
+      color: white;
+      font-weight: 600;
+    }
+    [role='tab'][aria-selected='true'] {
+      border: 2px solid #82dccc;
+      background-color: rgba(45, 140, 143, 0.514);
+    }
   }
 
   /* Right sidebar */
-  /* Affects all text from non nested lists */
-  starlight-toc > nav > ul > li > a > span {
-    color: #e1e3e5;
-    font-weight: 500;
-  }
-  /* Text color when hovering outside the text */
-  starlight-toc > nav > ul > li > a:hover > span {
-    color: #00ffff;
-    font-weight: 500;
-  }
-  /*Nested ul's*/
-  /*Color Hovering outside the text when in an nested item*/
-  /*Sibling item*/
-  starlight-toc > nav > ul > li > ul > li:hover > a {
-    color: #00ffff;
-  }
-  starlight-toc > nav > ul > li > ul > li > a > span {
-    color: rgba(255, 255, 255, 0.527);
-    font-weight: 500;
-  }
-  starlight-toc > nav > ul > li > ul > li > a:hover > span {
-    color: #00ffff;
-    font-weight: 500;
-  }
-  /* Current active sidebar item */
-  starlight-toc > nav > ul > li > a[aria-current='true'] {
-    background-color: rgba(102 173 160 / 0.26);
-  }
-  starlight-toc > nav > ul > li > a[aria-current='true'] > span {
-    background-color: rgba(102 173 160 / 0);
-    color: #00ffff;
-  }
-  /*Current active nested item*/
-  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] {
-    background-color: rgba(102 173 160 / 0.26);
-  }
-  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
-    color: #00ffff;
-    background-color: rgba(102 173 160 / 0);
+  starlight-toc {
+    /* Affects all text from non nested lists */
+    & > nav > ul > li > a > span {
+      color: #e1e3e5;
+      font-weight: 500;
+    }
+    /* Text color when hovering outside the text */
+    & > nav > ul > li > a:hover > span {
+      color: #00ffff;
+      font-weight: 500;
+    }
+    /*Nested ul's*/
+    /*Color Hovering outside the text when in an nested item*/
+    /*Sibling item*/
+    & > nav > ul > li > ul > li:hover > a {
+      color: #00ffff;
+    }
+    & > nav > ul > li > ul > li > a > span {
+      color: rgba(255, 255, 255, 0.527);
+      font-weight: 500;
+    }
+    & > nav > ul > li > ul > li > a:hover > span {
+      color: #00ffff;
+      font-weight: 500;
+    }
+    /* Current active sidebar item */
+    & > nav > ul > li > a[aria-current='true'] {
+      background-color: rgba(102 173 160 / 0.26);
+    }
+    & > nav > ul > li > a[aria-current='true'] > span {
+      background-color: rgba(102 173 160 / 0);
+      color: #00ffff;
+    }
+    /*Current active nested item*/
+    & > nav > ul > li > ul > li > a[aria-current='true'] {
+      background-color: rgba(102 173 160 / 0.26);
+    }
+    & > nav > ul > li > ul > li > a[aria-current='true'] > span {
+      color: #00ffff;
+      background-color: rgba(102 173 160 / 0);
+    }
   }
 
   /* Left sidebar  */
-  .top-level details > ul .group-label > span {
-    color: #b8c2d7;
-    font-weight: 500;
-  }
-  .top-level details > ul > li > details > ul > li > a:hover[aria-current='false'] {
-    background-color: rgba(0, 123, 127, 0.774);
+  .top-level {
+    details > ul .group-label > span {
+      color: #b8c2d7;
+      font-weight: 500;
+    }
+    details > ul > li > details > ul > li > a:hover[aria-current='false'] {
+      background-color: rgba(0, 123, 127, 0.774);
+    }
   }
 
-  /* Arrows */
-  sl-sidebar-state-persist > ul > li > details {
-    color: #00ffff;
-  }
-  /* Current active page */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] {
-    background-color: rgba(82 230 202 / 0.84);
-  }
-  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover[aria-current='page'] {
-    color: black;
-    background-color: #82dccc;
-  }
-  /* Color when hovering over text */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
-    color: white;
-  }
-  /*Color around text when hovering*/
-  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
-    color: black;
-  }
-  /* Color when hovering outside the text */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
-    color: white;
-    background-color: rgba(0, 123, 127, 0.774);
-  }
-  /* Affects all text of the sidebar */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a {
-    font-weight: 500;
+  sl-sidebar-state-persist {
+    /* Arrows */
+    & > ul > li > details {
+      color: #00ffff;
+    }
+    /* Current active page */
+    & > ul > li > details > ul > li > a[aria-current='page'] {
+      background-color: rgba(82 230 202 / 0.84);
+    }
+    & > ul > li > details > ul > li > a:hover[aria-current='page'] {
+      color: black;
+      background-color: #82dccc;
+    }
+    /* Color when hovering over text */
+    & > ul > li > details > ul > li > a > span:hover {
+      color: white;
+    }
+    /*Color around text when hovering*/
+    & > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
+      color: black;
+    }
+    /* Color when hovering outside the text */
+    & > ul > li > details > ul > li > a:hover {
+      color: white;
+      background-color: rgba(0, 123, 127, 0.774);
+    }
+    /* Affects all text of the sidebar */
+    & > ul > li > details > ul > li > a {
+      font-weight: 500;
+    }
   }
 }
 
 [data-theme='light'] {
   /* Left sidebar  */
-  .top-level details > ul .group-label > span {
-    color: black;
-    font-weight: 400;
-  }
-  .top-level details > ul > li > details > ul > li > a:hover[aria-current='false'] {
-    background-color: rgba(4, 156, 161, 0.63);
+  .top-level {
+    details > ul .group-label > span {
+      color: black;
+      font-weight: 400;
+    }
+    details > ul > li > details > ul > li > a:hover[aria-current='false'] {
+      background-color: rgba(4, 156, 161, 0.63);
+    }
   }
 
-  /* Arrows */
-  sl-sidebar-state-persist > ul > li > details {
-    color: #007d6f;
-  }
-  /* Current active page */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] {
-    color: white;
-    background-color: #007d6f;
-  }
-  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover[aria-current='page'] {
-    color: white;
-    background-color: #007d6f;
-  }
-  /* Color when hovering over text */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
-    color: black;
-  }
-  /* Color around text when hovering */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
-    color: white;
-  }
-  /* Color when hovering outside the text */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
-    color: black;
-    font-weight: 600;
-    background-color: rgba(4, 156, 161, 0.63);
-  }
-  /* Affects all text of the sidebar */
-  sl-sidebar-state-persist > ul > li > details > ul > li > a {
-    font-weight: 500;
+  sl-sidebar-state-persist {
+    /* Arrows */
+    & > ul > li > details {
+      color: #007d6f;
+    }
+    /* Current active page */
+    & > ul > li > details > ul > li > a[aria-current='page'] {
+      color: white;
+      background-color: #007d6f;
+    }
+    & > ul > li > details > ul > li > a:hover[aria-current='page'] {
+      color: white;
+      background-color: #007d6f;
+    }
+    /* Color when hovering over text */
+    & > ul > li > details > ul > li > a > span:hover {
+      color: black;
+    }
+    /* Color around text when hovering */
+    & > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
+      color: white;
+    }
+    /* Color when hovering outside the text */
+    & > ul > li > details > ul > li > a:hover {
+      color: black;
+      font-weight: 600;
+      background-color: rgba(4, 156, 161, 0.63);
+    }
+    /* Affects all text of the sidebar */
+    & > ul > li > details > ul > li > a {
+      font-weight: 500;
+    }
   }
 
   /* Right sidebar */
-  /* Affects all text from non nested lists */
-  starlight-toc > nav > ul > li > a > span {
-    color: black;
-    font-weight: 500;
-  }
-  /* Text color when hovering outside the text */
-  starlight-toc > nav > ul > li > a:hover > span {
-    color: black;
-    font-weight: 500;
-  }
-  /* This one affects the entire item except around the text*/
-  starlight-toc > nav > ul > li > a:hover {
-    background-color: #60c0c3;
-  }
-  /* Nested ul's */
-  /* Color Hovering outside the text when in an nested item */
-  /* Sibling item */
-  starlight-toc > nav > ul > li > ul > li:hover > a {
-    background-color: #60c0c3;
-  }
-  starlight-toc > nav > ul > li > ul > li > a > span {
-    color: rgba(0, 0, 0, 0.637);
-    font-weight: 500;
-  }
-  starlight-toc > nav > ul > li > ul > li > a:hover > span {
-    color: black;
-    font-weight: 500;
-  }
-  /* Current active nested item */
-  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] {
-    color: black;
-    background-color: #007d6f;
-  }
-  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
-    color: white;
-    background-color: #007d6f;
-  }
-  /* Current active sidebar item */
-  starlight-toc > nav > ul > li > a[aria-current='true'] {
-    color: black;
-    background-color: #007d6f;
-  }
-  starlight-toc > nav > ul > li > a[aria-current='true'] > span {
-    background-color: #007d6f;
-    color: white;
+  starlight-toc {
+    /* Affects all text from non nested lists */
+    & > nav > ul > li > a > span {
+      color: black;
+      font-weight: 500;
+    }
+    /* Text color when hovering outside the text */
+    & > nav > ul > li > a:hover > span {
+      color: black;
+      font-weight: 500;
+    }
+    /* This one affects the entire item except around the text*/
+    & > nav > ul > li > a:hover {
+      background-color: #60c0c3;
+    }
+    /* Nested ul's */
+    /* Color Hovering outside the text when in an nested item */
+    /* Sibling item */
+    & > nav > ul > li > ul > li:hover > a {
+      background-color: #60c0c3;
+    }
+    & > nav > ul > li > ul > li > a > span {
+      color: rgba(0, 0, 0, 0.637);
+      font-weight: 500;
+    }
+    & > nav > ul > li > ul > li > a:hover > span {
+      color: black;
+      font-weight: 500;
+    }
+    /* Current active nested item */
+    & > nav > ul > li > ul > li > a[aria-current='true'] {
+      color: black;
+      background-color: #007d6f;
+    }
+    & > nav > ul > li > ul > li > a[aria-current='true'] > span {
+      color: white;
+      background-color: #007d6f;
+    }
+    /* Current active sidebar item */
+    & > nav > ul > li > a[aria-current='true'] {
+      color: black;
+      background-color: #007d6f;
+    }
+    & > nav > ul > li > a[aria-current='true'] > span {
+      background-color: #007d6f;
+      color: white;
+    }
   }
 
-  /* Tabbed interface */
-  .tab [role='tab'][aria-selected='false'] {
-    transition: background-color 0.3s ease;
-    font-size: 1.063rem;
-    color: black;
-  }
-  .tab:hover [role='tab'][aria-selected='false'] {
-    background-color: #60c0c3;
-    color: black;
-    font-weight: 600;
-  }
-  .tab [role='tab'][aria-selected='true'] {
-    color: white;
-    border-right: 0px;
-    background-color: #007d6f;
+  .tab {
+    [role='tab'][aria-selected='false'] {
+      transition: background-color 0.3s ease;
+      font-size: 1.063rem;
+      color: black;
+    }
+    &:hover [role='tab'][aria-selected='false'] {
+      background-color: #60c0c3;
+      color: black;
+      font-weight: 600;
+    }
+    [role='tab'][aria-selected='true'] {
+      color: white;
+      border-right: 0px;
+      background-color: #007d6f;
+    }
   }
 }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -85,12 +85,22 @@ img {
 
 /* Strong tag style */
 
-[data-theme='dark'] aside.starlight-aside.starlight-aside--caution > div.starlight-aside__content > ul > li > p > strong {
-  color:#E5FF00;
+[data-theme='dark']
+  aside.starlight-aside.starlight-aside--caution
+  > div.starlight-aside__content
+  > ul
+  > li
+  > p
+  > strong {
+  color: #e5ff00;
 }
 
-[data-theme='dark'] aside.starlight-aside.starlight-aside--caution > div.starlight-aside__content > p > strong {
-  color:#E5FF00;
+[data-theme='dark']
+  aside.starlight-aside.starlight-aside--caution
+  > div.starlight-aside__content
+  > p
+  > strong {
+  color: #e5ff00;
 }
 
 [data-theme='dark'] strong {
@@ -149,17 +159,17 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 [data-theme='dark'] .tab [role='tab'][aria-selected='false'] {
   transition: background-color 0.3s ease;
   font-size: 1.063rem;
-  color: rgb(0, 255, 255);
+  color: #00ffff;
 }
 
 [data-theme='dark'] .tab:hover [role='tab'][aria-selected='false'] {
   background-color: rgba(0, 248, 236, 0.494);
-  color: rgb(255, 255, 255);
+  color: white;
   font-weight: 600;
 }
 
 [data-theme='dark'] .tab [role='tab'][aria-selected='true'] {
-  border: 2px solid rgb(130, 220, 204);
+  border: 2px solid #82dccc;
   background-color: rgba(45, 140, 143, 0.514);
 }
 
@@ -174,7 +184,7 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 
 /*Text color when hovering outside the text*/
 [data-theme='dark'] starlight-toc > nav > ul > li > a:hover > span {
-  color: rgb(0 255 255);
+  color: #00ffff;
   font-weight: 500;
 }
 
@@ -184,7 +194,7 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 
 /*Sibling item*/
 [data-theme='dark'] starlight-toc > nav > ul > li > ul > li:hover > a {
-  color: rgb(0 255 255);
+  color: #00ffff;
 }
 
 [data-theme='dark'] starlight-toc > nav > ul > li > ul > li > a > span {
@@ -193,7 +203,7 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 }
 
 [data-theme='dark'] starlight-toc > nav > ul > li > ul > li > a:hover > span {
-  color: rgb(0 255 255);
+  color: #00ffff;
   font-weight: 500;
 }
 
@@ -205,7 +215,7 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 
 [data-theme='dark'] starlight-toc > nav > ul > li > a[aria-current='true'] > span {
   background-color: rgba(102 173 160 / 0);
-  color: rgb(0 255 255);
+  color: #00ffff;
 }
 
 /*Current active nested item*/
@@ -214,7 +224,7 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 }
 
 [data-theme='dark'] starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
-  color: rgb(0 255 255);
+  color: #00ffff;
   background-color: rgba(102 173 160 / 0);
 }
 
@@ -225,13 +235,21 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
   font-weight: 500;
 }
 
-[data-theme='dark'] .top-level details > ul > li > details > ul > li > a:hover[aria-current='false'] {
+[data-theme='dark']
+  .top-level
+  details
+  > ul
+  > li
+  > details
+  > ul
+  > li
+  > a:hover[aria-current='false'] {
   background-color: rgba(0, 123, 127, 0.774);
 }
 
 /* Arrows */
 [data-theme='dark'] sl-sidebar-state-persist > ul > li > details {
-  color: rgb(0, 255, 255);
+  color: #00ffff;
 }
 
 /* Current active page */
@@ -254,14 +272,14 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
   > ul
   > li
   > a:hover[aria-current='page'] {
-  color: rgb(0, 0, 0);
-  background-color: rgb(130, 220, 204);
+  color: black;
+  background-color: #82dccc;
 }
 
 /* Color when hovering over text */
 
 [data-theme='dark'] sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
-  color: rgb(255, 255, 255);
+  color: white;
 }
 
 /*Color around text when hovering*/
@@ -274,13 +292,13 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
   > li
   > a[aria-current='page']
   > span:hover {
-  color: rgb(0, 0, 0);
+  color: black;
 }
 
 /* Color when hovering outside the text */
 
 [data-theme='dark'] sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
-  color: rgb(255, 255, 255);
+  color: white;
   background-color: rgba(0, 123, 127, 0.774);
 }
 
@@ -297,14 +315,21 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
   font-weight: 400;
 }
 
-[data-theme='light'] .top-level details > ul > li > details > ul > li > a:hover[aria-current='false'] {
+[data-theme='light']
+  .top-level
+  details
+  > ul
+  > li
+  > details
+  > ul
+  > li
+  > a:hover[aria-current='false'] {
   background-color: rgba(4, 156, 161, 0.63);
 }
 
-
 /* Arrows */
 [data-theme='light'] sl-sidebar-state-persist > ul > li > details {
-  color: rgb(0, 125, 111);
+  color: #007d6f;
 }
 
 /* Current active page */
@@ -316,8 +341,8 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
   > ul
   > li
   > a[aria-current='page'] {
-  color: rgb(255, 255, 255);
-  background-color: rgb(0, 125, 111);
+  color: white;
+  background-color: #007d6f;
 }
 
 [data-theme='light']
@@ -328,14 +353,14 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
   > ul
   > li
   > a:hover[aria-current='page'] {
-  color: rgb(255, 255, 255);
-  background-color: rgb(0, 125, 111);
+  color: white;
+  background-color: #007d6f;
 }
 
 /* Color when hovering over text */
 
 [data-theme='light'] sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
-  color: rgb(0, 0, 0);
+  color: black;
 }
 
 /*Color around text when hovering*/
@@ -348,13 +373,13 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
   > li
   > a[aria-current='page']
   > span:hover {
-  color: rgb(255, 255, 255);
+  color: white;
 }
 
 /* Color when hovering outside the text */
 
 [data-theme='light'] sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
-  color: rgb(0, 0, 0);
+  color: black;
   font-weight: 600;
   background-color: rgba(4, 156, 161, 0.63);
 }
@@ -370,12 +395,12 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 /* Affects all text from non nested lists */
 
 [data-theme='light'] starlight-toc > nav > ul > li > a > span {
-  color: rgb(0, 0, 0);
+  color: black;
   font-weight: 500;
 }
 /*Text color when hovering outside the text*/
 [data-theme='light'] starlight-toc > nav > ul > li > a:hover > span {
-  color: rgb(0, 0, 0);
+  color: black;
   font-weight: 500;
 }
 
@@ -398,31 +423,31 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 }
 
 [data-theme='light'] starlight-toc > nav > ul > li > ul > li > a:hover > span {
-  color: rgb(0, 0, 0);
+  color: black;
   font-weight: 500;
 }
 
 /*Current active nested item*/
 [data-theme='light'] starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] {
   color: black;
-  background-color: rgb(0, 125, 111);
+  background-color: #007d6f;
 }
 
 [data-theme='light'] starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
-  color: rgb(255, 255, 255);
-  background-color: rgb(0, 125, 111);
+  color: white;
+  background-color: #007d6f;
 }
 
 /* Current active sidebar item */
 
 [data-theme='light'] starlight-toc > nav > ul > li > a[aria-current='true'] {
   color: black;
-  background-color: rgb(0, 125, 111);
+  background-color: #007d6f;
 }
 
 [data-theme='light'] starlight-toc > nav > ul > li > a[aria-current='true'] > span {
-  background-color: rgb(0, 125, 111);
-  color: rgb(255, 255, 255);
+  background-color: #007d6f;
+  color: white;
 }
 
 /* Tabbed interface */
@@ -430,12 +455,12 @@ starlight-tabs > div > .sl-steps > li > ul > li > div {
 [data-theme='light'] .tab [role='tab'][aria-selected='false'] {
   transition: background-color 0.3s ease;
   font-size: 1.063rem;
-  color: rgb(0, 0, 0);
+  color: black;
 }
 
 [data-theme='light'] .tab:hover [role='tab'][aria-selected='false'] {
   background-color: #60c0c3;
-  color: rgb(0, 0, 0);
+  color: black;
   font-weight: 600;
 }
 

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -104,7 +104,7 @@ starlight-tabs {
     [role='tab'][aria-selected='false'] {
       transition: background-color 0.3s ease;
       font-size: 1.063rem;
-      color: #00ffff;
+      color: cyan;
     }
     &:hover [role='tab'][aria-selected='false'] {
       background-color: rgba(0, 248, 236, 0.494);
@@ -125,21 +125,21 @@ starlight-tabs {
     }
     /* Text color when hovering outside the text */
     & > nav > ul > li > a:hover > span {
-      color: #00ffff;
+      color: cyan;
       @apply font-medium;
     }
     /*Nested ul's*/
     /*Color Hovering outside the text when in an nested item*/
     /*Sibling item*/
     & > nav > ul > li > ul > li:hover > a {
-      color: #00ffff;
+      color: cyan;
     }
     & > nav > ul > li > ul > li > a > span {
       color: rgba(255, 255, 255, 0.527);
       @apply font-medium;
     }
     & > nav > ul > li > ul > li > a:hover > span {
-      color: #00ffff;
+      color: cyan;
       @apply font-medium;
     }
     /* Current active sidebar item */
@@ -148,14 +148,14 @@ starlight-tabs {
     }
     & > nav > ul > li > a[aria-current='true'] > span {
       background-color: rgba(102 173 160 / 0);
-      color: #00ffff;
+      color: cyan;
     }
     /*Current active nested item*/
     & > nav > ul > li > ul > li > a[aria-current='true'] {
       background-color: rgba(102 173 160 / 0.26);
     }
     & > nav > ul > li > ul > li > a[aria-current='true'] > span {
-      color: #00ffff;
+      color: cyan;
       background-color: rgba(102 173 160 / 0);
     }
   }
@@ -173,7 +173,7 @@ starlight-tabs {
   sl-sidebar-state-persist {
     /* Arrows */
     & > ul > li > details {
-      color: #00ffff;
+      color: cyan;
     }
     /* Current active page */
     & > ul > li > details > ul > li > a[aria-current='page'] {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -83,7 +83,7 @@ starlight-tabs {
   .sl-markdown-content {
     /* Code */
     code:not(:where(.not-content *)) {
-      font-size: 1rem;
+      @apply text-base;
     }
 
     /* Content header */
@@ -97,7 +97,7 @@ starlight-tabs {
     color: #e5ff00;
   }
   strong {
-    color: #82dccc;
+    @apply text-accent-200;
   }
 
   .tab {
@@ -108,11 +108,10 @@ starlight-tabs {
     }
     &:hover [role='tab'][aria-selected='false'] {
       background-color: rgba(0, 248, 236, 0.494);
-      color: white;
-      font-weight: 600;
+      @apply text-white font-semibold;
     }
     [role='tab'][aria-selected='true'] {
-      border: 2px solid #82dccc;
+      @apply border-2 border-accent-200;
       background-color: rgba(45, 140, 143, 0.514);
     }
   }
@@ -122,12 +121,12 @@ starlight-tabs {
     /* Affects all text from non nested lists */
     & > nav > ul > li > a > span {
       color: #e1e3e5;
-      font-weight: 500;
+      @apply font-medium;
     }
     /* Text color when hovering outside the text */
     & > nav > ul > li > a:hover > span {
       color: #00ffff;
-      font-weight: 500;
+      @apply font-medium;
     }
     /*Nested ul's*/
     /*Color Hovering outside the text when in an nested item*/
@@ -137,11 +136,11 @@ starlight-tabs {
     }
     & > nav > ul > li > ul > li > a > span {
       color: rgba(255, 255, 255, 0.527);
-      font-weight: 500;
+      @apply font-medium;
     }
     & > nav > ul > li > ul > li > a:hover > span {
       color: #00ffff;
-      font-weight: 500;
+      @apply font-medium;
     }
     /* Current active sidebar item */
     & > nav > ul > li > a[aria-current='true'] {
@@ -164,8 +163,7 @@ starlight-tabs {
   /* Left sidebar  */
   .top-level {
     details > ul .group-label > span {
-      color: #b8c2d7;
-      font-weight: 500;
+      @apply text-gray-300 font-medium;
     }
     details > ul > li > details > ul > li > a:hover[aria-current='false'] {
       background-color: rgba(0, 123, 127, 0.774);
@@ -182,25 +180,24 @@ starlight-tabs {
       background-color: rgba(82 230 202 / 0.84);
     }
     & > ul > li > details > ul > li > a:hover[aria-current='page'] {
-      color: black;
-      background-color: #82dccc;
+      @apply bg-accent-200 text-black;
     }
     /* Color when hovering over text */
     & > ul > li > details > ul > li > a > span:hover {
-      color: white;
+      @apply text-white;
     }
     /*Color around text when hovering*/
     & > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
-      color: black;
+      @apply text-black;
     }
     /* Color when hovering outside the text */
     & > ul > li > details > ul > li > a:hover {
-      color: white;
+      @apply text-white;
       background-color: rgba(0, 123, 127, 0.774);
     }
     /* Affects all text of the sidebar */
     & > ul > li > details > ul > li > a {
-      font-weight: 500;
+      @apply font-medium;
     }
   }
 }
@@ -209,8 +206,7 @@ starlight-tabs {
   /* Left sidebar  */
   .top-level {
     details > ul .group-label > span {
-      color: black;
-      font-weight: 400;
+      @apply text-black font-normal;
     }
     details > ul > li > details > ul > li > a:hover[aria-current='false'] {
       background-color: rgba(4, 156, 161, 0.63);
@@ -220,34 +216,31 @@ starlight-tabs {
   sl-sidebar-state-persist {
     /* Arrows */
     & > ul > li > details {
-      color: #007d6f;
+      @apply text-accent-600;
     }
     /* Current active page */
     & > ul > li > details > ul > li > a[aria-current='page'] {
-      color: white;
-      background-color: #007d6f;
+      @apply text-white bg-accent-600;
     }
     & > ul > li > details > ul > li > a:hover[aria-current='page'] {
-      color: white;
-      background-color: #007d6f;
+      @apply text-white bg-accent-600;
     }
     /* Color when hovering over text */
     & > ul > li > details > ul > li > a > span:hover {
-      color: black;
+      @apply text-black;
     }
     /* Color around text when hovering */
     & > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
-      color: white;
+      @apply text-white;
     }
     /* Color when hovering outside the text */
     & > ul > li > details > ul > li > a:hover {
-      color: black;
-      font-weight: 600;
+      @apply text-black font-semibold;
       background-color: rgba(4, 156, 161, 0.63);
     }
     /* Affects all text of the sidebar */
     & > ul > li > details > ul > li > a {
-      font-weight: 500;
+      @apply font-medium;
     }
   }
 
@@ -255,13 +248,11 @@ starlight-tabs {
   starlight-toc {
     /* Affects all text from non nested lists */
     & > nav > ul > li > a > span {
-      color: black;
-      font-weight: 500;
+      @apply text-black font-medium;
     }
     /* Text color when hovering outside the text */
     & > nav > ul > li > a:hover > span {
-      color: black;
-      font-weight: 500;
+      @apply text-black font-medium;
     }
     /* This one affects the entire item except around the text*/
     & > nav > ul > li > a:hover {
@@ -275,29 +266,24 @@ starlight-tabs {
     }
     & > nav > ul > li > ul > li > a > span {
       color: rgba(0, 0, 0, 0.637);
-      font-weight: 500;
+      @apply font-medium;
     }
     & > nav > ul > li > ul > li > a:hover > span {
-      color: black;
-      font-weight: 500;
+      @apply text-black font-medium;
     }
     /* Current active nested item */
     & > nav > ul > li > ul > li > a[aria-current='true'] {
-      color: black;
-      background-color: #007d6f;
+      @apply text-black bg-accent-600;
     }
     & > nav > ul > li > ul > li > a[aria-current='true'] > span {
-      color: white;
-      background-color: #007d6f;
+      @apply text-white bg-accent-600;
     }
     /* Current active sidebar item */
     & > nav > ul > li > a[aria-current='true'] {
-      color: black;
-      background-color: #007d6f;
+      @apply text-black bg-accent-600;
     }
     & > nav > ul > li > a[aria-current='true'] > span {
-      background-color: #007d6f;
-      color: white;
+      @apply text-white bg-accent-600;
     }
   }
 
@@ -305,17 +291,14 @@ starlight-tabs {
     [role='tab'][aria-selected='false'] {
       transition: background-color 0.3s ease;
       font-size: 1.063rem;
-      color: black;
+      @apply text-black;
     }
     &:hover [role='tab'][aria-selected='false'] {
       background-color: #60c0c3;
-      color: black;
-      font-weight: 600;
+      @apply text-black font-semibold;
     }
     [role='tab'][aria-selected='true'] {
-      color: white;
-      border-right: 0px;
-      background-color: #007d6f;
+      @apply text-white bg-accent-600 border-r-0;
     }
   }
 }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -86,7 +86,7 @@ starlight-tabs {
 
     /* Content header */
     :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
-      color: #ffffffcc;
+      @apply text-white/90;
     }
   }
 
@@ -133,8 +133,7 @@ starlight-tabs {
       color: cyan;
     }
     & > nav > ul > li > ul > li > a > span {
-      color: #ffffff86;
-      @apply font-medium;
+      @apply font-medium text-white/50;
     }
     & > nav > ul > li > ul > li > a:hover > span {
       color: cyan;
@@ -263,8 +262,7 @@ starlight-tabs {
       background-color: #60c0c3;
     }
     & > nav > ul > li > ul > li > a > span {
-      color: #000000a2;
-      @apply font-medium;
+      @apply font-medium text-black/90;
     }
     & > nav > ul > li > ul > li > a:hover > span {
       @apply text-black font-medium;

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -76,7 +76,7 @@ starlight-tabs {
 
 /* Tabbed interface */
 .tabs [role='tab'][aria-selected='false'] {
-  overflow-x: scroll;
+  @apply overflow-x-scroll;
 }
 
 [data-theme='dark'] {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -22,27 +22,18 @@
 }
 
 .hero {
-  padding-top: 2.5rem;
-  padding-bottom: 2.5rem;
+  @apply py-10;
+  /* Hero Buttons */
+  .sl-link-button {
+    @apply transition hover:scale-105;
+  }
 }
 
-/* Hero Buttons */
-
-a.sl-link-button {
-  transition: transform 0.3s ease-out;
-}
-
-a.sl-link-button:hover {
-  transform: scale(1.1);
-}
-
-div.sl-hidden > .social-icons > a {
-  font-size: 1.4rem;
-  transition: transform 0.3s ease-out;
-}
-
-div.sl-hidden > .social-icons > a:hover {
-  transform: scale(1.2);
+.social-icons {
+  /* Social Icons */
+  & > a {
+    @apply transition hover:scale-110 text-xl;
+  }
 }
 
 /* Temporal Fix */

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -36,20 +36,6 @@
   }
 }
 
-/* Temporal Fix */
-
-.sl-markdown-content > p {
-  margin-top: 0;
-}
-
-div.sl-heading-wrapper {
-  margin-bottom: 1rem;
-}
-
-img {
-  margin-top: 0;
-}
-
 /*Dark Theme*/
 
 /* Content text */

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -36,413 +36,297 @@
   }
 }
 
-/*Dark Theme*/
-
-/* Content text */
-
-[data-theme='dark'] body {
-  font-family: var(--__sl-font);
-  line-height: var(--sl-line-height);
-  -webkit-font-smoothing: antialiased;
-  color: white;
-  background-color: var(--sl-color-bg);
+starlight-tabs {
+  & > div > .sl-steps > li > ul {
+    margin-top: 0.5%;
+    padding-left: 4%;
+  }
+  & > div > .sl-steps > li > ul > li {
+    margin-top: 0%;
+    padding-left: 0.2%;
+  }
+  & > div > .sl-steps > li > ul > li > div {
+    margin-bottom: 1%;
+  }
 }
 
-/* Code */
+.sl-markdown-content {
+  /* Bullet point spacing */
+  & > ul {
+    margin-top: 1%;
+    padding-left: 2%;
+  }
 
-[data-theme='dark'] .sl-markdown-content code:not(:where(.not-content *)) {
-  font-size: 1rem;
-}
+  /* Numbered list */
+  & > ol.sl-steps {
+    margin-top: 2%;
+    padding-left: 0%;
+  }
 
-/* Anchor style*/
-
-[data-theme='dark'] starlight-tabs > div > ul > li > a {
-  color: white;
-}
-
-/* Strong tag style */
-
-[data-theme='dark']
-  aside.starlight-aside.starlight-aside--caution
-  > div.starlight-aside__content
-  > ul
-  > li
-  > p
-  > strong {
-  color: #e5ff00;
-}
-
-[data-theme='dark']
-  aside.starlight-aside.starlight-aside--caution
-  > div.starlight-aside__content
-  > p
-  > strong {
-  color: #e5ff00;
-}
-
-[data-theme='dark'] strong {
-  color: #82dccc;
-}
-
-/* Styling of bullet points in Steps */
-
-starlight-tabs > div > .sl-steps > li > ul {
-  margin-top: 0.5%;
-  padding-left: 4%;
-}
-
-starlight-tabs > div > .sl-steps > li > ul > li {
-  margin-top: 0%;
-  padding-left: 0.2%;
-}
-
-starlight-tabs > div > .sl-steps > li > ul > li > div {
-  margin-bottom: 1%;
-}
-
-/* Bullet point spacing */
-
-.sl-markdown-content > ul {
-  margin-top: 1%;
-  padding-left: 2%;
-}
-
-/* Numbered list */
-
-.sl-markdown-content > ol.sl-steps {
-  margin-top: 2%;
-  padding-left: 0%;
-}
-
-/* Nested bullet point spacing */
-
-.sl-markdown-content > ul > li > ul {
-  margin-top: 1%;
-  padding-left: 2%;
-}
-
-/* Content header */
-
-[data-theme='dark'] .sl-markdown-content :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
-  color: rgba(255 255 255 / 0.8);
+  /* Nested bullet point spacing */
+  & > ul > li > ul {
+    margin-top: 1%;
+    padding-left: 2%;
+  }
 }
 
 /* Tabbed interface */
-
 .tabs [role='tab'][aria-selected='false'] {
   overflow-x: scroll;
 }
 
-[data-theme='dark'] .tab [role='tab'][aria-selected='false'] {
-  transition: background-color 0.3s ease;
-  font-size: 1.063rem;
-  color: #00ffff;
+[data-theme='dark'] {
+  /* Content text */
+  body {
+    font-family: var(--__sl-font);
+    line-height: var(--sl-line-height);
+    -webkit-font-smoothing: antialiased;
+    color: white;
+    background-color: var(--sl-color-bg);
+  }
+
+  /* Code */
+  .sl-markdown-content code:not(:where(.not-content *)) {
+    font-size: 1rem;
+  }
+
+  /* Content header */
+  .sl-markdown-content :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
+    color: rgba(255 255 255 / 0.8);
+  }
+
+  /* Strong tag style */
+  aside.starlight-aside.starlight-aside--caution
+    > div.starlight-aside__content
+    > ul
+    > li
+    > p
+    > strong {
+    color: #e5ff00;
+  }
+  aside.starlight-aside.starlight-aside--caution > div.starlight-aside__content > p > strong {
+    color: #e5ff00;
+  }
+  strong {
+    color: #82dccc;
+  }
+
+  /* Tabbed interface */
+  .tab [role='tab'][aria-selected='false'] {
+    transition: background-color 0.3s ease;
+    font-size: 1.063rem;
+    color: #00ffff;
+  }
+  .tab:hover [role='tab'][aria-selected='false'] {
+    background-color: rgba(0, 248, 236, 0.494);
+    color: white;
+    font-weight: 600;
+  }
+  .tab [role='tab'][aria-selected='true'] {
+    border: 2px solid #82dccc;
+    background-color: rgba(45, 140, 143, 0.514);
+  }
+  .tab [role='tab'][aria-selected='false'] {
+    transition: background-color 0.3s ease;
+    font-size: 1.063rem;
+    color: #00ffff;
+  }
+  .tab:hover [role='tab'][aria-selected='false'] {
+    background-color: rgba(0, 248, 236, 0.494);
+    color: white;
+    font-weight: 600;
+  }
+  .tab [role='tab'][aria-selected='true'] {
+    border: 2px solid #82dccc;
+    background-color: rgba(45, 140, 143, 0.514);
+  }
+
+  /* Right sidebar */
+  /* Affects all text from non nested lists */
+  starlight-toc > nav > ul > li > a > span {
+    color: #e1e3e5;
+    font-weight: 500;
+  }
+  /* Text color when hovering outside the text */
+  starlight-toc > nav > ul > li > a:hover > span {
+    color: #00ffff;
+    font-weight: 500;
+  }
+  /*Nested ul's*/
+  /*Color Hovering outside the text when in an nested item*/
+  /*Sibling item*/
+  starlight-toc > nav > ul > li > ul > li:hover > a {
+    color: #00ffff;
+  }
+  starlight-toc > nav > ul > li > ul > li > a > span {
+    color: rgba(255, 255, 255, 0.527);
+    font-weight: 500;
+  }
+  starlight-toc > nav > ul > li > ul > li > a:hover > span {
+    color: #00ffff;
+    font-weight: 500;
+  }
+  /* Current active sidebar item */
+  starlight-toc > nav > ul > li > a[aria-current='true'] {
+    background-color: rgba(102 173 160 / 0.26);
+  }
+  starlight-toc > nav > ul > li > a[aria-current='true'] > span {
+    background-color: rgba(102 173 160 / 0);
+    color: #00ffff;
+  }
+  /*Current active nested item*/
+  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] {
+    background-color: rgba(102 173 160 / 0.26);
+  }
+  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
+    color: #00ffff;
+    background-color: rgba(102 173 160 / 0);
+  }
+
+  /* Left sidebar  */
+  .top-level details > ul .group-label > span {
+    color: #b8c2d7;
+    font-weight: 500;
+  }
+  .top-level details > ul > li > details > ul > li > a:hover[aria-current='false'] {
+    background-color: rgba(0, 123, 127, 0.774);
+  }
+
+  /* Arrows */
+  sl-sidebar-state-persist > ul > li > details {
+    color: #00ffff;
+  }
+  /* Current active page */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] {
+    background-color: rgba(82 230 202 / 0.84);
+  }
+  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover[aria-current='page'] {
+    color: black;
+    background-color: #82dccc;
+  }
+  /* Color when hovering over text */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
+    color: white;
+  }
+  /*Color around text when hovering*/
+  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
+    color: black;
+  }
+  /* Color when hovering outside the text */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
+    color: white;
+    background-color: rgba(0, 123, 127, 0.774);
+  }
+  /* Affects all text of the sidebar */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a {
+    font-weight: 500;
+  }
 }
 
-[data-theme='dark'] .tab:hover [role='tab'][aria-selected='false'] {
-  background-color: rgba(0, 248, 236, 0.494);
-  color: white;
-  font-weight: 600;
-}
+[data-theme='light'] {
+  /* Left sidebar  */
+  .top-level details > ul .group-label > span {
+    color: black;
+    font-weight: 400;
+  }
+  .top-level details > ul > li > details > ul > li > a:hover[aria-current='false'] {
+    background-color: rgba(4, 156, 161, 0.63);
+  }
 
-[data-theme='dark'] .tab [role='tab'][aria-selected='true'] {
-  border: 2px solid #82dccc;
-  background-color: rgba(45, 140, 143, 0.514);
-}
+  /* Arrows */
+  sl-sidebar-state-persist > ul > li > details {
+    color: #007d6f;
+  }
+  /* Current active page */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] {
+    color: white;
+    background-color: #007d6f;
+  }
+  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover[aria-current='page'] {
+    color: white;
+    background-color: #007d6f;
+  }
+  /* Color when hovering over text */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
+    color: black;
+  }
+  /* Color around text when hovering */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a[aria-current='page'] > span:hover {
+    color: white;
+  }
+  /* Color when hovering outside the text */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
+    color: black;
+    font-weight: 600;
+    background-color: rgba(4, 156, 161, 0.63);
+  }
+  /* Affects all text of the sidebar */
+  sl-sidebar-state-persist > ul > li > details > ul > li > a {
+    font-weight: 500;
+  }
 
-/* Right sidebar */
+  /* Right sidebar */
+  /* Affects all text from non nested lists */
+  starlight-toc > nav > ul > li > a > span {
+    color: black;
+    font-weight: 500;
+  }
+  /* Text color when hovering outside the text */
+  starlight-toc > nav > ul > li > a:hover > span {
+    color: black;
+    font-weight: 500;
+  }
+  /* This one affects the entire item except around the text*/
+  starlight-toc > nav > ul > li > a:hover {
+    background-color: #60c0c3;
+  }
+  /* Nested ul's */
+  /* Color Hovering outside the text when in an nested item */
+  /* Sibling item */
+  starlight-toc > nav > ul > li > ul > li:hover > a {
+    background-color: #60c0c3;
+  }
+  starlight-toc > nav > ul > li > ul > li > a > span {
+    color: rgba(0, 0, 0, 0.637);
+    font-weight: 500;
+  }
+  starlight-toc > nav > ul > li > ul > li > a:hover > span {
+    color: black;
+    font-weight: 500;
+  }
+  /* Current active nested item */
+  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] {
+    color: black;
+    background-color: #007d6f;
+  }
+  starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
+    color: white;
+    background-color: #007d6f;
+  }
+  /* Current active sidebar item */
+  starlight-toc > nav > ul > li > a[aria-current='true'] {
+    color: black;
+    background-color: #007d6f;
+  }
+  starlight-toc > nav > ul > li > a[aria-current='true'] > span {
+    background-color: #007d6f;
+    color: white;
+  }
 
-/* Affects all text from non nested lists */
-
-[data-theme='dark'] starlight-toc > nav > ul > li > a > span {
-  color: #e1e3e5;
-  font-weight: 500;
-}
-
-/*Text color when hovering outside the text*/
-[data-theme='dark'] starlight-toc > nav > ul > li > a:hover > span {
-  color: #00ffff;
-  font-weight: 500;
-}
-
-/*Nested ul's*/
-
-/*Color Hovering outside the text when in an nested item*/
-
-/*Sibling item*/
-[data-theme='dark'] starlight-toc > nav > ul > li > ul > li:hover > a {
-  color: #00ffff;
-}
-
-[data-theme='dark'] starlight-toc > nav > ul > li > ul > li > a > span {
-  color: rgba(255, 255, 255, 0.527);
-  font-weight: 500;
-}
-
-[data-theme='dark'] starlight-toc > nav > ul > li > ul > li > a:hover > span {
-  color: #00ffff;
-  font-weight: 500;
-}
-
-/* Current active sidebar item */
-
-[data-theme='dark'] starlight-toc > nav > ul > li > a[aria-current='true'] {
-  background-color: rgba(102 173 160 / 0.26);
-}
-
-[data-theme='dark'] starlight-toc > nav > ul > li > a[aria-current='true'] > span {
-  background-color: rgba(102 173 160 / 0);
-  color: #00ffff;
-}
-
-/*Current active nested item*/
-[data-theme='dark'] starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] {
-  background-color: rgba(102 173 160 / 0.26);
-}
-
-[data-theme='dark'] starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
-  color: #00ffff;
-  background-color: rgba(102 173 160 / 0);
-}
-
-/* Left sidebar  */
-
-[data-theme='dark'] .top-level details > ul .group-label > span {
-  color: #b8c2d7;
-  font-weight: 500;
-}
-
-[data-theme='dark']
-  .top-level
-  details
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a:hover[aria-current='false'] {
-  background-color: rgba(0, 123, 127, 0.774);
-}
-
-/* Arrows */
-[data-theme='dark'] sl-sidebar-state-persist > ul > li > details {
-  color: #00ffff;
-}
-
-/* Current active page */
-[data-theme='dark']
-  sl-sidebar-state-persist
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a[aria-current='page'] {
-  background-color: rgba(82 230 202 / 0.84);
-}
-
-[data-theme='dark']
-  sl-sidebar-state-persist
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a:hover[aria-current='page'] {
-  color: black;
-  background-color: #82dccc;
-}
-
-/* Color when hovering over text */
-
-[data-theme='dark'] sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
-  color: white;
-}
-
-/*Color around text when hovering*/
-[data-theme='dark']
-  sl-sidebar-state-persist
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a[aria-current='page']
-  > span:hover {
-  color: black;
-}
-
-/* Color when hovering outside the text */
-
-[data-theme='dark'] sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
-  color: white;
-  background-color: rgba(0, 123, 127, 0.774);
-}
-
-/* Affects all text of the sidebar */
-
-[data-theme='dark'] sl-sidebar-state-persist > ul > li > details > ul > li > a {
-  font-weight: 500;
-}
-
-/* Left sidebar  */
-
-[data-theme='light'] .top-level details > ul .group-label > span {
-  color: black;
-  font-weight: 400;
-}
-
-[data-theme='light']
-  .top-level
-  details
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a:hover[aria-current='false'] {
-  background-color: rgba(4, 156, 161, 0.63);
-}
-
-/* Arrows */
-[data-theme='light'] sl-sidebar-state-persist > ul > li > details {
-  color: #007d6f;
-}
-
-/* Current active page */
-[data-theme='light']
-  sl-sidebar-state-persist
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a[aria-current='page'] {
-  color: white;
-  background-color: #007d6f;
-}
-
-[data-theme='light']
-  sl-sidebar-state-persist
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a:hover[aria-current='page'] {
-  color: white;
-  background-color: #007d6f;
-}
-
-/* Color when hovering over text */
-
-[data-theme='light'] sl-sidebar-state-persist > ul > li > details > ul > li > a > span:hover {
-  color: black;
-}
-
-/*Color around text when hovering*/
-[data-theme='light']
-  sl-sidebar-state-persist
-  > ul
-  > li
-  > details
-  > ul
-  > li
-  > a[aria-current='page']
-  > span:hover {
-  color: white;
-}
-
-/* Color when hovering outside the text */
-
-[data-theme='light'] sl-sidebar-state-persist > ul > li > details > ul > li > a:hover {
-  color: black;
-  font-weight: 600;
-  background-color: rgba(4, 156, 161, 0.63);
-}
-
-/* Affects all text of the sidebar */
-
-[data-theme='light'] sl-sidebar-state-persist > ul > li > details > ul > li > a {
-  font-weight: 500;
-}
-
-/* Right sidebar */
-
-/* Affects all text from non nested lists */
-
-[data-theme='light'] starlight-toc > nav > ul > li > a > span {
-  color: black;
-  font-weight: 500;
-}
-/*Text color when hovering outside the text*/
-[data-theme='light'] starlight-toc > nav > ul > li > a:hover > span {
-  color: black;
-  font-weight: 500;
-}
-
-/* This one affects the entire item except around the text*/
-[data-theme='light'] starlight-toc > nav > ul > li > a:hover {
-  background-color: #60c0c3;
-}
-
-/*Nested ul's*/
-
-/*Color Hovering outside the text when in an nested item*/
-/*Sibling item*/
-[data-theme='light'] starlight-toc > nav > ul > li > ul > li:hover > a {
-  background-color: #60c0c3;
-}
-
-[data-theme='light'] starlight-toc > nav > ul > li > ul > li > a > span {
-  color: rgba(0, 0, 0, 0.637);
-  font-weight: 500;
-}
-
-[data-theme='light'] starlight-toc > nav > ul > li > ul > li > a:hover > span {
-  color: black;
-  font-weight: 500;
-}
-
-/*Current active nested item*/
-[data-theme='light'] starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] {
-  color: black;
-  background-color: #007d6f;
-}
-
-[data-theme='light'] starlight-toc > nav > ul > li > ul > li > a[aria-current='true'] > span {
-  color: white;
-  background-color: #007d6f;
-}
-
-/* Current active sidebar item */
-
-[data-theme='light'] starlight-toc > nav > ul > li > a[aria-current='true'] {
-  color: black;
-  background-color: #007d6f;
-}
-
-[data-theme='light'] starlight-toc > nav > ul > li > a[aria-current='true'] > span {
-  background-color: #007d6f;
-  color: white;
-}
-
-/* Tabbed interface */
-
-[data-theme='light'] .tab [role='tab'][aria-selected='false'] {
-  transition: background-color 0.3s ease;
-  font-size: 1.063rem;
-  color: black;
-}
-
-[data-theme='light'] .tab:hover [role='tab'][aria-selected='false'] {
-  background-color: #60c0c3;
-  color: black;
-  font-weight: 600;
-}
-
-[data-theme='light'] .tab [role='tab'][aria-selected='true'] {
-  color: white;
-  border-right: 0px;
-  background-color: #007d6f;
+  /* Tabbed interface */
+  .tab [role='tab'][aria-selected='false'] {
+    transition: background-color 0.3s ease;
+    font-size: 1.063rem;
+    color: black;
+  }
+  .tab:hover [role='tab'][aria-selected='false'] {
+    background-color: #60c0c3;
+    color: black;
+    font-weight: 600;
+  }
+  .tab [role='tab'][aria-selected='true'] {
+    color: white;
+    border-right: 0px;
+    background-color: #007d6f;
+  }
 }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -27,14 +27,12 @@
 
 .hero {
   @apply py-10;
-  /* Hero Buttons */
   .sl-link-button {
     @apply transition hover:scale-105;
   }
 }
 
 .social-icons {
-  /* Social Icons */
   & > a {
     @apply transition hover:scale-110 text-xl;
   }


### PR DESCRIPTION
There are some colors that need to be figured out, since they differ a bit here and there.
Also, some CSS paths could be simplified, like `nav > ul > li`, for example. But that needs figuring out, so it can be done next time.

I tried to nest similar rules under a single parent so they're easier to navigate. I also tried to use Tailwind as much as possible, since it will make the code more maintainable by using the same colors, sizes, and so on everywhere.

As a side note, I added some config settings to `.vscode` so `@apply` and similar items stop showing up as errors in VS Code.