### PR TITLE
Gaming: Increase shader cache using environment instead of profile.d

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -314,6 +314,10 @@ But if you have time to spare, then you can ignore this tip and let Steam pre co
 <ImageComponent imgsrc={import('~/assets/images/steam-setting.png')} />
 <ImageComponent imgsrc={import('~/assets/images/steam-shader-cache.png')} />
 
+:::note
+It's highly recommended to [increase your maximum shader cache size](#increase-maximum-shader-cache-size) after disabling pre-caching on Steam.
+:::
+
 ### Repurposing a Windows NTFS game partition
 
 :::caution
@@ -423,14 +427,14 @@ To avoid long loading times and stuttering, we can increase the global shader ca
 
 <Steps>
 1. Open the terminal.
-2. Enter this command:
+2. Enter this command to edit the environment file:
 	```sh
-	sudo nano /etc/profile.d/increase-shadercache.sh
+	sudo nano /etc/environment
 	```
-3. Paste the following into the file:
+3. Paste the following at the end of the file:
 	```sh
 	# Increase Nvidia's shader cache size to 12GB
-	export __GL_SHADER_DISK_CACHE_SIZE=12000000000
+	__GL_SHADER_DISK_CACHE_SIZE=12000000000
 	```
 4. Save the file by pressing `CTRL+X`, `Y`, then `Enter`.
 5. Restart your system.
@@ -442,17 +446,17 @@ To avoid long loading times and stuttering, we can increase the global shader ca
 
 <Steps>
 1. Open the terminal.
-2. Enter this command:
+2. Enter this command to edit the environment file:
 	```sh
-	sudo nano /etc/profile.d/increase-shadercache.sh
+	sudo nano /etc/environment
 	```
-3. Paste the following into the file:
+3. Paste the following at the end of the file:
 	```sh
 	# Enforces RADV Vulkan implementation
-	export AMD_VULKAN_ICD=RADV
+	AMD_VULKAN_ICD=RADV
     
 	# Increase AMD's shader cache size to 12GB
-	export MESA_SHADER_CACHE_MAX_SIZE=12G
+	MESA_SHADER_CACHE_MAX_SIZE=12G
 	```
 4. Save the file by pressing `CTRL+X`, `Y`, then `Enter`.
 5. Restart your system.


### PR DESCRIPTION
It turns out that not every CachyOS setup allows changing environment variables in `/etc/profile.d`. See https://github.com/CachyOS/wiki/pull/166#discussion_r2280417851 for more info.

This updated the guide to use `/etc/environment` instead, which should universally work.

I also added a note after disabling shader pre-caching pointing to increasing the maximum shader cache size as a recommended next step.