### PR TITLE
Document more Proton variables

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -60,8 +60,16 @@ The `proton-cachyos` package from the CachyOS repositories is compiled against n
 
 **Additional configuration options**
 
+- `PROTON_ENABLE_WAYLAND=1`: Enables native Wayland support. Allows for HDR output without Gamescope and may improve latency and frame pacing; breaks Steam overlay as it lacks Wayland support. Currently experimental and may cause issues in some games.
+- `PROTON_ENABLE_HDR=1`: Enables HDR output support. Requires either running under Gamescope started with `--hdr-enabled` or turning on native Wayland support to correctly pass colors through.
+- - Additional setup may be needed depending on your hardware and desktop environment, consult the article on [HDR monitor support](https://wiki.archlinux.org/title/HDR_monitor_support) on Arch Wiki for further guidance. For example, Nvidia users must install `vk-hdr-layer-kwin6-git` and set `ENABLE_HDR_WSI=1` if not using the Gamescope method.
+- `PROTON_USE_NTSYNC=1`: Enables using NTSync. Can help with game performance, mainly in CPU-bound situations and games that otherwise have to use WINESync. Currently experimental and known to cause issues with certain games.
+- - Do not rely on the MangoHud indicator for checking if NTSync is used as it's known to report incorrect information. Use a different method such as running `lsof /dev/ntsync` in terminal to list processes that are using NTSync.
 - `PROTON_NO_WM_DECORATION=1`: Disables window decorations using the Linux window manager. It can fix issues with **borderless fullscreen** and the mouse clicking through the window.
-- `PROTON_PREFER_SDL_INPUT=1`: Enable to work-around issues with proper controller detection.
+- `PROTON_PREFER_SDL=1`: May work around issues with proper controller detection.
+- `PROTON_NVIDIA_LIBS=1`: Enables proper implementations of various Nvidia-specific libraries; only useful on Nvidia GPUs. Allows using some Nvidia-specific features such as advanced PhysX or CUDA in games that take advantage of them - however, this should not be needed for DLSS and ray tracing.
+- - Alternatively, individual libraries can be enabled separately using `PROTON_NVIDIA_NVCUDA=1`, `PROTON_NVIDIA_NVENC=1`, `PROTON_NVIDIA_NVML=1` and `PROTON_NVIDIA_NVOPTIX=1`.
+- - You may encounter performance issues in 32-bit games with these libraries enabled on RTX 4000 series or newer GPUs; you can additionally set `PROTON_NVIDIA_LIBS_NO_32BIT=1` to only enable them in 64-bit titles.
 
 ### umu-launcher Setup
 


### PR DESCRIPTION
Initial effort to add documentation for some of the more commonly desired Proton variables. I haven't touched the section for wine-cachyos-opt below since I'm uncertain about variable names there.