### PR TITLE
community: add english-only rule

### DIFF
--- a/src/content/docs/policy/community-rules.md
+++ b/src/content/docs/policy/community-rules.md
@@ -15,3 +15,7 @@ Violating these rules is not allowed and account ban will follow:
 8. It is forbidden to flood (publish the same type of information several times in a row).
 9. It is forbidden to provoke conflicts between participants.
 10. This is a LGBTQ+ safe place, and so it is forbidden to provoke and insult LGBTQ+ people.
+
+Violating these rules will result in timeouts, escalating to an account ban for repeated offenses:
+
+1. The use of languages other than English for communication is prohibited.


### PR DESCRIPTION
make that explicit rule with properly defined punishment

community gets pretty with several cases where english-only rule gets violated which result in splited-community where some people might not able to give answer or search for issue&answer that they might be having:

1. In the former official community source (Telegram)
2. CachyOS Forum posts