### PR TITLE
Include UFS not supported with Limine

### DIFF
--- a/src/content/docs/installation/boot_managers.mdx
+++ b/src/content/docs/installation/boot_managers.mdx
@@ -192,6 +192,7 @@ Limine is a modern, advanced, and portable multiprotocol bootloader. It serves a
 - `/boot` must use FAT12/16/32 or ISO9660. Other filesystems require additional setup.
 - Does not automatically add an entry to UEFI NVRAM. This must be done manually with `efibootmgr`, or handled automatically with `limine-entry-tool` (preinstalled on CachyOS).
 - Incompatible with some MSI boards (UEFI spec violations).
+- Does not work with UFS-storage (e.g. some Chromebooks).
 
 ---
 

--- a/src/content/docs/installation/boot_managers.mdx
+++ b/src/content/docs/installation/boot_managers.mdx
@@ -192,7 +192,7 @@ Limine is a modern, advanced, and portable multiprotocol bootloader. It serves a
 - `/boot` must use FAT12/16/32 or ISO9660. Other filesystems require additional setup.
 - Does not automatically add an entry to UEFI NVRAM. This must be done manually with `efibootmgr`, or handled automatically with `limine-entry-tool` (preinstalled on CachyOS).
 - Incompatible with some MSI boards (UEFI spec violations).
-- Does not work with UFS-storage (e.g. some Chromebooks).
+- Does not work with UFS (Universal Flash Storage), used e.g. in some Chromebooks.
 
 ---
 


### PR DESCRIPTION
Limine currently does not work with UFS-storage and just shows a black screen instead of booting.

Also helpful would be a section that booting from UFS requires to add the modules ufs and ufshcd-pci in mkinitcpio conf after installation.
But I´m unsure where this would fit best (maybe Filesystems?).