### PR TITLE
FAQ: Add solution for invalid signatures (Octopi)

### DIFF
--- a/src/content/docs/cachyos_basic/faq.mdx
+++ b/src/content/docs/cachyos_basic/faq.mdx
@@ -56,7 +56,20 @@ While mirrors often fix themselves after a short while, if the issue persists, y
 
 <Tabs>
 
-<TabItem label='First Solution: Rate Your Mirrors'>
+<TabItem label='First Solution: Update via Octopi'>
+
+This is the easiest option, but it uses the GUI.
+
+- Open Octopi.
+- Press [CTRL]+[K]: This searches for updates.
+- Press [CTRL]+[U]: This installs the found updates.
+- Authenticate yourself to proceed with the installation.
+
+Alternatively, you can click on the first and second buttons in the top-left corner.
+
+</TabItem>
+
+<TabItem label='Second Solution: Rate Your Mirrors'>
 
 ```sh title='Rate your mirrors'
 sudo cachyos-rate-mirrors
@@ -64,7 +77,7 @@ sudo cachyos-rate-mirrors
 
 </TabItem>
 
-<TabItem label='Second Solution: Reset Keyrings'>
+<TabItem label='Third Solution: Reset Keyrings'>
 
 If rating your mirrors doesn't work, it's likely your system's keyrings are broken.
 


### PR DESCRIPTION
I often encounter this issue, and neither updating the mirrors nor manually resetting the keyring solves it. The only reliable solution is Octopi (for some reason).

I could also provide a german version.