### PR TITLE
ci: fix eslint error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from '@eslint/js';
 import eslintPluginAstro from 'eslint-plugin-astro';
 import tseslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ['dist', '.astro'],
   },


### PR DESCRIPTION
@Shendisx This fixes an issue:

```sh
❯ bun run eslint

~/Projects/wiki/eslint.config.mjs
  6:25  error  `config` is deprecated. ESLint core now provides this functionality via `defineConfig()`,
which we now recommend instead. See {@link https://typescript-eslint.io/packages/typescript-eslint/#config-deprecated}  @typescript-eslint/no-deprecated
```