### PR TITLE
Remove RTC as the tweak was reverted

### DIFF
--- a/src/content/docs/features/cachyos_settings.mdx
+++ b/src/content/docs/features/cachyos_settings.mdx
@@ -106,10 +106,6 @@ database
 
 - [systemd-resolved as the default DNS Resolver](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/NetworkManager/conf.d/dns.conf) for NetworkManager
 
-### RTC
-
-- Increase highest requested RTC interrupt frequency to `3072`
-
 ### NTP QoL
 
 - Preferred server set to `Cloudflare`


### PR DESCRIPTION
Just cleaning up the settings page as I've noticed there's an entry that no longer applies. See the merge below.
https://github.com/CachyOS/CachyOS-Settings/pull/151/commits