### PR TITLE
Fix systemd-boot is EFI driver capable

### DIFF
--- a/src/content/docs/installation/boot_managers.mdx
+++ b/src/content/docs/installation/boot_managers.mdx
@@ -61,8 +61,8 @@ If you encounter such issues, consider using `systemd-boot`.
     </tr>
     <tr>
       <td><strong><code>/boot</code> filesystem support</strong></td>
-      <td>FAT12/16/32 for /efi, with ext4/Btrfs via EFI drivers for /boot (<code>efifs</code>)</td>
-      <td>FAT natively; ext4/Btrfs via EFI drivers (<code>efifs</code>)</td>
+      <td>According to firmware's support (usually FAT12/16/32); More with EFI drivers</td>
+      <td>Firmware's,ext2,ext3,ext4,btrfs,ISO-9660,HFS+, and NTFS; More with EFI drivers</td>
       <td>Broad filesystem support (ext*, Btrfs, XFS, etc.)</td>
       <td>FAT12/16/32, ISO9660 for <code>/boot</code></td>
     </tr>
@@ -133,7 +133,7 @@ Part of the systemd family, systemd-boot was created to be as simple as possible
 #### Cons
 - No support for BIOS/MBR.
 - Very barebones: no theming or customization.
-- Requires manually setting up separate `esp` and `/boot` (XBOOTLDR) partitions with EFI drivers to support filesystems beyond the default supported ones (FAT12/16/32).
+- If using a boot filesystem beyond the firmware's default ones (FAT12/16/32), then separate ESP and [XBOOTLDR](https://wiki.archlinux.org/title/Systemd-boot#Installation_using_XBOOTLDR) partitions & EFI drivers need to be manually added.
 - Cannot find boot images on partitions other than its own ESP or the XBOOTLDR partition.
 - Config is not auto-generated unless configured to do so.
 - No native support for Btrfs snapshot rollbacks due to requirement to store kernel images on the boot partition rather than the root.

--- a/src/content/docs/installation/boot_managers.mdx
+++ b/src/content/docs/installation/boot_managers.mdx
@@ -61,7 +61,7 @@ If you encounter such issues, consider using `systemd-boot`.
     </tr>
     <tr>
       <td><strong><code>/boot</code> filesystem support</strong></td>
-      <td>FAT12/16/32 only</td>
+      <td>FAT12/16/32 for /efi, with ext4/Btrfs via EFI drivers for /boot (<code>efifs</code>)</td>
       <td>FAT natively; ext4/Btrfs via EFI drivers (<code>efifs</code>)</td>
       <td>Broad filesystem support (ext*, Btrfs, XFS, etc.)</td>
       <td>FAT12/16/32, ISO9660 for <code>/boot</code></td>
@@ -133,8 +133,8 @@ Part of the systemd family, systemd-boot was created to be as simple as possible
 #### Cons
 - No support for BIOS/MBR.
 - Very barebones: no theming or customization.
-- Only able to read boot images on EFI-supported filesystems (FAT12/16/32).
-- Cannot find boot images on partitions other than its own ESP.
+- Requires manually setting up separate `esp` and `/boot` (XBOOTLDR) partitions with EFI drivers to support filesystems beyond the default supported ones (FAT12/16/32).
+- Cannot find boot images on partitions other than its own ESP or the XBOOTLDR partition.
 - Config is not auto-generated unless configured to do so.
 - No native support for Btrfs snapshot rollbacks due to requirement to store kernel images on the boot partition rather than the root.
   - Snapshot booting is possible only with custom setups (not provided by CachyOS).


### PR DESCRIPTION
The docs are just fully wrong about systemd-boot not being able to use non-FAT partitions, [has been documented on the Arch wiki](https://wiki.archlinux.org/title/Systemd-boot#Installation_using_XBOOTLDR) and can personally attest to it working on CachyOS too just fine. TLDR; FAT `esp`, copy `efifs` UEFI drivers to it for an `XBOOTLDR` marked `/boot` partition on the same disk.