### PR TITLE
Adding additional information to Google Chrome hardware acceleration RE: Intel GPU's

### DIFF
--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -9,9 +9,15 @@ This guide outlines enabling hardware acceleration in Chromium-based browsers on
 
 ## Prerequisites
 
+**Required:**
 * **Chromium-based Browser:** (e.g., Chrome, Brave, Ungoogled Chromium, Edge)
 * **GPU Drivers/APIs:** Up-to-date Mesa (AMD/Intel) or NVIDIA drivers, with Vulkan/VA-API/VDPAU configured.
+
+**Optional:**
+
 * **amdgpu_top:** Install `amdgpu_top` from the repository through package manager if you wish to monitor AMD GPU activity from the terminal.
+* **nvtop:** (Intel GPU's only) Install `nvtop` (Lunar Lake) and `intel-gpu-tools` (Pre-Lunar Lake) through the octopi package manager if you wish to monitor Intel GPU activity from the terminal. 
+
 
 ## Contribution
 
@@ -56,6 +62,40 @@ This guide is extensible. If you have a working hardware acceleration setup for 
     ```
 2. Start playing a video in your browser (e.g., on YouTube).
 3. Observe the `media` section in `amdgpu_top`. You should see some utilization here, indicating your GPU's media engine is active. If it remains at 0% during video playback, hardware acceleration might not be fully engaged for decoding.
+
+</Steps>
+
+</TabItem>
+
+<TabItem label='Intel GPUs (nvtop)'>
+
+<Steps>
+
+1. Open a terminal and run the command: 
+    ```bash
+    sudo nvtop 
+        ```
+2. Start playing a video in your browser (e.g., on YouTube).
+3. Observe the `ENC/DEC` percentage in `nvtop`, the percentage should increase if video decoding is working in hardware.
+
+</Steps>
+
+</TabItem>
+
+<TabItem label='Intel GPUs (intel_gpu_tools)'>
+
+<Steps>
+
+1. Open a terminal and run the command: 
+
+   ```bash
+    sudo intel_gpu_top 
+        ```
+
+          Note: Some newer Intel gpu's such as Lunar Lake GPU's no longer expose the gpu performance counters with `intel_gpu_top`, use `nvtop` for these systems
+
+2. Start playing a video in your browser (e.g., on YouTube).
+3. Observe the `Video` and `VideoEnhance` percentage in intel_gpu_top, the percentage should increase if video decoding is working in hardware.
 
 </Steps>
 


### PR DESCRIPTION
- Added information for Intel GPU's
- Clarified which requirements are optional and when to install them
- Added info for Lunar lake intel GPU (tested on 258v laptop)
- Added info for pre Lunar Lake GPU (tested on 155H)