### PR TITLE
Update chromium hw accel page to include Nvidia GPU and Vivaldi browser

### DIFF
--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -155,7 +155,7 @@ This guide is extensible. If you have a working hardware acceleration setup for 
 ```bash
 # Keep all other lines the same
 # You should only change this Exec= entry under the '[Desktop Entry]' section
-Exec=/usr/bin/vivaldi-stable --enable-accelerated-video-decode --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiIgnoreDriverChecks,VaapiOnNvidiaGPUs %U
+Exec=/usr/bin/vivaldi-stable --enable-accelerated-video-decode --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL %U
 ```
 
 **Notes:** Alternatively you can do the following for KDE:
@@ -164,7 +164,7 @@ Exec=/usr/bin/vivaldi-stable --enable-accelerated-video-decode --enable-features
 3. Right-click the entry in the Application Launcher and select `Edit Application...`
 4. In the `Command-line arguments` section, add in the following arguments before the last argumen `%U`:
 ```
---enable-accelerated-video-decode --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiIgnoreDriverChecks,VaapiOnNvidiaGPUs
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL
 ```
 5. Launch Vivaldi and pin the process to your Task Manager / taskbar
 

--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -144,6 +144,30 @@ This guide is extensible. If you have a working hardware acceleration setup for 
 
 **Notes:** Leverages Vulkan (via ANGLE) and VA-API. `--ozone-platform-hint=x11` can be useful even on Wayland for certain acceleration paths.
 
+### Nvidia RTX 4090- (Vivaldi)
+
+* ** Browser:** Vivaldi
+
+* **GPU:** Nvidia RTX 4090
+
+* **Flags File:** `/usr/share/applications/vivaldi-stable.desktop`
+
+```bash
+# Keep all other lines the same
+# You should only change this Exec= entry under the '[Desktop Entry]' section
+Exec=/usr/bin/vivaldi-stable --enable-accelerated-video-decode --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiIgnoreDriverChecks,VaapiOnNvidiaGPUs %U
+```
+
+**Notes:** Alternatively you can do the following for KDE:
+1. Delete any Task Manager / taskbar shortcuts for Vivaldi
+2. Search for `Vivaldi` in the Application Launcher list
+3. Right-click the entry in the Application Launcher and select `Edit Application...`
+4. In the `Command-line arguments` section, add in the following arguments before the last argumen `%U`:
+```
+--enable-accelerated-video-decode --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiIgnoreDriverChecks,VaapiOnNvidiaGPUs
+```
+5. Launch Vivaldi and pin the process to your Task Manager / taskbar
+
 ---
 
 ### Template to contribute

--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -144,25 +144,35 @@ This guide is extensible. If you have a working hardware acceleration setup for 
 
 **Notes:** Leverages Vulkan (via ANGLE) and VA-API. `--ozone-platform-hint=x11` can be useful even on Wayland for certain acceleration paths.
 
-### Nvidia RTX 4090- (Vivaldi)
+### Nvidia RTX 4090 (Vivaldi)
 
-* ** Browser:** Vivaldi
+* **Browser:** Vivaldi
 
 * **GPU:** Nvidia RTX 4090
+
+* **Flags File:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL
+```
 
 * **Flags File:** `/usr/share/applications/vivaldi-stable.desktop`
 
 ```bash
 # Keep all other lines the same
 # You should only change this Exec= entry under the '[Desktop Entry]' section
-Exec=/usr/bin/vivaldi-stable --enable-accelerated-video-decode --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL %U
+Exec=/usr/bin/vivaldi-stable --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL %U
 ```
 
-**Notes:** Alternatively you can do the following for KDE:
+**Notes:**
+
+You should only need to aply one of these conf file changes, but doing so on both should not cause issues.
+
+Alternatively you can do the following for KDE:
 1. Delete any Task Manager / taskbar shortcuts for Vivaldi
 2. Search for `Vivaldi` in the Application Launcher list
 3. Right-click the entry in the Application Launcher and select `Edit Application...`
-4. In the `Command-line arguments` section, add in the following arguments before the last argumen `%U`:
+4. In the `Command-line arguments` section, add in the following arguments before the last argument `%U`:
 ```
 --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL
 ```


### PR DESCRIPTION
Added config / steps for Nvidia GPU's and Vivaldi browser.

I can validate that hardware acceleration works using the method I provided in this wiki section.

`vivaldi://gpu` shows the following:
```bash
Graphics Feature Status
=======================
*   Canvas: Hardware accelerated
*   Direct Rendering Display Compositor: Disabled
*   Compositing: Hardware accelerated
*   Multiple Raster Threads: Enabled
*   OpenGL: Enabled
*   Rasterization: Hardware accelerated
*   Raw Draw: Disabled
*   Skia Graphite: Disabled
*   TreesInViz: Disabled
*   Video Decode: Hardware accelerated
*   Video Encode: Software only. Hardware acceleration disabled
*   Vulkan: Disabled
*   WebGL: Hardware accelerated
*   WebGL2: Hardware accelerated
*   WebGPU: Disabled
*   WebNN: Disabled
...
Video Acceleration Information
==============================
Decoding                      : 
Decode h264 baseline          : 48x16 to 4096x4096 pixels
Decode h264 main              : 48x16 to 4096x4096 pixels
Decode h264 high              : 48x16 to 4096x4096 pixels
Decode vp8                    : 48x16 to 4096x4096 pixels
Decode vp9 profile0           : 128x128 to 8192x8192 pixels
Decode vp9 profile2           : 128x128 to 8192x8192 pixels
Decode hevc main              : 144x144 to 8192x8192 pixels
Decode hevc main 10           : 144x144 to 8192x8192 pixels
Decode hevc main still-picture: 144x144 to 8192x8192 pixels
Decode av1 profile main       : 128x128 to 8192x8192 pixels
Encoding                      :
```

Looking at the `Media tab of the Developer Tools page for a tab that has a video playing shows the following information:
```bash
Decoder name: VaapiVideoDecoder
Hardware decoder: true
```