### PR TITLE
Added doc about cachyos-samba-settings

### DIFF
--- a/src/content/docs/configuration/post_install_setup.mdx
+++ b/src/content/docs/configuration/post_install_setup.mdx
@@ -467,3 +467,31 @@ To manage AppImages, you can use [AppImageLauncher](https://github.com/TheAssass
         </Steps>
     </TabItem>
 </Tabs>
+
+## Configuring Access to Samba Shares
+
+Samba is a free software re-implementation of the SMB networking protocol. To connect to your samba server, a useful config has been made available to CachyOS users, but it requires changing the configuration of your samba server.
+
+<Tabs>
+  <TabItem label='Installing and using the CachyOS smb.conf file'>
+    To use the convenient smb.conf file, you first need to install a specific package, which will create the smb file you need, then replace your server's smb.conf with it, and add your shared volumes again.
+    :::note[This assumes you already have an up and running Samba server]
+    :::
+
+    <Steps>
+      1. Make a backup of your original smb.conf file. On Linux, this should be in ```/etc/samba/smb.conf```
+      2. Install the CachyOS samba settings package on your client machine
+          ```sh 
+          sudo pacman -S cachyos-samba-settings
+          ```
+      2. Copy the smb.conf from your client machine to the samba server
+      3. Open and edit it to add the shared directories/printers/etc.
+      4. Restart the samba service on your server
+          ```sh 
+          sudo systemctl restart --now samba
+          ```
+      5. On the client machine, navigate via your file manager to your shared repositories (ex: smb://&lt;your_server_ip&gt;/&lt;share_name&gt;).
+      If everything works, you'll be asked for your login informations. Don't forget to check the checkmark to save your login informations.
+    </Steps>
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
Added a bit of doc in post_install_setup.mdx about using the cachyos-samba-settings package that allows for an easy setup of samba shares.

Please review for pertinence, and correct location for this doc.