### PR TITLE
Document TPM PCR Measured Boot support in boot manager comparison

### DIFF
--- a/src/content/docs/installation/boot_managers.mdx
+++ b/src/content/docs/installation/boot_managers.mdx
@@ -109,6 +109,13 @@ If you encounter such issues, consider using `systemd-boot` or `Limine`.
       <td>Works reliably</td>
     </tr>
     <tr>
+      <td><strong>TPM PCR Measured Boot</strong></td>
+      <td>Yes, <a href="https://systemd.io/TPM2_PCR_MEASUREMENTS/" target="_blank">built-in</a></td>
+      <td>Possible using systemd-ukify</td>
+      <td>Yes, <a href="https://www.gnu.org/software/grub/manual/grub/html_node/Measured-Boot.html" target="_blank">built-in</a></td>
+      <td><a href="https://github.com/fwupd/fwupd/discussions/9568" target="_blank">Possible using systemd-ukify</a></td>
+    </tr>
+    <tr>
       <td><strong>Best use case</strong></td>
       <td>Fast/simple UEFI setups; fallback for MSI quirks</td>
       <td>Multi-boot with polished UI</td>
@@ -129,6 +136,7 @@ Part of the systemd family, systemd-boot was created to be as simple as possible
 - Boot entries are separated into multiple files, making them easy to manage.
 - Ensures compatibility with some MSI boards that face UEFI issues when using other boot managers.
 - On CachyOS, configuration is auto-generated out of the box.
+- TPM PCRs are measured during boot.
 
 #### Cons
 - No support for BIOS/MBR.
@@ -156,7 +164,9 @@ A fork of rEFIt, rEFInd was primarily made to make it easier for MacOS users to 
 - No support for BIOS systems.
 - Incompatible with some MSI boards (due to UEFI spec violations).
   - Fixable with a workaround, but requires extra steps.
-
+- TPM PCRs are not measured. <a href="https://github.com/fwupd/fwupd/wiki/TPM-PCR0-differs-from-reconstruction">Will fail TPM PCR0 Reconstruction test</a>.
+  - Fixable by booting UKI that uses systemd-stub as UEFI stub. The systemd-ukify can make this.
+  - Another workaround is to chainload another bootloader that measured TPM PCR (e.g. systemd-boot, GRUB).
 ---
 
 ### GRUB
@@ -170,6 +180,7 @@ GRUB is the oldest of the available boot managers. It has a very large feature s
 - Supports Btrfs snapshot booting (via `grub-btrfs-support` on CachyOS).
 - Supports BIOS and UEFI systems.
 - Theme support available, despite the somewhat dated UI.
+- TPM PCRs are measured during boot.
 
 #### Cons
 - Large and complex, with many filesystem drivers.
@@ -192,6 +203,9 @@ Limine is a modern, advanced, and portable multiprotocol bootloader. It serves a
 - `/boot` must use FAT12/16/32 or ISO9660. Other filesystems require additional setup.
 - Does not automatically add an entry to UEFI NVRAM. This must be done manually with `efibootmgr`, or handled automatically with `limine-entry-tool` (preinstalled on CachyOS).
 - Does not work with UFS (Universal Flash Storage), used e.g. in some Chromebooks.
+- TPM PCRs are not measured. <a href="https://github.com/fwupd/fwupd/wiki/TPM-PCR0-differs-from-reconstruction">Will fail TPM PCR0 Reconstruction test</a>.
+  - Fixable by booting UKI that uses systemd-stub as UEFI stub. The systemd-ukify can make this (<a href="https://github.com/fwupd/fwupd/discussions/9568" target="_blank">see here</a>).
+  - Another workaround is to chainload another bootloader that measured TPM PCR (e.g. systemd-boot, GRUB).
 
 ---
 


### PR DESCRIPTION
Added details about TPM PCR Measured Boot support for various boot managers, including systemd-boot and GRUB, and provided workarounds for those that do not support it.