### PR TITLE
Update installation_on_root.mdx

### DIFF
--- a/src/content/docs/installation/installation_on_root.mdx
+++ b/src/content/docs/installation/installation_on_root.mdx
@@ -350,7 +350,7 @@ One way to avoid this issue is to install each operating system on separate driv
         3. Copy the EFI binaries from the **Windows EFI partition** to the **Linux EFI partition**:
 
             ```sh
-            sudo cp -r /mnt/WinBoot/EFI/* /boot/EFI
+            sudo cp -r /mnt/WinBoot/EFI/Microsoft/ /boot/EFI
             ```
 
         4. Unmount the previously mounted partition, and Windows should appear in the boot menu on the next startup.


### PR DESCRIPTION
fix the path for Microsoft EFI to be copied to be only the Microsoft folder.  My Windows install had a Boot folder next to the Microsoft folder on the Windows boot partition, and performing the command as specificed in the documentation overwrote my  /boot/EFI/BOOT folder, which broke booting to my CachyOS install.  Only copying the Microsoft folder and subfolders allows selecting Windows as a boot option as expected.