### PR TITLE
Update installation/filesystem.md regarding bcachefs

### DIFF
--- a/src/content/docs/installation/filesystem.md
+++ b/src/content/docs/installation/filesystem.md
@@ -173,6 +173,11 @@ Bcachefs is still considered as experimental and may have issues.
 - Experimental
 - Setup can be complicated
 
+### Required tools
+
+`bcachefs-dkms` provides out-of-tree kernel module support.
+`bcachefs-tools` for the userspace utilities.
+
 ## TL:DR
 
 Use the default filesystem **BTRFS** as it is considered stable and has a lot of neat features (snapshots, compression, etc). Use **XFS** or **EXT4** for a simple


### PR DESCRIPTION
Mentioned bcachefs-tools and bcachefs-dkms given removal from kernel in 6.18. Not much to it