### PR TITLE
Fix outdated sysctl config link

### DIFF
--- a/src/content/docs/features/cachyos_settings.mdx
+++ b/src/content/docs/features/cachyos_settings.mdx
@@ -10,7 +10,7 @@ helper scripts for QoL improvements. All these configurations and scripts are un
 ## sysctl Tweaks
 
 We provide a lot of sysctl tweaks that aim to improve overall desktop performance. Each sysctl entry is well documented
-in the file [99-cachyos-settings.conf](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/sysctl.d/99-cachyos-settings.conf).
+in the file [70-cachyos-settings.conf](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/sysctl.d/70-cachyos-settings.conf).
 
 To make changes to any of these values, copy the original entry and make a new file under `/etc/sysctl.d/` with the modified value.
 


### PR DESCRIPTION
The file was renamed in https://github.com/CachyOS/CachyOS-Settings/commit/002d4bbdc12c1ed84f52d66a47875d3e63460b18