### PR TITLE
Only upgrade updated packages during optimized repo migration

### DIFF
--- a/src/content/docs/features/optimized_repos.mdx
+++ b/src/content/docs/features/optimized_repos.mdx
@@ -237,7 +237,7 @@ is most optimized for it. It also backs up your old `pacman.conf` for repository
     ```sh
     sudo pacman -Scc # Enter Y in both instances
     sudo pacman -Sy
-    pacman -Qqn | sudo pacman -S - # To replace all the v4 packages with the znver4 packages
+    pacman -Qqn | sudo pacman -S --needed - # To replace all the v4 packages with the znver4 packages
     # Reboot your system
     ```
    :::


### PR DESCRIPTION
The current `pacman -Qqn | sudo pacman -S` command proposed for optimized repository migration re-installs all installed packages, no matter whether they have an optimized variant in one of the CachyOS repos or not (e.g., `core/hwdata`):

> warning: hwdata-0.401-1 is up to date -- reinstalling

Adding the `--needed` flag ignores same-version updates and only re-installs those that have a different version available:

> warning: hwdata-0.401-1 is up to date -- **skipping**