### PR TITLE
Added instructions for dealing with package corruption when a mirror goes down

### DIFF
--- a/src/content/docs/cachyos_basic/faq.mdx
+++ b/src/content/docs/cachyos_basic/faq.mdx
@@ -739,6 +739,13 @@ sudo pacman-key --lsign-key F3B607488DB35A47
 sudo rm -R /var/lib/pacman/sync
 ```
 
+If the above is unsuccessful, your keyring is not the problem. There could be an issue with your mirrors, so you can select working mirrors then clear your cache by running the following:
+
+```sh
+sudo cachyos-rate-mirrors
+sudo pacman -Scc
+```
+
 #### error: unable to lock database
 
 This error occurs when another pacman process is already running, which locks the database to prevent corruption. If the previous process crashed or was interrupted, the lock file `db.lck` might not have been removed.


### PR DESCRIPTION
Recently, users had issues with pacman downloading an html page instead of a tarball because a mirror went down. This change addresses this possibility.