### PR TITLE
Update installation_on_root.mdx

### DIFF
--- a/src/content/docs/installation/installation_on_root.mdx
+++ b/src/content/docs/installation/installation_on_root.mdx
@@ -12,26 +12,26 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Before you begin
 
-:::note[If you only get GRUB and Limine as boot manager options after pressing Launch Installer, then the system is booted in Legacy/BIOS mode.]
+:::note[If you only get GRUB and Limine as boot manager options after pressing **Launch Installer**, then the system is booted in Legacy/BIOS mode.]
 :::
 
-:::danger[Installing multiple desktop environments is not allowed during the installation process.]
+:::note[Installing multiple desktop environments is not allowed during the installation process.]
 :::
 
 :::caution[Secure Boot and CSM must be disabled in the BIOS/UEFI settings when installing in UEFI mode.]
-To setup Secure Boot after installation, refer to the [Secure Boot](/configuration/secure_boot_setup) section.
+To set up Secure Boot after installation, refer to the [Secure Boot](/configuration/secure_boot_setup) section.
 
-`Legacy USB Support` should be set to `Auto`
+`Legacy USB Support` should be set to `Auto`.
 :::
 
 :::caution
 The `Install alongside` and `Replace partition` options are not 100% reliable and can cause the installation to fail.
 
-`Manual partitioning` is **preferred** when installing CachyOS.
+`Manual partitioning` is **strongly preferred** when installing CachyOS.
 :::
 
 :::tip
-It is highly recommended to restart the ISO after a failed installation attempt.
+It is highly recommended to reboot into the ISO after a failed installation attempt.
 
 Otherwise, continuous errors can happen during the installation process.
 
@@ -47,12 +47,12 @@ This happens because the installer doesn't properly unmount partitions on a fail
     ```sh title='Execute this command in the terminal'
     efibootmgr -v
     ```
-If the output is: `EFI variables are not supported on this system.` Then the system is booted in Legacy/BIOS mode and you need to ensure that UEFI mode is configured in the BIOS/UEFI settings. Refer to the **[Requisites section](/installation/installation_on_root#_top).**
+If the output is `EFI variables are not supported on this system.`, then the system is booted in Legacy/BIOS mode, and you need to ensure that UEFI mode is configured in the BIOS/UEFI settings. Refer to the [Requisites](/installation/installation_on_root/#before-you-begin) section.
 :::
 
 #### UEFI/GPT
 
-The partition table for each boot manager varies. Please follow the correct instructions for each.
+The partition table for each boot manager varies. Follow the instructions for the desired boot manager.
 
 <Tabs>
 
@@ -60,35 +60,35 @@ The partition table for each boot manager varies. Please follow the correct inst
 
 <Steps>
 
-1. Boot into the ISO and click the **Launch Installer** button
+1. Boot into the ISO and click on **Launch Installer**.
 
-2. Set the preferred **Language** and **Region/Timezone**
+2. Set the preferred **Language** and **Region/Timezone**.
 
-3. Configure **Keyboard Layout**
+3. Configure the **Keyboard Layout**.
 
-4. Select **Manual partitioning**
+4. Select **Manual partitioning**.
 
 5. Create a new partition with the following:
-   - ##### Size: **2048MiB**
+   - ##### Size: **2048 MiB**
    - ##### Filesystem: **FAT32**
    - ##### Mount point: **/boot**
    - ##### Flags: **boot**
 
 6. Create another partition for **root**:
-   - ##### Size: At least **20000MiB**
+   - ##### Size: At least **20000 MiB**
    - ##### Filesystem: **Any**, refer to [Filesystem](/installation/filesystem)
    - ##### Mount point: **/**
    - ##### Flags:
 
-7. Double check that **Install boot loader on:** is pointing to **/boot**
+7. Double check that **Install boot loader on:** is pointing to **/boot**.
 
-8. Select the **Desktop Environment** of choice, see [Desktop Environments](/installation/desktop_environments).
+8. Select the [Desktop Environment](/installation/desktop_environments) of choice.
 
-9. Customize which packages should or should not be installed during the installation process.
+9. Choose which packages should be installed during the installation process.
 
-10. Setup login credentials.
+10. Set up the login credentials.
 
-11. Review the installation summary on the Overview Page carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
+11. Review the installation summary carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
 
 </Steps>
 
@@ -96,41 +96,37 @@ The partition table for each boot manager varies. Please follow the correct inst
 
 <TabItem label='Limine'>
 
-:::note
-In storage space constrained environments, such as virtual machines, the /boot partition size can be reduced to 2048MiB.
-:::
-
 <Steps>
 
-1. Boot into the ISO and click the **Launch Installer** button
+1. Boot into the ISO and click on **Launch Installer**.
 
-2. Set the preferred **Language** and **Region/Timezone**
+2. Set the preferred **Language** and **Region/Timezone**.
 
-3. Configure **Keyboard Layout**
+3. Configure the **Keyboard Layout**.
 
-4. Select **Manual partitioning**
+4. Select **Manual partitioning**.
 
 5. Create a new partition with the following:
-   - ##### Size: **2048MiB**
+   - ##### Size: **2048 MiB**
    - ##### Filesystem: **FAT32**
    - ##### Mount point: **/boot**
    - ##### Flags: **boot**
 
 6. Create another partition for **root**:
-   - ##### Size: At least **20000MiB**
+   - ##### Size: At least **20000 MiB**
    - ##### Filesystem: **Any**, refer to [Filesystem](/installation/filesystem)
    - ##### Mount point: **/**
    - ##### Flags:
 
-7. Double check that **Install boot loader on:** is pointing to **/boot**
+7. Double check that **Install boot loader on:** is pointing to **/boot**.
 
-8. Select the **Desktop Environment** of choice, see [Desktop Environments](/installation/desktop_environments).
+8. Select the [Desktop Environment](/installation/desktop_environments) of choice.
 
-9. Customize which packages should or should not be installed during the installation process.
+9. Choose which packages should be installed during the installation process.
 
-10. Setup login credentials.
+10. Set up the login credentials.
 
-11. Review the installation summary on the Overview Page carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
+11. Review the installation summary carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
 
 </Steps>
 
@@ -140,35 +136,35 @@ In storage space constrained environments, such as virtual machines, the /boot p
 
 <Steps>
 
-1. Boot into the ISO and click the **Launch Installer** button
+1. Boot into the ISO and click on **Launch Installer**.
 
-2. Set the preferred **Language** and **Region/Timezone**
+2. Set the preferred **Language** and **Region/Timezone**.
 
-3. Configure **Keyboard Layout**
+3. Configure the **Keyboard Layout**.
 
-4. Select **Manual partitioning**
+4. Select **Manual partitioning**.
 
 5. Create a new partition with the following:
-    - ##### Size: At least **100MiB**
+    - ##### Size: At least **100 MiB**
     - ##### Filesystem: **FAT32**
     - ##### Mount point: **/boot/efi**
     - ##### Flags: **boot**
 
 6. Create another partition for **root**:
-    - ##### Size: At least **20000MiB**
+    - ##### Size: At least **20000 MiB**
     - ##### Filesystem: **Any**, refer to [Filesystem](/installation/filesystem)
     - ##### Mount point: **/**
     - ##### Flags:
 
-7. Double check that **Install boot loader on:** is pointing to **/boot/efi**
+7. Double check that **Install boot loader on:** is pointing to **/boot/efi**.
 
-8. Select the **Desktop Environment** of choice, see [Desktop Environments](/installation/desktop_environments).
+8. Select the [Desktop Environment](/installation/desktop_environments) of choice.
 
-9. Customize which packages should or should not be installed during the installation process.
+9. Choose which packages should be installed during the installation process.
 
-10. Setup login credentials.
+10. Set up the login credentials.
 
-11. Review the installation summary on the Overview Page carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
+11. Review the installation summary carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
 
 </Steps>
 
@@ -184,29 +180,29 @@ In storage space constrained environments, such as virtual machines, the /boot p
 
 <Steps>
 
-1. Boot into the ISO and click the **Launch Installer** button
+1. Boot into the ISO and click on **Launch Installer**.
 
-2. Set your preferred **Language** and **Region/Timezone**
+2. Set the preferred **Language** and **Region/Timezone**.
 
-3. Configure your **Keyboard Layout**
+3. Configure the **Keyboard Layout**.
 
-4. Select **Manual partitioning**
+4. Select **Manual partitioning**.
 
 5. Create a new partition with the following:
-    - ##### Size: At least **20000MiB**
-    - ##### Filesystem: **Any**, refer [Filesystem](/installation/filesystem)
+    - ##### Size: At least **20000 MiB**
+    - ##### Filesystem: **Any**, refer to [Filesystem](/installation/filesystem)
     - ##### Mount point: **/**
     - ##### Flags:
 
-6. Double check that **Install boot loader on:** is pointing to your boot drive e.g: **/dev/sda**
+6. Double check that **Install boot loader on:** is pointing to your boot drive, e.g., **/dev/sda**.
 
-7. Pick the **Desktop Environment** you'd like to use, see [Desktop Environments](/installation/desktop_environments).
+7. Select the [Desktop Environment](/installation/desktop_environments) of choice.
 
-8. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
+8. Choose which packages should be installed during the installation process.
 
-9. Setup your login credentials.
+9. Set up the login credentials.
 
-10. Review the installation summary on the Overview Page carefully. If all the settings look correct for you, proceed with the installation by clicking on **Install Now**. Otherwise, go back and make any necessary changes.
+10. Review the installation summary carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
 
 </Steps>
 
@@ -214,41 +210,37 @@ In storage space constrained environments, such as virtual machines, the /boot p
 
 <TabItem label='Limine'>
 
-:::note
-In storage space constrained environments, such as virtual machines, the /boot partition size can be reduced to 2048MiB.
-:::
-
 <Steps>
 
-1. Boot into the ISO and click the **Launch Installer** button
+1. Boot into the ISO and click on **Launch Installer**.
 
-2. Set your preferred **Language** and **Region/Timezone**
+2. Set the preferred **Language** and **Region/Timezone**.
 
-3. Configure your **Keyboard Layout**
+3. Configure the **Keyboard Layout**.
 
 4. Select **Manual partitioning**
 
 5. Create a new partition with the following:
-    - ##### Size: At least **2048MiB**
+    - ##### Size: At least **2048 MiB**
     - ##### Filesystem: **FAT32**
     - ##### Mount point: **/boot**
     - ##### Flags: **boot**
 
 6. Create another partition for **root**:
-    - ##### Size: At least **20000MiB**
-    - ##### Filesystem: **Any**, refer [Filesystem](/installation/filesystem)
+    - ##### Size: At least **20000 MiB**
+    - ##### Filesystem: **Any**, refer to [Filesystem](/installation/filesystem)
     - ##### Mount point: **/**
     - ##### Flags:
 
-7. Double check that **Install boot loader on:** is pointing to your boot drive e.g: **/dev/sda**
+7. Double check that **Install boot loader on:** is pointing to your boot drive, e.g., **/dev/sda**.
 
-8. Pick the **Desktop Environment** you'd like to use, see [Desktop Environments](/installation/desktop_environments).
+8. Select the [Desktop Environment](/installation/desktop_environments) of choice.
 
-9. Select the specific packages you wish to install from the provided list, and deselect any that you do not require.
+9. Choose which packages should be installed during the installation process.
 
-10. Setup your login credentials.
+10. Set up the login credentials.
 
-11. Review the installation summary on the Overview Page carefully. If all the settings look correct for you, proceed with the installation by clicking on **Install Now**. Otherwise, go back and make any necessary changes.
+11. Review the installation summary carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
 
 </Steps>
 
@@ -258,67 +250,69 @@ In storage space constrained environments, such as virtual machines, the /boot p
 
 ### Erase Disk
 
-The "Erase Disk" Option in Calamares will wipe the selected disk and install CachyOS to the target.
+The **Erase Disk** option in Calamares will wipe the selected disk and install CachyOS to the target.
 
 <Steps>
 
-1. Boot into the ISO and click on **Launch Installer**
+1. Boot into the ISO and click on **Launch Installer**.
 
-2. Select the preferred **Boot Manager**. Check the [Boot Managers](/installation/boot_managers) section for more information.
+2. Select the preferred [Boot Manager](/installation/boot_managers).
 
-3. Set the preferred **Language** and **Region/Timezone**
+3. Set the preferred **Language** and **Region/Timezone**.
 
-4. Configure **Keyboard Layout**
+4. Configure the **Keyboard Layout**.
 
 5. Select **Erase Disk** and choose a [Filesystem](/installation/filesystem).
 
-6. Select the **Desktop Environment** of choice, see [Desktop Environments](/installation/desktop_environments).
+6. Select the [Desktop Environment](/installation/desktop_environments) of choice.
 
-7. Customize which packages should or should not be installed during the installation process.
+7. Choose which packages should be installed during the installation process.
 
-8. Setup login credentials.
+8. Set up the login credentials.
 
-9. Review the installation summary on the Overview Page carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
+9. Review the installation summary carefully. Proceed with the installation by clicking on **Install Now** if everything looks correct. Otherwise, go back and make any necessary changes.
 
 </Steps>
 
 ## Dual Booting Windows and CachyOS
 
-:::note[This guide assumes that Windows is already installed on the system and you decided to install CachyOS alongside it sharing the same drive.]
+:::note[This guide assumes that Windows is already installed on the system and you decided to install CachyOS alongside it, sharing the same drive.]
 :::
 
 :::caution
 Dual booting Windows and Linux is not 100% reliable. Windows updates can break the bootloader by overwriting the EFI partition.
-In some cases issues might never occur, but for some users it can be a recurring problem.
+In some cases, issues might never occur, but for some users it can be a recurring problem.
 
-One way to avoid this issue is to install each operating system on separate drives.
+One way to avoid this issue is to install each operating system on a separate drive.
 :::
 
 :::caution
-The EFI partition may need to be resized, depending on the recommended minimum size on the target boot manager. Refer to **[Manual Partitioning](/installation/installation_on_root#manual-partitioning)**. Note that FAT filesystems cannot be resized in-placed. To properly "resize" the FAT EFI partition, one must back up the existing EFI filesystem, use a tool such as `gparted` to resize the existing partition and reformat the new partition, then copy the previous filesystem structure back into the EFI partition.
+The EFI partition may need to be resized, depending on the recommended minimum size on the target boot manager. Refer to [Manual Partitioning](/installation/installation_on_root#manual-partitioning).
+
+FAT filesystems cannot be resized in-place. To properly "resize" the FAT EFI partition, one must back up the existing EFI filesystem, use a tool such as `gparted` to resize the existing partition and reformat the new partition, then copy the previous filesystem structure back into the EFI partition.
 :::
 
-- Prerequisites
+### Prerequisites
 
-- Disable Windows Fast Startup and Hibernation
-  - Open Windows Powershell as Administrator and execute the following command:
+- Windows Fast Startup and Hibernation must be disabled.
+  - Open Windows Powershell as administrator and execute the following command:
       ```ps
       powercfg /H off
       ```
-    Reboot the system to make sure the changes take effect.
-- Windows BitLocker must be disabled
+    Reboot the system to ensure the changes take effect.
+- Windows BitLocker must be disabled.
   - Checking if BitLocker is enabled:
     ```ps title='Open a Command Prompt as administrator and execute the following command'
     manage-bde -status
     ```
-  If Encryption Method shows as `None`, then BitLocker is disabled.
+  If **Encryption Method** shows as `None`, then BitLocker is disabled.
 - Secure Boot must be disabled.
-- A +30GB empty partition
+- A ≥30 GB empty partition.
   - Guide on how to shrink a Windows partition:
     - Press `Win + R`, type `diskmgmt.msc`, and press Enter to open Disk Management.
-    - Identify your main Windows partition (usually C:) and right-click on it.
-    - Click on `Shrink Volume...` and specify at least **30720MB** (30GB) and click on `Shrink`.
-- Booteable USB with CachyOS
+    - Identify your main Windows partition (usually C:) and right-click it.
+    - Click on `Shrink Volume...`, specify at least **30720 MB** (30 GiB), and click on `Shrink`.
+- A bootable USB with CachyOS.
   - Refer to the [Creating a Bootable CachyOS USB Drive](/installation/installation_prepare#creating-a-bootable-cachyos-usb-drive) section.
 
 <Tabs>
@@ -326,7 +320,7 @@ The EFI partition may need to be resized, depending on the recommended minimum s
         **We need to copy the Windows EFI binaries to the Linux EFI partition so that the boot manager can recognize them.**
 
         <Steps>
-        1. Locate the **Windows EFI partition** with `lsblk`
+        1. Locate the **Windows EFI partition** with `lsblk`.
 
             ```sh title='Execute this command in the terminal'
             lsblk -o NAME,FSTYPE,SIZE,MOUNTPOINT
@@ -344,20 +338,20 @@ The EFI partition may need to be resized, depending on the recommended minimum s
             ```
             EFI partitions are almost always formatted as `FAT32/vfat`. Since `nvme0n1p1` does not have a Linux mount point, we can assume that this partition is the Windows EFI partition.
 
-        2. Temporarily mount the Windows EFI partition
+        2. Temporarily mount the Windows EFI partition.
 
             ```sh
             sudo mkdir /mnt/WinBoot
             sudo mount /dev/nvme0n1p1 /mnt/WinBoot # Replace `nvme0n1p1` with the name of the Windows EFI partition.
             ```
 
-        3. Copy the EFI binaries from the **Windows EFI partition** to the **Linux EFI partition**:
+        3. Copy the EFI binaries from the **Windows EFI partition** to the **Linux EFI partition**.
 
             ```sh
             sudo cp -r /mnt/WinBoot/EFI/Microsoft/ /boot/EFI
             ```
 
-        4. Unmount the previously mounted partition, and Windows should appear in the boot menu on the next startup.
+        4. Unmount the previously-mounted partition. Windows should appear in the boot menu on the next startup.
 
             ```sh
             sudo umount /mnt/WinBoot
@@ -371,14 +365,13 @@ The EFI partition may need to be resized, depending on the recommended minimum s
         **GRUB uses os-prober to automatically detect the Windows EFI partition and add it to the boot menu.**
 
         <Steps>
-        1. Install and execute **os-prober**
+        1. Install **os-prober**.
 
             ```sh
             sudo pacman -S os-prober
-            sudo os-prober
             ```
 
-        2. Enable **os-prober** in the GRUB configuration file
+        2. Enable **os-prober** in the GRUB configuration file.
 
             ```sh title='Press CTRL+S to save and CTRL+Q to exit from Micro'
             sudo micro /etc/default/grub
@@ -389,6 +382,10 @@ The EFI partition may need to be resized, depending on the recommended minimum s
             # operating systems.
             GRUB_DISABLE_OS_PROBER=false
 
+            ```
+
+        3. Update grub.cfg, now using **os-prober**.
+            ```sh
             sudo grub-mkconfig -o /boot/grub/grub.cfg
             ```
 


### PR DESCRIPTION
Many changes: fixing language syntax and grammar, making text more terse, removing unnecessary text, reusing text where appropriate, fixing errors, other small changes.

Note: I did all this only editing plaintext, check syntax
Note: MBR/BIOS > GRUB doesn't have a boot partition step listed
Note: UEFI/GPT and MBR/BIOS can probably be consolidated
Note: "Double check that Install boot loader on: is pointing to /boot/efi" ~ where in the installation does it say "Install boot loader on:"? I can't find it.
Note: it sometimes uses 1000's of MiB and 1024's of MiB, should probably be consistent
Note: Removed the "In storage space constrained environments, ..." notes because the sizes were identical to the recommended sizes
Note: changed the "Installing multiple desktop environments ..." note from "danger" to "note" because there's no way to override this using calamares.