### PR TITLE
fix: permalink to kernel config

### DIFF
--- a/src/content/docs/cs/features/kernel.md
+++ b/src/content/docs/cs/features/kernel.md
@@ -100,7 +100,7 @@ Kernel CachyOS má také některé další pozoruhodné vlastnosti, které jsou 
 
 - Zahrnuje debug variantu kernelu, která poskytuje ne-stripnutý binární soubor kernelu pro účely ladění. Tento balíček je potřebný pro profilování kernelu pomocí AutoFDO.
 - [Binder](https://developer.android.com/reference/android/os/Binder), modul potřebný pro [Waydroid](https://waydro.id/), je ve výchozím nastavení povolen v konfiguraci kernelu
-a již [nastaven](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10559).
+a již [nastaven](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Konvence pojmenování balíčků
 

--- a/src/content/docs/de/features/kernel.mdx
+++ b/src/content/docs/de/features/kernel.mdx
@@ -61,7 +61,7 @@ Der CachyOS-Kernel hat auch einige andere bemerkenswerte Features, die zwar subt
 
 - Enthält eine Debug-Variante des Kernels, die eine unstripped Kernel-Binärdatei für Debugging-Zwecke bereitstellt. Dieses Paket wird benötigt, um den Kernel mit AutoFDO zu profilen.
 - [Binder](https://developer.android.com/reference/android/os/Binder), das für [Waydroid](https://waydro.id/) benötigte Modul, ist standardmäßig in der Kernel-Konfiguration aktiviert
-und bereits [eingerichtet](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10784).
+und bereits [eingerichtet](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Varianten
 

--- a/src/content/docs/es/features/kernel.mdx
+++ b/src/content/docs/es/features/kernel.mdx
@@ -61,7 +61,7 @@ El kernel de CachyOS también tiene otras características notables que, aunque 
 
 - Incluye una variante de depuración del kernel que proporciona un binario del kernel sin depurar (unstripped) para fines de depuración. Este paquete es necesario para perfilar el kernel con AutoFDO.
 - [Binder](https://developer.android.com/reference/android/os/Binder), el módulo necesario para [Waydroid](https://waydro.id/), está activado por defecto en la configuración del kernel
-y ya está [configurado](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10784).
+y ya está [configurado](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Variantes
 

--- a/src/content/docs/features/kernel.mdx
+++ b/src/content/docs/features/kernel.mdx
@@ -61,7 +61,7 @@ The CachyOS kernel also has some other notable features that are subtle yet impr
 
 - Includes a debug variant of the kernel that provides an unstripped kernel binary for debugging purposes. This package is needed to profile the kernel with AutoFDO.
 - [Binder](https://developer.android.com/reference/android/os/Binder), the module needed for [Waydroid](https://waydro.id/) is enabled by default in the kernel config
-and already [set up](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10784).
+and already [set up](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Variants
 

--- a/src/content/docs/fr/features/kernel.mdx
+++ b/src/content/docs/fr/features/kernel.mdx
@@ -61,7 +61,7 @@ Le noyau CachyOS possède également d'autres fonctionnalités notables qui sont
 
 - Inclut une variante de débogage du noyau qui fournit un binaire de noyau non "strippé" à des fins de débogage. Ce paquet est nécessaire pour profiler le noyau avec AutoFDO.
 - [Binder](https://developer.android.com/reference/android/os/Binder), le module nécessaire pour [Waydroid](https://waydro.id/) est activé par défaut dans la configuration du noyau
-et déjà [configuré](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10784).
+et déjà [configuré](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Variantes
 

--- a/src/content/docs/pl/features/kernel.mdx
+++ b/src/content/docs/pl/features/kernel.mdx
@@ -61,7 +61,7 @@ Jądro CachyOS posiada również inne godne uwagi funkcje, które są subtelne, 
 
 - Zawiera wariant debug jądra, który dostarcza niepozbawiony symboli plik binarny jądra do celów debugowania. Ten pakiet jest potrzebny do profilowania jądra za pomocą AutoFDO.
 - [Binder](https://developer.android.com/reference/android/os/Binder), moduł potrzebny do [Waydroid](https://waydro.id/), jest domyślnie włączony w konfiguracji jądra
-i już [skonfigurowany](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10784).
+i już [skonfigurowany](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Warianty
 

--- a/src/content/docs/ru/features/kernel.mdx
+++ b/src/content/docs/ru/features/kernel.mdx
@@ -60,7 +60,7 @@ tableOfContents:
 Ядро CachyOS также имеет некоторые другие примечательные особенности, которые незаметны, но улучшают пользовательский опыт:
 
 - Включает отладочный вариант ядра, который предоставляет бинарный файл ядра без удаления отладочной информации. Этот пакет необходим для профилирования ядра с помощью AutoFDO.
-- [Binder](https://developer.android.com/reference/android/os/Binder), модуль, необходимый для [Waydroid](https://waydro.id/), включен по умолчанию в конфигурации ядра и уже [настроен](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10784).
+- [Binder](https://developer.android.com/reference/android/os/Binder), модуль, необходимый для [Waydroid](https://waydro.id/), включен по умолчанию в конфигурации ядра и уже [настроен](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Варианты
 

--- a/src/content/docs/sk/features/kernel.md
+++ b/src/content/docs/sk/features/kernel.md
@@ -93,7 +93,7 @@ Jadro CachyOS má aj niektoré ďalšie pozoruhodné funkcie, ktoré sú nenápa
 
 - Obsahuje debug variantu jadra, ktorá poskytuje neodstránený binárny súbor jadra na účely ladenia. Tento balík je potrebný na profilovanie jadra pomocou AutoFDO.
 - [Binder](https://developer.android.com/reference/android/os/Binder), modul potrebný pre [Waydroid](https://waydro.id/), je predvolene povolený v konfigurácii jadra
-a už [nastavený](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10559).
+a už [nastavený](https://github.com/CachyOS/linux-cachyos/blob/2f380e2b35c4ad9acda98296f638f93af3742533/linux-cachyos/config#L11037).
 
 ## Konvencia Pomenovania Balíkov
 


### PR DESCRIPTION
the link in:
> [Binder](https://developer.android.com/reference/android/os/Binder), the module needed for [Waydroid](https://waydro.id/) is enabled by default in the kernel config and already __[set up](https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config#L10784)__

leads to an unrelated line of config, because it's referencing the master branch (where its location constantly changes) rather than a specific commit

this is fixed here by using a permalink to a specific commit (latest on master as of PRing) instead