### PR TITLE
Fix typo in gaming.mdx

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -343,7 +343,7 @@ If you want to use desktop application, we suggest using `wine` or `wine-staging
 
     If you want to use `winetricks` with `wine-cachyos-opt`, you can invoke it like this:
     ```shell
-    WINE=/opt/wine-cachyos/bin/wine WINEPRFIX=<your prefix> winetricks <verb>
+    WINE=/opt/wine-cachyos/bin/wine WINEPREFIX=<your prefix> winetricks <verb>
     ```
     </TabItem>
     <TabItem label='Lutris'>


### PR DESCRIPTION
Fixes a typo in the example for running winetricks with wine-cachyos-opt.