### PR TITLE
Add warning against using Pamac and Bauh

### DIFF
--- a/src/content/docs/configuration/post_install_setup.mdx
+++ b/src/content/docs/configuration/post_install_setup.mdx
@@ -10,6 +10,12 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 ## Updating The System
 
+:::caution
+Don't use any GUI package manager except Octopi. Notably, Pamac (for Manjaro) and Bauh (effectively abandoned) are known to break CachyOS.
+
+Using `pacman` is preferred.
+:::
+
 <Tabs>
 
 <TabItem label="Using Octopi (GUI)">

--- a/src/content/docs/configuration/post_install_setup.mdx
+++ b/src/content/docs/configuration/post_install_setup.mdx
@@ -11,9 +11,7 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 ## Updating The System
 
 :::caution
-Don't use any GUI package manager except Octopi. Notably, Pamac (for Manjaro) and Bauh (effectively abandoned) are known to break CachyOS.
-
-Using `pacman` is preferred.
+Improperly updating can break the system. Refer to the [Security & Best Practices](/cachyos_basic/faq/#security--best-practices) section.
 :::
 
 <Tabs>


### PR DESCRIPTION
Add warning to avoid Pamac and Bauh, and stick to Octopi/pacman