### PR TITLE
desktop_env/niri: update launcher keybind, mention noctalia docs

### DIFF
--- a/src/content/docs/configuration/desktop_environments/niri.mdx
+++ b/src/content/docs/configuration/desktop_environments/niri.mdx
@@ -14,6 +14,7 @@ Our main goal with our setup is to have a working Niri configuration that provid
 Take a look into our [Niri FAQ.](/configuration/desktop_environments/niri#faq)
 
 **Dotfiles maintained by [Ly-sec](https://github.com/Ly-sec)**
+For Noctalia related issues please take a look at the [Noctalia docs](https://docs.noctalia.dev/).
 
 ## Keybinds
 
@@ -24,7 +25,7 @@ Most of the key combinations require the use of the mod key which in our case is
 | Description | Key |
 |-------------|-----|
 | Open terminal | <Kbd linux="Super+Return" /> |
-| Open Wofi (Program Launcher) | <Kbd linux="Super+Space" /> |
+| Open program launcher | <Kbd linux="Super+Ctrl+Return" /> |
 | Open browser (Firefox) | <Kbd linux="Super+B" /> |
 | Open file manager | <Kbd linux="Super+E" /> |
 | Close focused window | <Kbd linux="Super+Q" /> |


### PR DESCRIPTION
As the title states, this updates the launcher keybind since it differentiates from the actual Niri config. I also added the link to the Noctalia documentation in case people are wondering about some things.