### PR TITLE
Use actual brackets instead of html codes

### DIFF
--- a/src/content/docs/configuration/post_install_setup.mdx
+++ b/src/content/docs/configuration/post_install_setup.mdx
@@ -494,7 +494,7 @@ To use the convenient smb.conf file, first install a specific package that provi
         ```sh
         sudo systemctl restart --now samba
         ```
-    6. On the client machine, access your shared resources through your file manager (e.g., `smb://&lt;your_server_ip&gt;/&lt;share_name&gt;`).
+    6. On the client machine, access your shared resources through your file manager (e.g., `smb://<your_server_ip>/<share_name>`).
 
         If configured correctly, you'll be prompted for login credentials. Remember to select the option to save your login information if desired.
 </Steps>


### PR DESCRIPTION
Seems to have gotten mixed up in the last change that moved it into inline code from normal text. Currently displays the lt and gt literally on in the docs

https://wiki.cachyos.org/configuration/post_install_setup/#installing-and-using-the-cachyos-smbconf-file