### PR TITLE
Update recommended boot partition size to 4192

### DIFF
--- a/src/content/docs/installation/installation_on_root.mdx
+++ b/src/content/docs/installation/installation_on_root.mdx
@@ -70,7 +70,7 @@ The partition table for each boot manager varies. Follow the instructions for th
 4. Select **Manual partitioning**.
 
 5. Create a new partition with the following:
-   - ##### Size: **2048 MiB**
+   - ##### Size: **4192 MiB**
    - ##### Filesystem: **FAT32**
    - ##### Mount point: **/boot**
    - ##### Flags: **boot**


### PR DESCRIPTION
When using limine, the minimum is now 4192 MiB according to a new error that appears in the installer and the [26.01 changelog](https://wiki.cachyos.org/cachyos_basic/changelogs/gui_installer/#_top)