### PR TITLE
Change default ZSTD compression level in BTRFS documentation

### DIFF
--- a/src/content/docs/installation/filesystem.md
+++ b/src/content/docs/installation/filesystem.md
@@ -37,7 +37,7 @@ BTRFS is a modern copy-on-write(COW) filesystem created in 2007 and declared sta
 
 ### Pros
 
-- Transparent compression. BTRFS supports transparently compressing files to allow for significant space savings with no user intervention. **CachyOS ships with ZSTD compression set to level 3 by default.**
+- Transparent compression. BTRFS supports transparently compressing files to allow for significant space savings with no user intervention. **CachyOS ships with ZSTD compression set to level 1 by default.**
 - Snapshot functionality. BTRFS leverages its COW nature to allow for the creation of snapshots of subvolumes that take up very little actual space.
 - Subvolume functionality allowing for greater control over the filesystem.
 - Able to grow or shrink.


### PR DESCRIPTION
Update the default ZSTD compression level from 3 to 1 as it was recently changed in https://github.com/CachyOS/cachyos-calamares/pull/151