### PR TITLE
Optimized Repositories: Updated dead link

### DIFF
--- a/src/content/docs/features/optimized_repos.mdx
+++ b/src/content/docs/features/optimized_repos.mdx
@@ -180,7 +180,7 @@ is most optimized for it. It also backs up your old `pacman.conf` for repository
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-mirrorlist-22-1-any.pkg.tar.zst' \
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v3-mirrorlist-22-1-any.pkg.tar.zst' \
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v4-mirrorlist-22-1-any.pkg.tar.zst' \
-   'https://mirror.cachyos.org/repo/x86_64/cachyos/pacman-7.1.0.r7.gb9f7d4a-3-x86_64.pkg.tar.zst'
+   'https://mirror.cachyos.org/repo/x86_64/cachyos/pacman-7.1.0.r9.g54d9411-2-x86_64.pkg.tar.zst'
    ```
 3. Add the CachyOS repositories to the pacman config file:
    :::note


### PR DESCRIPTION
The previous link returns a 404. Which stops the command from succeeding.