### PR TITLE
Using sha256sum for one step verification of iso

### DIFF
--- a/src/content/docs/cachyos_basic/download.mdx
+++ b/src/content/docs/cachyos_basic/download.mdx
@@ -47,19 +47,15 @@ Always take the extra step of verifying the ISO's integrity to avoid any undesir
 <Steps>
 
 1. Download the [file](https://mirror.cachyos.org/ISO/desktop/260124/cachyos-desktop-linux-260124.iso.sha256) containing the SHA256 hash.
-2. Open a terminal, navigate to the directory containing the `.sha256` file, and execute the following commands:
+2. Open a terminal, navigate to the directory containing both the `.sha256` and `.iso` file.
+3. Execute the following commands:
    ```sh
    # Example:
    cd ~/Downloads
-   cat cachyos-desktop-linux-260124.iso.sha256
-   # 0c070fba1eb06a740983e8e195ecb686c4fc2060920137af1cedbd5ffca5be47
+   sha256sum -c cachyos-desktop-linux-260124.iso.sha256
+   # cachyos-desktop-linux-260124.iso: OK
    ```
-3. Compare the output from **Step 2** to the ISO file's hash:
-   ```sh
-   # Example:
-   sha256sum cachyos-desktop-linux-260124.iso
-   ```
-4. If the hashes from **Step 2** and **Step 3** match, you may proceed with the CachyOS installation.
+4. If the output from **Step 3** is OK, you may proceed with the CachyOS installation.
 
 </Steps>
 


### PR DESCRIPTION
Just using sha256sum -c instead of cat the checksum file and then verify. Just do it in one step with "sha256sum -c"