### PR TITLE
Update systemctl commands to include 'sudo'

### DIFF
--- a/src/content/docs/virtualization/qemu_and_vmm_setup.mdx
+++ b/src/content/docs/virtualization/qemu_and_vmm_setup.mdx
@@ -19,9 +19,9 @@ sudo pacman -S qemu-full virt-manager swtpm
 # This will add the user to the "libvirt" group so they can use it:
 sudo usermod -aG libvirt $USER
 # LXC backend (optional, for linux containers, enabling both backends does not conflict):
-systemctl enable --now libvirtd.service
+sudo systemctl enable --now libvirtd.service
 # QEMU backend (for VMs):
-systemctl enable --now libvirtd.socket
+sudo systemctl enable --now libvirtd.socket
 # This will bring Internet up in a VM whenever one starts:
 sudo virsh net-autostart default
 ```


### PR DESCRIPTION
Add 'sudo' to systemctl commands for enabling services.

This code block is inconsistent right now with usage of sudo, these systemctl command require elevated permissions to execute and thus trigger pkexec in graphical environments.