### PR TITLE
Update QEMU setup instructions regarding guest networking

### DIFF
--- a/src/content/docs/virtualization/qemu_and_vmm_setup.mdx
+++ b/src/content/docs/virtualization/qemu_and_vmm_setup.mdx
@@ -24,6 +24,8 @@ systemctl enable --now libvirtd.service
 systemctl enable --now libvirtd.socket
 # This will bring Internet up in a VM whenever one starts:
 sudo virsh net-autostart default
+# And to enable the entire VM network to have unfettered transit: (You should consider if you need more granular firewall rules based on your use case and security posture)
+sudo ufw route allow from 192.168.122.0/24
 ```
 
 :::note[Windows 11]


### PR DESCRIPTION
Supplied an example ufw rule that enables networking to the outside world (Internet) for QEMU guests.