### PR TITLE
Remove outdated SDDM theme explanation due to sddm being switched out to plasmalogin by default

### DIFF
--- a/src/content/docs/configuration/desktop_environments/kde.mdx
+++ b/src/content/docs/configuration/desktop_environments/kde.mdx
@@ -24,9 +24,3 @@ sudo pacman -S plasma-x11-session kwin-x11
     ```
   Apply both in `Appearance & Style - Colors & Themes`
 
-### Why does SDDM look so bland and old?
-
-- *Since there is no SDDM theme being applied by default, SDDM will fallback to the classic theme.*
-  - **Apply the Breeze Theme as shown in the screenshot**
-    <br />
-    <ImageComponent imgsrc={import('~/assets/images/plasma-sddm-theme.png')} />


### PR DESCRIPTION
Removed section explaining SDDM's default appearance.