### PR TITLE
Update QEMU and VMM setup instructions

### DIFF
--- a/src/content/docs/virtualization/qemu_and_vmm_setup.mdx
+++ b/src/content/docs/virtualization/qemu_and_vmm_setup.mdx
@@ -16,6 +16,8 @@ To get **VMM** (Virtual Machine Manager) and **QEMU** installed and running on
 ```sh
 # This will install the needed packages (note the "Windows 11" note below):
 sudo pacman -S qemu-full virt-manager swtpm
+# Force libvirt to use iptables
+echo 'firewall_backend = "iptables"' | sudo tee -a /etc/libvirt/network.conf
 # This will add the user to the "libvirt" group so they can use it:
 sudo usermod -aG libvirt $USER
 # LXC backend (optional, for linux containers, enabling both backends does not conflict):


### PR DESCRIPTION
Added command to force libvirt to use iptables in network configuration.
Otherwise guest instances don't have a internet connection and doesn't get an IP address.
Tested with CachyOS Dekstop as Guest

Before Guest Session:
<img width="1146" height="763" alt="grafik" src="https://github.com/user-attachments/assets/c45407f6-b51b-4142-94cf-d43fd0eca2d1" />
After Guest Session:
<img width="1006" height="716" alt="grafik" src="https://github.com/user-attachments/assets/d9711bc5-ec62-499d-913f-0cf7fda51e44" />
