### PR TITLE
Boot Manager Documentation Change

### DIFF
--- a/src/content/docs/installation/installation_handheld.mdx
+++ b/src/content/docs/installation/installation_handheld.mdx
@@ -9,8 +9,7 @@ CachyOS provides an edition for handheld devices, such as the Steam Deck, ROG Al
 
 The Handheld Edition employs the LAVD scheduler as the default CPU scheduler, which is optimized for handheld devices. This results in improved frame rates and battery life during gaming.
 
-The Handheld Edition uses `systemd-boot` as the boot manager. Boot manager selection is not available
-as opposed to the default CachyOS ISO. This is intended to simplify the installation process.
+The Handheld Edition uses `limine` as the boot manager with automatic snapshots. `systemd-boot` is also available as an alternative option.
 
 :::note[KDE Plasma is the only supported desktop environment for the Handheld Edition.]
 :::


### PR DESCRIPTION
Updated the boot manager information for Handheld Edition, noting the change from systemd-boot to limine by default.