### PR TITLE
Add helpful note from arch wiki to secure boot setup instructions

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -51,10 +51,6 @@ However, some MSI motherboards don't have a setup mode. To achieve the same effe
 
 ## Setting Up sbctl
 
-:::tip[Info]
-For some PCs, for example with a Framework laptop, it is recommended to also include the OEM firmware's built-in certificates, if you want to retain the ability to upgrade the firmware and run others boot applications provided by OEM. In this case run `sudo sbctl enroll-keys --microsoft --firmware-builtin` indead of `sudo sbctl enroll-keys --microsoft`
-:::
-
 ```bash
 sudo sbctl status # If setup mode is enabled we can proceed to the next step
 Installed:      ✘ sbctl is not installed
@@ -66,7 +62,8 @@ Created Owner UUID a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
 Creating secure boot keys...✔
 Secure boot keys created!
 
-sudo sbctl enroll-keys --microsoft # Enroll your keys with Microsoft's keys
+# Enroll your keys with Microsoft's and the OEM firmware's built-in keys
+sudo sbctl enroll-keys --microsoft --firmware-builtin
 Enrolling keys to EFI variables...✔
 Enrolled keys to the EFI variables!
 

--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -51,6 +51,10 @@ However, some MSI motherboards don't have a setup mode. To achieve the same effe
 
 ## Setting Up sbctl
 
+:::tip[Info]
+For some PCs, for example with a Framework laptop, it is recommended to also include the OEM firmware's built-in certificates, if you want to retain the ability to upgrade the firmware and run others boot applications provided by OEM. In this case run `sudo sbctl enroll-keys --microsoft --firmware-builtin` indead of `sudo sbctl enroll-keys --microsoft`
+:::
+
 ```bash
 sudo sbctl status # If setup mode is enabled we can proceed to the next step
 Installed:      ✘ sbctl is not installed


### PR DESCRIPTION
Source: https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Creating_and_enrolling_keys