### PR TITLE
Fixed typo in BTRFS Zswap instructions

### DIFF
--- a/src/content/docs/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/configuration/general_system_tweaks.mdx
@@ -411,7 +411,7 @@ This guide assumes you have the default CachyOS setup with ZRam enabled and no s
                         ```
                     4. Add the swap file to `/etc/fstab` to make it persistent across reboots:
                         ```bash
-                        echo "/swapfile none swap defaults 0 0" | sudo tee -a /etc/fstab
+                        echo "/swap/swapfile none swap defaults 0 0" | sudo tee -a /etc/fstab
                         ```
                 </Steps>
         </details>


### PR DESCRIPTION
This PR fixes a path inconsistency in the Btrfs swap file setup instructions.
In step 1 the guide creates a Btrfs subvolume at /swap. However, in step 4 for adding the entry to fstab, it incorrectly points to /swapfile (likely a carryover from the standard non-Btrfs guide when doing commit 9fb15bc).