### PR TITLE
Update dual_gpu.mdx to include instructions to enable iGPU in Steam

### DIFF
--- a/src/content/docs/configuration/dual_gpu.mdx
+++ b/src/content/docs/configuration/dual_gpu.mdx
@@ -107,7 +107,7 @@ prime-run %command%
 Be sure to add `%command%` after `prime-run`. Remember that game options come after the placeholder,
 while system environment variables or commands should precede it.
 
-To run a game on the integrated graphics instead, use the following launch option as an example for Radeon integrated graphics.
+To run a game on the integrated graphics instead, use the following launch option as an example for Radeon integrated graphics. This can be desirable for greater battery life and reduced fan noise for lower power games.
 
 ```bash
 VK_DRIVER_FILES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/usr/share/vulkan/icd.d/radeon_icd.i686.json %command%

--- a/src/content/docs/configuration/dual_gpu.mdx
+++ b/src/content/docs/configuration/dual_gpu.mdx
@@ -107,6 +107,12 @@ prime-run %command%
 Be sure to add `%command%` after `prime-run`. Remember that game options come after the placeholder,
 while system environment variables or commands should precede it.
 
+To run a game on the integrated graphics instead, use the following launch option as an example for Radeon integrated graphics.
+
+```bash
+VK_DRIVER_FILES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/usr/share/vulkan/icd.d/radeon_icd.i686.json %command%
+```
+
 <br />
 <ImageComponent imgsrc={import('~/assets/images/steam-prime.png')} />
 


### PR DESCRIPTION
Going through this documentation it was lacking some instruction on how to enable the iGPU for Steam. This can be desirable for greater battery life and reduced fan noise.

I only have access to a Radeon iGPU, so these instructions work for me. For an Intel iGPU the path to the Intel Vulkan driver would be substituted, but I don't have the ability to verify that.