### PR TITLE
socials: Remove Forum,Discord,Reddit

### DIFF
--- a/src/content/docs/support/social.md
+++ b/src/content/docs/support/social.md
@@ -1,6 +1,6 @@
 ---
 title: Official CachyOS Community
-description: Discord, Reddit, X, Forum, Mastodon
+description: Bluesky, Reddit, X, Forum, Mastodon
 ---
 
 The following Social Media are maintained by the CachyOS Team.
@@ -9,8 +9,6 @@ You can follow the links to chat and ask for help.
 
 Feel free to join!
 
-- [Discord](<https://discord.gg/cachyos-862292009423470592>)
-- [Reddit](<https://www.reddit.com/r/cachyos>)
-- [Forum](<https://discuss.cachyos.org>)
 - [X](<https://x.com/cachyos>) - `Excluded from asking for help.`
 - [Mastodon](<https://fosstodon.org/@CachyOS>) - `Excluded from asking for help.`
+- [Bluesky](<https://bsky.app/profile/cachyos.org>) - `Excluded from asking for help.`


### PR DESCRIPTION
Due to demanding increase in moderation. Forum,Discord,Reddit are unable to handle moderation of these channels and therefore cannot be considered official where community rules must be enforced 

ps: also adds bluesky as official, which was missing previously