### PR TITLE
docs: add Vivaldi + AMD RX 9070 XT HW acceleration config

### DIFF
--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -236,6 +236,28 @@ If you're using X11, use this:
 **Notes:**
 Works on Wayland. Disabling "Ambient Mode" in YouTube settings is required to prevent UI lag.
 
+### Vivaldi - AMD Radeon RX 9070 XT (Contributed by tTrmc)
+
+* **Browser:** Vivaldi
+
+* **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
+
+* **Flags File Path:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--ozone-platform=wayland
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```
+
+**Notes:**
+- Tested on CachyOS with kernel 6.19.11-1-cachyos, Mesa 26.0.3, GNOME (Wayland), display 2560x1440.
+- Confirmed working: `vivaldi://gpu` shows Video Decode and Video Encode as "Hardware accelerated". Full codec support for H264, VP9, HEVC, AV1 decoding and H264, AV1 encoding. DevTools Media tab shows `VaapiVideoDecoder` as the active decoder.
+- The RX 9070 XT (RDNA 4) may be on Chromium's GPU blocklist, so `--ignore-gpu-blocklist` is required.
+- The log may show a warning: `'--ozone-platform=wayland' is not compatible with Vulkan` — this does not prevent hardware acceleration from working. You can alternatively use `--ozone-platform-hint=auto` if you prefer.
+
 ---
 
 ### Template to contribute


### PR DESCRIPTION
Adds a verified hardware acceleration configuration for Vivaldi on AMD Radeon RX 9070 XT (RDNA 4 / gfx1201) running CachyOS with Wayland (GNOME).

Verified with:
- vivaldi://gpu: Video Decode & Encode both Hardware accelerated
- DevTools Media tab: VaapiVideoDecoder confirmed
- Kernel 6.19.11-1-cachyos, Mesa 26.0.3

This is the first RDNA 4 entry in the guide.