### PR TITLE
Improve boot manager configuration page for limine

### DIFF
--- a/src/content/docs/configuration/boot_manager_configuration.mdx
+++ b/src/content/docs/configuration/boot_manager_configuration.mdx
@@ -120,6 +120,10 @@ Configuration primarily happens in `/boot/limine.conf` (or sometimes in the EFI 
 
 This file controls the boot menu's behavior and appearance. Changes made here take effect immediately after saving – no extra commands are needed.
 
+:::caution
+  After modifying `/boot/limine.conf`, run `sudo limine-update` to re-enroll the config checksum. Without this step, Limine may panic with "checksum mismatch for config file" during boot.
+:::
+
 * **Timeout:** Sets how many seconds Limine waits before automatically booting the default entry.
 
   ```shell


### PR DESCRIPTION
Warn users to run `sudo limine-update` after modifying `limine.conf` to prevent "checksum mismatch" boot errors, especially with Secure Boot.

I run in this issue, after modifying the timeout parameter. After a restart I got a Panic "CHECKSUM MISMATCH FOR CONFIG FILE". After booting in a live iso and cachy-chroot the issue was fixed with a "sudo limine-update".

See: https://discord.com/channels/862292009423470592/862294383470051348/1492811465378500749

`bun run preview` was successful and this is how the change would look like:

<img width="1169" height="593" alt="grafik" src="https://github.com/user-attachments/assets/9cddcf8c-45e9-4bab-919f-098a420b92c3" />
