### PR TITLE
Add ASUS motherboard caveats for secure boot setup

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -43,6 +43,10 @@ However, some MSI motherboards don't have a setup mode. To achieve the same effe
 <br />
 <ImageComponent imgsrc={import('~/assets/images/MSI-bios-secure-boot.jpg')} />
 
+Some Asus motherboards have a similar behavior to the above mentioned MSI motherboards, as they do not have a dedicated setup mode.
+
+Navigate to Boot → Secure Boot, set Secure Boot Mode to Custom, then open Key Management and select "Delete all Secure Boot Variables". 
+
 #### Installing sbctl and Enrolling Keys
 
 Before proceeding, make sure to check if `sbctl` is installed.
@@ -95,6 +99,26 @@ Now that `sbctl` is installed, you have to setup sbctl and enroll your keys to t
         Enrolled keys to the EFI variables!
         ```
     </details>
+
+    :::caution[ASUS Motherboards — Do not use `--firmware-builtin`]
+    On some ASUS motherboards using the `--firmware-builtin` flag causes duplicate entries
+    in the EFI key variables (e.g. `builtin-db` appearing multiple times in `Vendor Keys`).
+    When activating Secure Boot in the UEFI settings afterwards, the board detects this
+    inconsistent key structure and throws a **Secure Boot Violation** before the boot
+    manager can load.
+
+    Use only `--microsoft` on ASUS boards:
+
+    ```bash
+    sudo sbctl enroll-keys --microsoft
+    ```
+
+    If `Vendor Keys` shows `microsoft builtin-db builtin-db ...`, the keys need to be
+    re-enrolled. Re-enter Setup Mode in the UEFI (using delete all keys), then run
+    `sbctl enroll-keys --microsoft` again without `--firmware-builtin`.
+    :::
+
+
 4. Check the status of sbctl again to make sure that the keys are enrolled and setup mode is disabled:
     ```bash
     sudo sbctl status
@@ -146,6 +170,26 @@ Verifying file database and EFI images in /boot...
 ```
 
 Now that all the files are signed. **Reboot your system and go to your UEFI Settings to enable Secure Boot.**
+
+:::caution[ASUS Motherboards — enabling Secure Boot]
+Some ASUS motherboards behave differently from other vendors when enabling Secure Boot:
+
+- **Use `Windows UEFI Mode`, not `Other OS`:**
+  The name is misleading this setting simply controls whether Secure Boot is enforced.
+  Setting `OS Type` to `Other OS` **actively disables** Secure Boot on ASUS boards,
+  regardless of any other settings. `sbctl status` will continue to show
+  `Secure Boot: Disabled` even after rebooting.
+
+- **There is no separate Secure Boot on/off toggle** on some ASUS boards.
+  Secure Boot is activated implicitly by selecting `Windows UEFI Mode`.
+
+The correct ASUS BIOS configuration to activate Secure Boot in this case is:
+```
+Boot → Secure Boot
+  OS Type          → Windows UEFI Mode
+  Secure Boot Mode → Custom
+```
+:::
 
 Check [this part for reference](/configuration/secure_boot_setup#enabling-setup-mode-in-uefi)
 

--- a/src/content/docs/de/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/de/configuration/secure_boot_setup.mdx
@@ -49,6 +49,10 @@ Manche MSI-Motherboards haben jedoch keinen Setup-Modus. Um den gleichen Effekt 
 <br />
 <ImageComponent imgsrc={import('~/assets/images/MSI-bios-secure-boot.jpg')} />
 
+Manche ASUS Mainboards verhalten sich ähnlich wie die gerade genannten MSI Mainboards, da sie keinen dedizierten Setup Mode haben.
+
+Unter Boot → Secure Boot den Secure Boot Mode auf Custom stellen, anschließend unter Key Management die Option "Delete all Secure Boot Variables" auswählen.
+
 ## sbctl einrichten
 
 ```bash
@@ -108,6 +112,26 @@ Verifying file database and EFI images in /boot...
 ```
 
 Jetzt, da alle Dateien signiert sind. **Starte dein System neu und geh in deine UEFI-Einstellungen, um Secure Boot zu aktivieren.**
+
+
+:::caution[ASUS Mainboards — Aktivieren von Secure Boot]
+Manche ASUS Mainboards verhalten sich beim Aktivieren von Secure Boot anders als andere Hersteller:
+
+- **`Windows UEFI Mode` verwenden, nicht `Other OS`:**
+  Der Name ist irreführend, diese Einstellung steuert lediglich ob Secure Boot aktiv ist.
+  Das Setzen von `OS Type` auf `Other OS` **deaktiviert** Secure Boot auf ASUS Mainboards, unabhängig von allen anderen Einstellungen.
+  `sbctl status` zeigt in diesem Fall weiterhin `Secure Boot: Disabled`, auch nach einem Neustart.
+
+- **Auf manchen ASUS Mainboards gibt es keinen separaten Secure Boot Ein/Aus-Schalter.**
+  Secure Boot wird implizit durch die Auswahl von `Windows UEFI Mode` aktiviert.
+
+Die korrekte ASUS BIOS Konfiguration zum aktivieren von Secure Boot ist dann:
+```
+Boot → Secure Boot
+  OS Type          → Windows UEFI Mode
+  Secure Boot Mode → Custom
+```
+:::
 
 Beachte, dass dies ein einmaliger Vorgang ist, da das Signieren von Dateien mit dem `-s`-Flag diese Dateien in der Datenbank von `sbctl` speichert.
 


### PR DESCRIPTION
This adds instructions and caveats for setting up and enabling Secure Boot on some ASUS motherboards, which behave differently from other vendors.


### Changes Made
Both the English and German versions of the wiki have been updated to include the following:

- Added a caution block explaining the risk of using `--firmware-builtin` on ASUS boards, as it can cause duplicate EFI key entries and lead to Secure Boot violations.
- Clarified that some ASUS boards lack a dedicated Secure Boot toggle and require `Windows UEFI Mode` to activate Secure Boot, while setting `OS Type` to `Other OS` actually disables it.
- Documented the need to use `--microsoft` instead and provided steps to re-enroll keys if necessary **(English wiki only)**.

### Context
- The changes are based on my observations from an ASUS Z790-P motherboard running a **dual-boot setup with Windows 11**.
- These instructions may not apply to all ASUS or other vendor boards, especially in non-dual-boot or different Linux-only setups.

### Question
**Why do the command instructions for enrolling keys differ between the English and German wiki versions?**

**German wiki:**
```bash
sudo sbctl enroll-keys --microsoft
```

**English wiki:**
 ```bash
 sudo sbctl enroll-keys --microsoft --firmware-builtin
 ```