### PR TITLE
docs: add warning about rebooting after system update (#361)

### DIFF
--- a/src/content/docs/features/kernel_manager.mdx
+++ b/src/content/docs/features/kernel_manager.mdx
@@ -11,6 +11,24 @@ import ImageComponent from '~/components/image-component.astro';
 Installing a Kernel from a Repository
 ---------------------------------------
 
+:::warning[Important: Reboot After System Update]
+
+Before using Kernel Manager to switch or install kernels, make sure to reboot your system if you recently performed a system update.
+
+**Why?**
+- Running kernel might be different from the installed one after update
+- Switching kernels without rebooting can cause `mkinitramfs` failures
+- System might become unbootable
+
+**Recommended workflow:**
+1. System update
+2. Reboot when prompted
+3. Then use Kernel Manager to switch/install kernels
+
+**Tip:** Enable system snapshots (like Snapper) for quick recovery if something goes wrong.
+
+:::
+
 The CachyOS Kernel Manager makes it simple to install and manage kernels from any Arch Linux repository.
 
 To install a kernel. Launch the `CachyOS Kernel Manager` application and choose the desired kernel by ticking the box `[]` from the list of all the available options, then just press `Execute` to start the kernel installation.


### PR DESCRIPTION
Closes #361

This adds a warning notice to the Kernel Manager documentation, reminding users to reboot their system after updates before switching kernels.

This prevents `mkinitramfs` failures that can occur when the running kernel differs from the installed kernel after a system update.

Suggested by @dkchshv in #361