### PR TITLE
Document hardware acceleration setup for RX 9070 XT

### DIFF
--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -257,6 +257,17 @@ Works on Wayland. Disabling "Ambient Mode" in YouTube settings is required to pr
 - Confirmed working: `vivaldi://gpu` shows Video Decode and Video Encode as "Hardware accelerated". Full codec support for H264, VP9, HEVC, AV1 decoding and H264, AV1 encoding. DevTools Media tab shows `VaapiVideoDecoder` as the active decoder.
 - The RX 9070 XT (RDNA 4) may be on Chromium's GPU blocklist, so `--ignore-gpu-blocklist` is required.
 - The log may show a warning: `'--ozone-platform=wayland' is not compatible with Vulkan` — this does not prevent hardware acceleration from working. You can alternatively use `--ozone-platform-hint=auto` if you prefer.
+### Google Chrome - AMD Radeon RX 9070 XT (Contributed by naknak)
+- **Browser:** Google Chrome
+- **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
+- **Flags File Path:** `~/.config/chrome-flags.conf`
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--ozone-platform-hint=auto
+--use-gl=angle
+--use-angle=vulkan
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo,Vulkan,VulkanFromANGLE,DefaultANGLEVulkan
 
 ---
 


### PR DESCRIPTION
Added configuration details for enabling hardware acceleration on Google Chrome with AMD Radeon RX 9070 XT.