### PR TITLE
Switch Desktops: Update maintained package list

### DIFF
--- a/src/content/docs/configuration/desktop_environments/switch_desktop.mdx
+++ b/src/content/docs/configuration/desktop_environments/switch_desktop.mdx
@@ -99,7 +99,9 @@ You'll have to keep an eye on the GitHub repository of the respective DE/WM for 
 
 Here is a list of all the repositories of different DEs and WMs maintained by CachyOS:
 - [KDE Plasma](https://github.com/CachyOS/cachyos-kde-settings)
-- [Niri](https://github.com/CachyOS/cachyos-niri-settings)
+- [GNOME](https://github.com/CachyOS/cachyos-gnome-settings)
+- [Niri](https://github.com/cachyos/cachyos-niri-noctalia)
+- [MangoWM](https://github.com/CachyOS/cachyos-mangowc-dms)
 - [i3](https://github.com/CachyOS/cachyos-i3wm-settings)
 - [Qtile](https://github.com/CachyOS/cachyos-qtile-settings)
 - [Wayfire](https://github.com/CachyOS/cachyos-wayfire-settings)
@@ -114,4 +116,4 @@ All the other DE and WMs we offer when installing CachyOS don't have their own `
 
 "CachyOS Settings" are convenient configuration packages for various desktop environments and window managers. They provide pre-configured settings, themes, and tweaks depending on the DE/WM you choose.
 
-When you install one of these packages . It will also automatically install extra dependencies that are not part of the vanilla DE/WM, such as themes, icons, wallpapers and additional applications. For example in `cachyos-i3wm-settings` we install `rofi`, `dunst`, `picom`, `lxappearance` and more.
+When you install one of these packages, it will also automatically install extra dependencies that are not part of the vanilla DE/WM, such as themes, icons, wallpapers and additional applications. For example in `cachyos-i3wm-settings` we install `rofi`, `dunst`, `picom`, `lxappearance` and more.


### PR DESCRIPTION
Reintroduces GNOME, adds new Niri and MangoWC settings with up to date links. Also fixes minor typo.