### PR TITLE
Secure Boot: Added missing 'reenable Secure boot' step for Limine.

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -13,7 +13,7 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 ### GRUB Boot Manager
 
-If you are using GRUB, run the following command to enable secure boot support on GRUB using CA Keys.
+If you are using GRUB, run the following command to enable secure boot support on GRUB using CA Keys:
 
 ```bash
 sudo grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=cachyos --modules="tpm" --disable-shim-lock
@@ -27,7 +27,7 @@ Only run this command if you actually need secure boot.
 ### Enabling Setup Mode in UEFI
 
 Firstly, we need to go to firmware settings and set secure boot mode to "Setup Mode". You can reboot from an
-already running system to firmware settings with following command.
+already running system to firmware settings with following command:
 
 ```bash
 systemctl reboot --firmware-setup
@@ -56,7 +56,7 @@ offering key management capabilities, and keeping track of files that need to be
 
 <details>
     <summary>How to install sbctl</summary>
-    ```bash title='Open a terminal and run the following command'
+    ```bash title='Open a terminal and run the following command:'
     sudo pacman -S sbctl
     ```
 </details>
@@ -274,12 +274,43 @@ After enabling config checksum enrollment and generating the hash for the splash
 sudo limine-enroll-config
 sudo limine-update
 ```
+
+Now that all the files are signed. **Reboot your system and go to your UEFI Settings to enable Secure Boot.**
+
+:::caution[ASUS Motherboards — enabling Secure Boot]
+Some ASUS motherboards behave differently from other vendors when enabling Secure Boot:
+
+- **Use `Windows UEFI Mode`, not `Other OS`:**
+  The name is misleading this setting simply controls whether Secure Boot is enforced.
+  Setting `OS Type` to `Other OS` **actively disables** Secure Boot on ASUS boards,
+  regardless of any other settings. `sbctl status` will continue to show
+  `Secure Boot: Disabled` even after rebooting.
+
+- **There is no separate Secure Boot on/off toggle** on some ASUS boards.
+  Secure Boot is activated implicitly by selecting `Windows UEFI Mode`.
+
+The correct ASUS BIOS configuration to activate Secure Boot in this case is:
+```
+Boot → Secure Boot
+  OS Type          → Windows UEFI Mode
+  Secure Boot Mode → Custom
+```
+:::
+
+Check [this part for reference](/configuration/secure_boot_setup#enabling-setup-mode-in-uefi)
+
+:::tip[Reminder]
+`sbctl` ships with a [pacman hook](https://wiki.archlinux.org/title/Pacman_hook) meaning it will automatically
+sign all new files upon a kernel or boot manager update.
+:::
+
+
 </TabItem>
 </Tabs>
 
 ## Secure Boot Status Check
 
-To check that secure boot is indeed enabled. You can run one of the following commands
+To check that secure boot is indeed enabled. You can run one of the following commands:
 
 ```bash
 sudo sbctl status


### PR DESCRIPTION
The Secure Boot section for Limine was missing a crucial step - to reboot and reenable Secure Boot when everything is done. Compared to the systmd-boot info, it was also missing the warning for ASUS motherboards as well as the info about  `sbctl` shipping with a `pacman` hook.

I also made some minor corrections to the text (adding colon before terminal commands).
