### PR TITLE
docs: add RX 9070 XT Chrome hardware acceleration config

### DIFF
--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -258,9 +258,14 @@ Works on Wayland. Disabling "Ambient Mode" in YouTube settings is required to pr
 - The RX 9070 XT (RDNA 4) may be on Chromium's GPU blocklist, so `--ignore-gpu-blocklist` is required.
 - The log may show a warning: `'--ozone-platform=wayland' is not compatible with Vulkan` — this does not prevent hardware acceleration from working. You can alternatively use `--ozone-platform-hint=auto` if you prefer.
 ### Google Chrome - AMD Radeon RX 9070 XT (Contributed by naknak)
-- **Browser:** Google Chrome
-- **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
-- **Flags File Path:** `~/.config/chrome-flags.conf`
+
+* **Browser:** Google Chrome
+
+* **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
+
+* **Flags File Path:** `~/.config/chrome-flags.conf`
+
+```bash
 --ignore-gpu-blocklist
 --enable-gpu-rasterization
 --enable-zero-copy
@@ -268,6 +273,11 @@ Works on Wayland. Disabling "Ambient Mode" in YouTube settings is required to pr
 --use-gl=angle
 --use-angle=vulkan
 --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo,Vulkan,VulkanFromANGLE,DefaultANGLEVulkan
+```
+
+**Notes:**
+- Video decoding **and** encoding showing as `Hardware accelerated` on `chrome://gpu`.
+- Sometimes inspecting the `media` tab on a YouTube video will show Hardware acceleration, sometimes not.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Google Chrome hardware acceleration configuration for AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
- Includes tested chrome-flags.conf with Vulkan/VAAPI acceleration
- Confirmed hardware-accelerated video decoding and encoding on `chrome://gpu`