### PR TITLE
docs: add NVIDIA s2idle suspend/resume fix for AMD laptops

### DIFF
--- a/src/content/docs/configuration/dual_gpu.mdx
+++ b/src/content/docs/configuration/dual_gpu.mdx
@@ -170,3 +170,53 @@ For GNOME this has been fixed in version 46.2. For Plasma 6 it will probably be
 fixed with 6.1 although some users report normal performance already on 6.0.
 Other environments/window managers still have this issue, so you need to switch
 to the latest version of GNOME or Plasma to fix it.
+
+## Suspend/Resume on AMD + NVIDIA Laptops (s2idle)
+
+Modern AMD laptops only support the `s2idle` sleep state (AMD Modern Standby) —
+you can verify this with:
+
+```bash
+cat /sys/power/mem_sleep
+```
+
+If the output shows only `s2idle` with no `deep` option, your system requires
+the NVIDIA driver to explicitly manage its power state during sleep. Without
+configuration, the GPU enters suspend without saving its state, and the screen
+stays black on wake.
+
+### Symptoms
+
+- Screen does not turn on after suspending the laptop
+- Reproducible even from a TTY session (not a compositor issue)
+- `cat /proc/driver/nvidia/gpus/.../power` shows `S0ix Status: Disabled`
+
+### Fix
+
+Create the modprobe config:
+
+```bash
+sudo tee /etc/modprobe.d/nvidia-power.conf << 'EOF'
+options nvidia NVreg_EnableS0ixPowerManagement=1
+options nvidia NVreg_PreserveVideoMemoryAllocations=1
+EOF
+```
+
+Rebuild your initramfs:
+
+```bash
+sudo mkinitcpio -P
+```
+
+Ensure the NVIDIA systemd hooks are enabled:
+
+```bash
+sudo systemctl enable nvidia-suspend.service nvidia-resume.service nvidia-hibernate.service
+```
+
+Reboot and verify the fix took effect:
+
+```bash
+cat /proc/driver/nvidia/gpus/0000:01:00.0/power
+# Should now show: S0ix Power Management → Status: Enabled
+```


### PR DESCRIPTION
## Problem
On AMD laptops with only `s2idle` support (no S3/deep sleep), the NVIDIA driver
does not participate in the S0ix sleep cycle by default, causing a black screen
on resume after suspend. This is visible in `/proc/driver/nvidia/gpus/.../power`
as `S0ix Status: Disabled`.

## Fix
Documents `NVreg_EnableS0ixPowerManagement=1` and
`NVreg_PreserveVideoMemoryAllocations=1`, which enable proper GPU power state
management during s2idle suspend.

## Tested on
- CachyOS (rolling)
- NVIDIA GeForce RTX 4070 Laptop GPU
- Driver 595.71.05
- Kernel 7.0.3-1-cachyos
- AMD + NVIDIA hybrid laptop