### PR TITLE
Update Limine configuration link to version 12.x

### DIFF
--- a/src/content/docs/configuration/boot_manager_configuration.mdx
+++ b/src/content/docs/configuration/boot_manager_configuration.mdx
@@ -226,5 +226,5 @@ While entries are handled automatically, you can **configure the kernel paramete
 * [loader.conf manual page](https://man.archlinux.org/man/loader.conf.5)
 * [rEFInd: Configuring the boot manager](https://www.rodsbooks.com/refind/configfile.html)
 * [GRUB Manual: Configuration](https://www.gnu.org/software/grub/manual/grub/grub.html#Configuration)
-* [Official Limine Configuration Docs](https://github.com/limine-bootloader/limine/blob/v9.x/CONFIG.md)
+* [Official Limine Configuration Docs](https://github.com/limine-bootloader/limine/blob/v12.x/CONFIG.md)
 * [limine-entry-tool Project](https://gitlab.com/Zesko/limine-entry-tool)


### PR DESCRIPTION
Updated the Limine configuration documentation to match the version of Limine now present on pacman for CachyOS.