### PR TITLE
Update Secure Boot setup instructions for MSI motherboards

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -39,7 +39,7 @@ systemctl reboot --firmware-setup
 This is how the BIOS looks like on a Lenovo Ideapad 5 Pro. Reset to setup mode or restore factory keys and reboot back
 to the system.
 
-However, some MSI motherboards don't have a Setup Mode. To achieve the same effect, set the Secure Boot Mode to "custom" and select the "maximum Security" compatibility option (this is important: with the default mode, you might not be able to boot from your bootloader into CachyOS!). Then, go into "key management" and follow the two steps illustrated in the image below:
+However, some MSI motherboards don't have a Setup Mode. To achieve the same effect, set the Secure Boot Mode to "custom" and select the "maximum security" compatibility option (this is important: with the default mode, you might not be able to boot from your bootloader into CachyOS!). Then, go into "key management" and follow the two steps illustrated in the image below:
 <br />
 <ImageComponent imgsrc={import('~/assets/images/MSI-bios-secure-boot.jpg')} />
 

--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -39,7 +39,7 @@ systemctl reboot --firmware-setup
 This is how the BIOS looks like on a Lenovo Ideapad 5 Pro. Reset to setup mode or restore factory keys and reboot back
 to the system.
 
-However, some MSI motherboards don't have a setup mode. To achieve the same effect, follow the two steps from the image below:
+However, some MSI motherboards don't have a Setup Mode. To achieve the same effect, set the Secure Boot Mode to "custom" and select the "maximum Security" compatibility option (this is important: with the default mode, you might not be able to boot from your bootloader into CachyOS!). Then, go into "key management" and follow the two steps illustrated in the image below:
 <br />
 <ImageComponent imgsrc={import('~/assets/images/MSI-bios-secure-boot.jpg')} />
 


### PR DESCRIPTION
Clarified instructions for setting Secure Boot on MSI motherboards, emphasizing the importance of selecting the 'maximum Security' option.