### PR TITLE
Update kernel.mdx, remove obsolete mention of BORE sched

### DIFF
--- a/src/content/docs/features/kernel.mdx
+++ b/src/content/docs/features/kernel.mdx
@@ -97,7 +97,6 @@ is built  with [clang](https://clang.llvm.org/) instead of [GCC](https://gcc.gnu
     - `Does not support sched-ext.`
 - **linux-cachyos-rc**
   - Based on the latest mainline kernel from [Linus's tree](https://github.com/torvalds/linux/).
-  - Uses the [BORE](https://github.com/firelzrd/bore-scheduler) scheduler.
   - Main kernel to introduce new features in our patchset.
 - **linux-cachyos-server**
   - Tuned for server workloads compared to desktop usage.


### PR DESCRIPTION
Removed mention of the BORE scheduler from -rc, since that info seems to be outdated.

Proof:
```
❮ uname -r && sysctl kernel.sched_bore
7.1.0-rc4-1-cachyos-rc
sysctl: cannot stat /proc/sys/kernel/sched_bore: No such file or directory
```