### PR TITLE
Added Ryzen AI Max+ (Strix Halo) with Vivaldi

### DIFF
--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -298,8 +298,6 @@ Works on Wayland. Disabling "Ambient Mode" in YouTube settings is required to pr
 **Notes:**
 - Tested on CachyOS with kernel 7.0.10-2-cachyos, Mesa 26.1.1, GNOME (Wayland), display 5120x1440.
 - Confirmed working: `vivaldi://gpu` shows Canvas, Compositing, Rasterization, Video Decode, Video Encode, WebGL, WebGPU, and WebGPU interop as "Hardware accelerated". Full codec support for H264, H265, VP9, AV1 decoding and H264, H265 and AV1 encoding.
-- The RX 9070 XT (RDNA 4) may be on Chromium's GPU blocklist, so `--ignore-gpu-blocklist` is required.
-- The log may show a warning: `'--ozone-platform=wayland' is not compatible with Vulkan` — this does not prevent hardware acceleration from working. You can alternatively use `--ozone-platform-hint=auto` if you prefer.
 
 ### Template to contribute
 

--- a/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -279,7 +279,27 @@ Works on Wayland. Disabling "Ambient Mode" in YouTube settings is required to pr
 - Video decoding **and** encoding showing as `Hardware accelerated` on `chrome://gpu`.
 - Sometimes inspecting the `media` tab on a YouTube video will show Hardware acceleration, sometimes not.
 
----
+### Vivaldi - AMD Ryzen AI Max+ 395 (Contributed by woutervanelten)
+
+* **Browser:** Vivaldi (8.0.4033.35)
+
+* **APU:** AMD Radeon 8060S (GFX1151/Strix Halo)
+
+* **Flags File Path:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--ozone-platform=wayland
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```
+
+**Notes:**
+- Tested on CachyOS with kernel 7.0.10-2-cachyos, Mesa 26.1.1, GNOME (Wayland), display 5120x1440.
+- Confirmed working: `vivaldi://gpu` shows Canvas, Compositing, Rasterization, Video Decode, Video Encode, WebGL, WebGPU, and WebGPU interop as "Hardware accelerated". Full codec support for H264, H265, VP9, AV1 decoding and H264, H265 and AV1 encoding.
+- The RX 9070 XT (RDNA 4) may be on Chromium's GPU blocklist, so `--ignore-gpu-blocklist` is required.
+- The log may show a warning: `'--ozone-platform=wayland' is not compatible with Vulkan` — this does not prevent hardware acceleration from working. You can alternatively use `--ozone-platform-hint=auto` if you prefer.
 
 ### Template to contribute
 


### PR DESCRIPTION
Added configuration details for enabling hardware acceleration in Vivaldi browser with AMD Ryzen AI Max 395.