### PR TITLE
Fixed Formatting, CSS and Updated Lutris/Heroic section

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -202,7 +202,7 @@ Links to Proton-EM documents:
 ### Setting Up Proton-CachyOS with Lutris and Heroic
 
 :::note
-The following configuration only applies to proton-cachyos. If you're using proton-cachyos-slr, -GE or -EM, you can skip this section.
+The following configuration only applies to proton-cachyos-slr. If you're using -GE or -EM, you can skip this section.
 :::
 
 Make sure you have umu-launcher from CachyOS installed in your system. Install it with the following command.
@@ -215,7 +215,7 @@ sudo pacman -S cachyos/umu-launcher
     <Steps>
       1. In the main Lutris screen, click the cogwheel icon next to Wine.
       2. Go to the **Runner Options** tab and confirm that your settings match the following:
-          - **Wine version** = `proton-cachyos`
+          - **Wine version** = `proton-cachyos-slr`
           - **Use System winetricks** = *Disabled*
           - **Graphics**
           - **Enable DXVK** = `Enabled`
@@ -223,12 +223,9 @@ sudo pacman -S cachyos/umu-launcher
       3. Navigate to the **System Options** tab.
           - **Lutris**
           - **Disable Lutris Runtime** = `Enabled`
-          - **Prefer system libraries** = `Enabled`
+          - **Prefer system libraries** = `Disabled`
       4. Continue scrolling down to the **Game execution** section and locate the **Environment variables** table.
       5. Add the following environment variables:
-          - **Key**: `UMU_RUNTIME_UPDATE` *optional*
-          - **Value**: `0`
-            - *This will skip Steam Linux Runtime updates for proton-cachyos. Do not use this with any Proton that utilizes the Steam Linux Runtime, such as proton-cachyos-slr, -GE, or -EM.*
           - **Key**: `PROTON_VERB` *optional*
           - **Value**: `waitforexitandrun`
             - *This allows protonfixes to work with a corresponding GAMEID.*
@@ -239,7 +236,7 @@ sudo pacman -S cachyos/umu-launcher
     <Steps>
       1. Right-click the game you want to configure, then click on **Configure**.
       2. Go to the **Runner Options** tab and confirm that your settings match the following:
-          - **Wine version** = `proton-cachyos`
+          - **Wine version** = `proton-cachyos-slr`
           - **Use System winetricks** = *Disabled*
           - **Graphics**
           - **Enable DXVK** = `Enabled`
@@ -247,12 +244,9 @@ sudo pacman -S cachyos/umu-launcher
       3. Navigate to the **System Options** tab.
           - **Lutris**
           - **Disable Lutris Runtime** = `Enabled`
-          - **Prefer system libraries** = `Enabled`
+          - **Prefer system libraries** = `Disabled`
       4. Continue scrolling down to the **Game execution** section and locate the **Environment variables** table.
       5. Add the following environment variables:
-          - **Key**: `UMU_RUNTIME_UPDATE` *optional*
-          - **Value**: `0`
-            - *This will skip Steam Linux Runtime updates for proton-cachyos. Do not use this with any Proton that utilizes the Steam Linux Runtime, such as proton-cachyos-slr, -GE, or -EM.*
           - **Key**: `PROTON_VERB` *optional*
           - **Value**: `waitforexitandrun`
             - *This allows protonfixes to work with a corresponding GAMEID.*
@@ -262,7 +256,7 @@ sudo pacman -S cachyos/umu-launcher
   <TabItem label='Heroic Games Launcher'>
     <Steps>
       1. Click on the `Configure` button next to the `Play Now` button in the game you want to run.
-      2. In the `WINE` tab. Set the Wine Version to `Proton - proton-cachyos`.
+      2. In the `WINE` tab. Set the Wine Version to `Proton - proton-cachyos-slr`.
     </Steps>
   </TabItem>
 </Tabs>

--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -48,9 +48,9 @@ Follow the steps below to start with the gaming setup.
   <TabItem label='Tools & Stores'>
     The `cachyos-gaming-applications` meta-package includes the following:
     - Tools
-    - Gamescope, GOverlay, MangoHud
+      - Gamescope, GOverlay, MangoHud
     - Launchers
-    - Steam, Heroic Games Launcher, Lutris, Faugus Launcher
+      - Steam, Heroic Games Launcher, Lutris, Faugus Launcher
     ```sh
     sudo pacman -S cachyos-gaming-applications
     ```
@@ -219,7 +219,7 @@ sudo pacman -S cachyos/umu-launcher
           - **Use System winetricks** = *Disabled*
           - **Graphics**
           - **Enable DXVK** = `Enabled`
-          - Note: User-defined versions of **DXVK**, **VKD3D**, and **DXVK-NVAPI** are not applied when using `umu-launcher`.
+            - Note: User-defined versions of **DXVK**, **VKD3D**, and **DXVK-NVAPI** are not applied when using `umu-launcher`.
       3. Navigate to the **System Options** tab.
           - **Lutris**
           - **Disable Lutris Runtime** = `Enabled`
@@ -228,10 +228,10 @@ sudo pacman -S cachyos/umu-launcher
       5. Add the following environment variables:
           - **Key**: `UMU_RUNTIME_UPDATE` *optional*
           - **Value**: `0`
-          - *This will skip Steam Linux Runtime updates for proton-cachyos. Do not use this with any Proton that utilizes the Steam Linux Runtime, such as proton-cachyos-slr, -GE, or -EM.*
+            - *This will skip Steam Linux Runtime updates for proton-cachyos. Do not use this with any Proton that utilizes the Steam Linux Runtime, such as proton-cachyos-slr, -GE, or -EM.*
           - **Key**: `PROTON_VERB` *optional*
           - **Value**: `waitforexitandrun`
-          - *This allows protonfixes to work with a corresponding GAMEID.*
+            - *This allows protonfixes to work with a corresponding GAMEID.*
       6. Click **Save** to apply the changes.
     </Steps>
   </TabItem>
@@ -243,7 +243,7 @@ sudo pacman -S cachyos/umu-launcher
           - **Use System winetricks** = *Disabled*
           - **Graphics**
           - **Enable DXVK** = `Enabled`
-          - Note: User-defined versions of **DXVK**, **VKD3D**, and **DXVK-NVAPI** are not applied when using `umu-launcher`.
+            - Note: User-defined versions of **DXVK**, **VKD3D**, and **DXVK-NVAPI** are not applied when using `umu-launcher`.
       3. Navigate to the **System Options** tab.
           - **Lutris**
           - **Disable Lutris Runtime** = `Enabled`
@@ -252,10 +252,10 @@ sudo pacman -S cachyos/umu-launcher
       5. Add the following environment variables:
           - **Key**: `UMU_RUNTIME_UPDATE` *optional*
           - **Value**: `0`
-          - *This will skip Steam Linux Runtime updates for proton-cachyos. Do not use this with any Proton that utilizes the Steam Linux Runtime, such as proton-cachyos-slr, -GE, or -EM.*
+            - *This will skip Steam Linux Runtime updates for proton-cachyos. Do not use this with any Proton that utilizes the Steam Linux Runtime, such as proton-cachyos-slr, -GE, or -EM.*
           - **Key**: `PROTON_VERB` *optional*
           - **Value**: `waitforexitandrun`
-          - *This allows protonfixes to work with a corresponding GAMEID.*
+            - *This allows protonfixes to work with a corresponding GAMEID.*
       6. Click **Save** to apply the changes.
     </Steps>
   </TabItem>
@@ -314,8 +314,8 @@ If you encounter issues with games using **Easy Anti-Cheat** (EAC) or **BattlEye
         Choose the one that ends with `x86-64_v3` if your CPU supports **[AVX2](/installation/installation_prepare#x86_64-microarchitecture-level-support)**
         Otherwise download the one ending with `x86-64`.
         :::
-        2. Decompress the file and move the folder to `~/.steam/steam/compatibilitytools.d/`
-        3. Restart Steam if you had it open.
+    2. Decompress the file and move the folder to `~/.steam/steam/compatibilitytools.d/`
+    3. Restart Steam if you had it open.
   </Steps>
 
 </details>
@@ -418,7 +418,7 @@ They are not related and are irrelevant to each other. Our suggestion lately has
 - `Proton 11.0` is the stable release from `Valve`. Use this if the game you want to play is known to work well with it.
 - `Proton Experimental` is the bleeding edge release from `Valve`. Use this if the game you want to play is relatively new, doesn't work well with the current Proton stable release, or if people recommend it on **[ProtonDB](https://www.protondb.com/)**.
 
-For new users we suggest using Valve's Proton, or Proton Experimental. If you want to experiment with the extra features, you want to use Proton outside of Steam or need fixes not present in the official Proton, there are a few custom Proton flavors you can try.
+  For new users we suggest using Valve's Proton, or Proton Experimental. If you want to experiment with the extra features, you want to use Proton outside of Steam or need fixes not present in the official Proton, there are a few custom Proton flavors you can try.
 
 - `Proton-CachyOS` is the one built and maintained by [CachyOS](https://github.com/CachyOS/proton-cachyos). Using it over `Proton Experimental` is recommended **only** if you want the extra quality-of-life features and fixes. In the CachyOS repositories you can find two different flavors if it, [proton-cachyos](https://packages.cachyos.org/package/cachyos/x86_64/proton-cachyos) and [proton-cachyos-slr](https://packages.cachyos.org/package/cachyos/x86_64/proton-cachyos-slr). We suggest using the `proton-cachyos-slr` package over the `proton-cachyos` one.
 - `Proton-EM` is a development oriented custom build made by [Etaash-mathamsetty](https://github.com/Etaash-mathamsetty/Proton). It is a very good option if you want to use `winewayland` and `FSR4` without any of the extras `Proton-CachyOS` offers. It is also the source of various improvements that `Proton-CachyOS` also includes, including but not limited to the ones mentioned before. If you are interested in the latest and greatest in `winewayland` development, this is for you.

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -161,6 +161,10 @@ starlight-tabs {
     @apply mb-3;
   }
 
+  [role="tablist"] {
+      @apply pl-0;
+  }
+
   & > div > ul {
     @apply pl-6 mt-1;
   }
@@ -172,6 +176,7 @@ starlight-tabs {
   & > div > ul {
     @apply pl-4;
   }
+
 }
 
 /* Link buttons */


### PR DESCRIPTION
THIS PR:
1) fixes tabitem margin bug introduced with this [commit](https://github.com/lukaogadze/Cachy-OS-Wiki/commit/c82405b16479253869442a583df1ec491a883fbe)

before
<img width="1291" height="495" alt="1 before" src="https://github.com/user-attachments/assets/931e359d-721a-4425-8df9-2a1da5d9d5f2" />

after
<img width="1088" height="480" alt="1 after" src="https://github.com/user-attachments/assets/ec10959c-6415-47f6-9938-f29b3e14f815" />

2) improves formatting

3) updates "Setting Up Proton-CachyOS with Lutris and Heroic" section. @loathingKernel please review it when you have time. 