### PR TITLE
updated Do Not Combine gamemode and ananicy-cpp section

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -534,7 +534,7 @@ Do not include `=` in the Key field. It should only contain the variable name.
 
 ### Do Not Combine gamemode and ananicy-cpp
 
-Due to `gamemode` and `ananicy-cpp` both trying to modify a process niceness at the same time, it can lead to conflicts and unexpected behavior. It's recommended to use gamemode without ananicy-cpp.
+Due to `gamemode` and `ananicy-cpp` both trying to modify a process niceness at the same time, it can lead to conflicts and unexpected behavior. If you want to use gamemode, it's recommended to disable or stop ananicy-cpp first.
 
 To stop ananicy-cpp, execute the following command:
 


### PR DESCRIPTION
Small change in "Do Not Combine gamemode and ananicy-cpp" section.
i wanted it to be more clear.
The gamemode hardly does anything without proper configuration, and most users just copy and paste launch options without understanding them.

