### PR TITLE
docs: fix malformed LinkButton href syntax in general_system_tweaks

### DIFF
--- a/src/content/docs/bg/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/bg/configuration/general_system_tweaks.mdx
@@ -66,7 +66,7 @@ echo power | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_pr
 
 Available preferences: `performance`, `power`, `balance_power`, `balance_performance`
 
-<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Official Benchmark for each preference</LinkButton>
+<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Official Benchmark for each preference</LinkButton>
 
 ### AMD 3D V-Cache Optimizer
 

--- a/src/content/docs/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/configuration/general_system_tweaks.mdx
@@ -66,7 +66,7 @@ echo power | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_pr
 
 Available preferences: `performance`, `power`, `balance_power`, `balance_performance`
 
-<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Official Benchmark for each preference</LinkButton>
+<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Official Benchmark for each preference</LinkButton>
 
 ### AMD 3D V-Cache Optimizer
 

--- a/src/content/docs/el/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/el/configuration/general_system_tweaks.mdx
@@ -66,7 +66,7 @@ echo power | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_pr
 
 Available preferences: `performance`, `power`, `balance_power`, `balance_performance`
 
-<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Official Benchmark for each preference</LinkButton>
+<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Official Benchmark for each preference</LinkButton>
 
 ### AMD 3D V-Cache Optimizer
 

--- a/src/content/docs/ja/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/ja/configuration/general_system_tweaks.mdx
@@ -66,7 +66,7 @@ echo power | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_pr
 
 利用可能な設定値: `performance`, `power`, `balance_power`, `balance_performance`
 
-<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">各設定値の公式ベンチマーク</LinkButton>
+<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">各設定値の公式ベンチマーク</LinkButton>
 
 ### AMD 3D V-Cache オプティマイザー
 

--- a/src/content/docs/ko/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/ko/configuration/general_system_tweaks.mdx
@@ -66,7 +66,7 @@ echo power | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_pr
 
 사용 가능한 선호도: `performance`, `power`, `balance_power`, `balance_performance`
 
-<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">각 선호도에 대한 공식 벤치마크</LinkButton>
+<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">각 선호도에 대한 공식 벤치마크</LinkButton>
 
 ### AMD 3D V-Cache 최적화
 

--- a/src/content/docs/ru/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/ru/configuration/general_system_tweaks.mdx
@@ -66,7 +66,7 @@ echo power | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_pr
 
 Доступные предпочтения: `performance`, `power`, `balance_power`, `balance_performance`
 
-<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Официальные тесты для каждого предпочтения</LinkButton>
+<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Официальные тесты для каждого предпочтения</LinkButton>
 
 ### Оптимизатор AMD 3D V-Cache
 


### PR DESCRIPTION
Fixes a syntax typo in `<LinkButton>` where standard Markdown link formatting `](...)` was mistakenly included inside the `href` attribute. 

**Files updated (across 6 locales):**
- `src/content/docs/configuration/general_system_tweaks.mdx` (en)
- `src/content/docs/bg/configuration/general_system_tweaks.mdx` (bg)
- `src/content/docs/el/configuration/general_system_tweaks.mdx` (el)
- `src/content/docs/ja/configuration/general_system_tweaks.mdx` (ja)
- `src/content/docs/ko/configuration/general_system_tweaks.mdx` (ko)
- `src/content/docs/ru/configuration/general_system_tweaks.mdx` (ru)
