### PR TITLE
Include CJK on formatting for mount folder names

### DIFF
--- a/src/content/docs/configuration/automount_with_fstab.mdx
+++ b/src/content/docs/configuration/automount_with_fstab.mdx
@@ -74,7 +74,7 @@ Let us say we want to use this drive primarily for games, a good place to mount 
 For a systemd mount file, that translates to home-$USER-games.mount (forward slashes `/` get replaced with hypens `-`) and systemd mount files go in /etc/systemd/system.
 
 :::tip
-If you want to use a space, a hyphen, or an accented character in your mount folder name, it must be formatted differently. Let's say you want to use the folder path of `/home/grzegorz/brzęczyszczykiewicz`, run the following command to get the name you need to use with your file:
+If you want to use a space, a hyphen, a CJK character, or an accented character in your mount folder name, it must be formatted differently. Let's say you want to use the folder path of `/home/grzegorz/brzęczyszczykiewicz`, run the following command to get the name you need to use with your file:
 ```bash
 systemd-escape -p --suffix=mount "/home/grzegorz/brzęczyszczykiewicz"
 ```


### PR DESCRIPTION
Updated the tip on formatting mount folder names to include about CJK characters.