### PR TITLE
Update secure_boot_setup.mdx with notes on Gigabyte motherboards

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -100,14 +100,14 @@ Now that `sbctl` is installed, you have to setup sbctl and enroll your keys to t
         ```
     </details>
 
-    :::caution[ASUS Motherboards — Do not use `--firmware-builtin`]
-    On some ASUS motherboards using the `--firmware-builtin` flag causes duplicate entries
+    :::caution[ASUS / Gigabyte Motherboards — Do not use `--firmware-builtin`]
+    On some ASUS and Gigabyte motherboards using the `--firmware-builtin` flag causes duplicate entries
     in the EFI key variables (e.g. `builtin-db` appearing multiple times in `Vendor Keys`).
     When activating Secure Boot in the UEFI settings afterwards, the board detects this
     inconsistent key structure and throws a **Secure Boot Violation** before the boot
     manager can load.
 
-    Use only `--microsoft` on ASUS boards:
+    Use only `--microsoft` on ASUS / Gigabyte boards:
 
     ```bash
     sudo sbctl enroll-keys --microsoft


### PR DESCRIPTION
Note on using the `--firmware-builtin` option on Gigabyte motherboards. It's an issue for example with the B650M AORUS ELITE AX ICE, BIOS version F42.