### PR TITLE
Fix typo in bootloader entries instruction

### DIFF
--- a/src/content/docs/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/configuration/btrfs_snapshots.mdx
@@ -146,7 +146,7 @@ Follow these steps:
         - Hold `SHIFT` to select a range of snapshots.
         :::
     4. Click on the `Delete` button located at the top of the window.
-    5. Regenerate your bootloader entires to reflect the changes:
+    5. Regenerate your bootloader entries to reflect the changes:
         <details>
             <summary>systemd-boot</summary>
             ```bash


### PR DESCRIPTION
Fix a small typo `entires` -> `entries` in _btrfs snapshot_ wiki page.