### PR TITLE
Secure Boot Setup: add a note when Setup Mode shows Enabled

### DIFF
--- a/src/content/docs/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/configuration/secure_boot_setup.mdx
@@ -133,6 +133,13 @@ Now that `sbctl` is installed, you have to setup sbctl and enroll your keys to t
         Vendor Keys:    microsoft
         ```
     </details>
+
+    :::note[Setup Mode shows Enabled?]
+    If `Setup Mode` shows **Enabled**, go to firmware settings and **temporarily disable Secure Boot**. 
+    Boot back into the system, check status of sbctl again, proceed with [Signing the Kernel Image and Boot Manager](#signing-the-kernel-image-and-boot-manager) 
+    below, then reboot and re-enable Secure Boot in firmware settings.
+    :::
+    
 </Steps>
 
 ## Signing the Kernel Image and Boot Manager


### PR DESCRIPTION
On some devices (e.g. My mechrevo laptop), after **Installing sbctl and Enrolling Keys** `sudo sbctl status` may show `Setup Mode: Enabled.` If the user reboots at this point, they may be greeted with a **Secure Boot Violation** and cannot enter the system.

This PR adds a note under step 4 (Check the status of sbctl again) explaining the workaround:

1. Enter firmware settings and temporarily disable Secure Boot
2. Boot back into the system
3. Proceed with signing the kernel image and boot manager
4. Reboot, re-enable Secure Boot in firmware settings

This worked on my laptop. 

I have previewed this change, the note shows like this, looks OK

![img](https://markdown-1308105459.cos.ap-beijing.myqcloud.com/Typora/20260702161052453.png)