### PR TITLE
Update btrfs_snapshots.mdx

### DIFF
--- a/src/content/docs/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/configuration/btrfs_snapshots.mdx
@@ -255,10 +255,31 @@ Here is a list of the most common Snapper commands.
     <details>
         <summary>Output Example:</summary>
         ```bash
-        ❯ snapper list-configs
-        Config │ Subvolume
-        ───────┼──────────
-        root   │ /
+        Key                    │ Value
+        ───────────────────────┼──────
+        ALLOW_GROUPS           │
+        ALLOW_USERS            │
+        BACKGROUND_COMPARISON  │ yes
+        EMPTY_PRE_POST_CLEANUP │ yes
+        EMPTY_PRE_POST_MIN_AGE │ 1800
+        FREE_LIMIT             │ 0.2
+        FSTYPE                 │ btrfs
+        NUMBER_CLEANUP         │ yes
+        NUMBER_LIMIT           │ 10
+        NUMBER_LIMIT_IMPORTANT │ 10
+        NUMBER_MIN_AGE         │ 3600
+        QGROUP                 │
+        SPACE_LIMIT            │ 0.5
+        SUBVOLUME              │ /
+        SYNC_ACL               │ no
+        TIMELINE_CLEANUP       │ yes
+        TIMELINE_CREATE        │ no
+        TIMELINE_LIMIT_DAILY   │ 0
+        TIMELINE_LIMIT_HOURLY  │ 0
+        TIMELINE_LIMIT_MONTHLY │ 0
+        TIMELINE_LIMIT_WEEKLY  │ 0
+        TIMELINE_LIMIT_YEARLY  │ 0
+        TIMELINE_MIN_AGE       │ 1800
         ```
     </details>
 </details>


### PR DESCRIPTION
correction to display the output of 'sudo snapper get-config' instead of 'snapper list-configs'