### PR TITLE
Update btrfs_snapshots.mdx

### DIFF
--- a/src/content/docs/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/configuration/btrfs_snapshots.mdx
@@ -69,7 +69,7 @@ sudo pacman -Syu grub-btrfs-support
 A few things to consider before managing snapshots. **Applies to both CLI and GUI methods.**
 
 - A maximum of 10 snapshots are recommended to be kept. Beyond that, snapshots become too old and less useful. In a worst case scenario, reverting to an old snapshot may introduce compatibility issues with newer software versions.
-- Snapshots ideally are meant to be used to recover purposes. Although you can use them to undo changes to files without restoring the entire snapshot.
+- Snapshots ideally are meant to be used for recovery purposes. Although you can use them to undo changes to files without restoring the entire snapshot.
 - Add a meaningful description when creating snapshots. This will help you identify the purpose of each snapshot later on.
 
 ### Btrfs Assistant (GUI)


### PR DESCRIPTION
Fixed grammatical issue on line 71 - "to be used to recover purposes." -> "to be used for recovery purposes."