### PR TITLE
Change keybinds.lua to binds.lua

### DIFF
--- a/src/content/docs/configuration/desktop_environments/hyprland.mdx
+++ b/src/content/docs/configuration/desktop_environments/hyprland.mdx
@@ -46,7 +46,7 @@ You will want to configure a few user-specific things after setup. For additiona
 
 ## Keybinds
 
-Most of the key combinations require the use of the mod key which in our case is the Windows/Command key (referenced as SUPER), you can change it in `keybinds.lua`.
+Most of the key combinations require the use of the mod key which in our case is the Windows/Command key (referenced as SUPER), you can change it in `binds.lua`.
 
 ### Window Management
 


### PR DESCRIPTION
As I wrote in the [comment on the German translation](https://github.com/CachyOS/wiki/pull/529#issuecomment-5042215493) in line 49 it still mentions the old fine keybinds.lua instead of the new binds.lua file. @Jinra is the fix I proposed correct?