### PR TITLE
Update the German configuration/boot_manager_configuration.mdx

### DIFF
--- a/src/content/docs/de/configuration/boot_manager_configuration.mdx
+++ b/src/content/docs/de/configuration/boot_manager_configuration.mdx
@@ -226,5 +226,5 @@ Obwohl die Einträge automatisch verwaltet werden, kannst du die **Kernel-Parame
 * [loader.conf Handbuchseite](https://man.archlinux.org/man/loader.conf.5)
 * [rEFInd: Konfiguration des Bootmanagers](https://www.rodsbooks.com/refind/configfile.html)
 * [GRUB-Handbuch: Konfiguration](https://www.gnu.org/software/grub/manual/grub/grub.html#Configuration)
-* [Offizielle Limine Konfigurations-Doku](https://github.com/limine-bootloader/limine/blob/v9.x/CONFIG.md)
+* [Offizielle Limine Konfigurations-Dokumentation](https://github.com/limine-bootloader/limine/blob/v12.x/CONFIG.md)
 * [limine-entry-tool Projekt](https://gitlab.com/Zesko/limine-entry-tool)


### PR DESCRIPTION
I updated the German translation for the configuration/boot_manager_configuration.mdx file to include the commit [based on this link](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/boot_manager_configuration.mdx?since=2025-12-21T14:20:06.000Z) from the https://wiki.cachyos.org/localization/