### PR TITLE
Update the German configuration/dual_gpu.mdx

### DIFF
--- a/src/content/docs/de/configuration/dual_gpu.mdx
+++ b/src/content/docs/de/configuration/dual_gpu.mdx
@@ -106,6 +106,12 @@ prime-run %command%
 Achte darauf, `%command%` nach `prime-run` hinzuzufügen. Denk dran, dass Spieloptionen nach dem Platzhalter kommen,
 während Systemumgebungsvariablen oder Befehle davor stehen sollten.
 
+Um ein Spiel mit der integrierten Grafik laufen zu lassen, kannst du die folgende Launch Option als ein Beispiel für eine Radeon iGPU benutzen. Der Vorteil ist, dass du bei Spielen mit niedrigen Grafikanforderungen eine längere Batterielaufzeit und niedrigere Lüfterlautstärke haben kannst.
+
+```bash
+VK_DRIVER_FILES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/usr/share/vulkan/icd.d/radeon_icd.i686.json %command%
+```
+
 <br />
 <ImageComponent imgsrc={import('~/assets/images/steam-prime.png')} />
 


### PR DESCRIPTION
I updated the German translation for the configuration/dual_gpu.mdx file to include the commit [based on this link](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/dual_gpu.mdx?since=2025-12-21T14:20:06.000Z) from the https://wiki.cachyos.org/localization/