### PR TITLE
Update the German configuration/general_system_tweaks.mdx

### DIFF
--- a/src/content/docs/de/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/de/configuration/general_system_tweaks.mdx
@@ -139,9 +139,9 @@ Erstellt von [firelzrd](https://github.com/firelzrd)
 :::note
 CachyOS enthält den stabilen Zweig von ADIOS im Kernel.
 
-Aktuelle Version in **linux-cachyos**: `3.1.7`
+Aktuelle Version in **linux-cachyos**: `3.2.0`
 
-Aktuelle Version in **linux-cachyos-rc**: `3.1.7`
+Aktuelle Version in **linux-cachyos-rc**: `3.2.0`
 :::
 
 Kurze Einführung aus der README:


### PR DESCRIPTION
I updated the German translation for the configuration/general_system_tweaks.mdx file to include the commit [based on this link](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/general_system_tweaks.mdx?since=2026-06-28T22:49:25.000Z) from the https://wiki.cachyos.org/localization/
Note: I only had to apply one of the two commits, commit 5cc318a already included the changes in the de file.
