### PR TITLE
Update the German installation/installation_t2macbook.mdx

### DIFF
--- a/src/content/docs/de/installation/installation_t2macbook.mdx
+++ b/src/content/docs/de/installation/installation_t2macbook.mdx
@@ -98,7 +98,7 @@ Für einen zusätzlichen Überblick über die Vorbereitung eines T2-Macs für Li
     *   Du solltest dich nun über das Netzwerk-Applet in der Taskleiste mit WLAN-Netzwerken verbinden können.
 3.  **Das CachyOS-Installationsprogramm ausführen:**
     *   Starte das CachyOS-Installationsprogramm vom Desktop oder aus dem Anwendungsmenü.
-    *   Folge dem Standard-Installationsverfahren und beziehe dich dabei auf den Leitfaden [Installation on Root](/de/installation/installation_on_root).
+    *   Folge dem Standard-Installationsverfahren und beziehe dich dabei auf den Leitfaden [CachyOS Installation Desktop/Laptop](/de/installation/installation_on_root).
     *   Wähle bei der Partitionierung den zuvor erstellten freien Speicherplatz aus. Lass das Installationsprogramm die Formatierung übernehmen.
         :::caution[Vorsicht bei der Partitionierung]
         Sei **sehr vorsichtig** beim Partitionierungsschritt im Installationsprogramm. Stelle sicher, dass du den richtigen freien Speicherplatz auswählst, den du vorbereitet hast, und **lösche oder formatiere nicht** versehentlich deine bestehende macOS-Partition, besonders wenn du ein Dual-Boot beabsichtigst. Überprüfe deine Auswahl doppelt, bevor du fortfährst.


### PR DESCRIPTION
I updated the German translation for the installation/installation_t2macbook.mdx file to include the commit [based on this link](https://github.com/CachyOS/wiki/commits/next/src/content/docs/installation/installation_t2macbook.mdx?since=2026-01-03T21:43:45.000Z) from the https://wiki.cachyos.org/localization/
Note: Only one of two commits, commit a2387a5, had to be applied