### PR TITLE
Updated the German configuration/btrfs_snapshots.mdx

### DIFF
--- a/src/content/docs/de/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/de/configuration/btrfs_snapshots.mdx
@@ -426,7 +426,7 @@ Wenn der Snapshot, aus dem du wiederherstellen möchtest, ein Kernel-Update bein
             <MultipleImageComponent
                 images={[
                 import('~/assets/images/limine-snapshotMenu-2.jpg'),
-                import('~/assets/images/limine-snapshotMenu-1.jpg')]}
+                import('~/assets/images/limine-snapshotMenu-3.jpg')]}
             />
         3. Dein System befindet sich jetzt im `read-only-Modus`. Eine Pop-up-Benachrichtigung sollte erscheinen, die anzeigt, dass ein Snapshot erkannt wurde und dich fragt, ob du daraus wiederherstellen möchtest:
             <ImageComponent imgsrc={import('~/assets/images/kde-snapshot-popup.png')} />

--- a/src/content/docs/de/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/de/configuration/btrfs_snapshots.mdx
@@ -255,10 +255,31 @@ Hier ist eine Liste der häufigsten Snapper-Befehle.
     <details>
         <summary>Ausgabebeispiel:</summary>
         ```bash
-        ❯ snapper list-configs
-        Config │ Subvolume
-        ───────┼──────────
-        root   │ /
+        Key                    │ Value
+        ───────────────────────┼──────
+        ALLOW_GROUPS           │
+        ALLOW_USERS            │
+        BACKGROUND_COMPARISON  │ yes
+        EMPTY_PRE_POST_CLEANUP │ yes
+        EMPTY_PRE_POST_MIN_AGE │ 1800
+        FREE_LIMIT             │ 0.2
+        FSTYPE                 │ btrfs
+        NUMBER_CLEANUP         │ yes
+        NUMBER_LIMIT           │ 10
+        NUMBER_LIMIT_IMPORTANT │ 10
+        NUMBER_MIN_AGE         │ 3600
+        QGROUP                 │
+        SPACE_LIMIT            │ 0.5
+        SUBVOLUME              │ /
+        SYNC_ACL               │ no
+        TIMELINE_CLEANUP       │ yes
+        TIMELINE_CREATE        │ no
+        TIMELINE_LIMIT_DAILY   │ 0
+        TIMELINE_LIMIT_HOURLY  │ 0
+        TIMELINE_LIMIT_MONTHLY │ 0
+        TIMELINE_LIMIT_WEEKLY  │ 0
+        TIMELINE_LIMIT_YEARLY  │ 0
+        TIMELINE_MIN_AGE       │ 1800
         ```
     </details>
 </details>


### PR DESCRIPTION
Updated the German translation for the configuration/btrfs_snapshots.mdx file based on [this link in the CachyOS localization status](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/btrfs_snapshots.mdx?since=2026-01-30T15:37:00.000Z).
Note: two of the four commits were typos in English so obviously only 2/4 commits in this translation!