### PR TITLE
Updated the German desktop_environments/hyprland.mdx

### DIFF
--- a/src/content/docs/de/configuration/desktop_environments/hyprland.mdx
+++ b/src/content/docs/de/configuration/desktop_environments/hyprland.mdx
@@ -146,18 +146,18 @@ Die meisten Tastenkombinationen erfordern die Verwendung der Mod-Taste, die in u
 Wenn du bereits eine andere DE/WM installiert hast, kannst du mit der folgenden Anleitung zu diesen Dots migrieren.
 
 :::note
-Es ist zwar möglich, dasselbe Benutzerkonto mit Hyprland zu verwenden, es wird jedoch dringend empfohlen, ein neues Benutzerkonto zu erstellen (Anleitung enthalten). Selbst mit einem neuen Benutzerkonto kann es zu Daemon-Konflikten mit deiner vorherigen DE/WM kommen.
+Es ist zwar möglich, dasselbe Benutzerkonto mit Hyprland zu verwenden, es wird jedoch dringend empfohlen, ein neues Benutzerkonto zu erstellen (Anleitung enthalten). Selbst mit einem neuen Benutzerkonto kann es zu Daemon-Konflikten mit deiner vorherigen DE/WM kommen, weswegen empfohlen wird, eine einzelne Umgebung zu verwenden.
 :::
 
 Stelle sicher, dass du die Variablen in den spitzen Klammern (\<\>) unten einschließlich der spitzen Klammern selbst ersetzt.
 
-1. Führe `sudo pacman -S cachyos-hypr-noctalia` aus. Wenn du einen Paketkonflikt mit einem anderen `-settings`-Paket hast (wie z. B. `cachyos-kde-settings`), kannst du das konfliktierende Paket löschen.
-1. Wenn du die Noctalia v5 Beta (oder -git) verwenden möchtest, folge stattdessen den untenstehenden Schritten:
-    * Installiere Noctalia v5 Beta mit `sudo pacman -Syu noctalia`. Wenn du die -git-Version möchtest, führe `paru -Syu noctalia-git` oder `shelly -AI noctalia-git` aus
-1. Um einen neuen Benutzer zu erstellen, führe `sudo useradd -m <new_user> -s /bin/fish` aus.
+1. Führe `sudo pacman -S cachyos-hypr-noctalia` aus. Wenn du einen Paketkonflikt mit einem anderen `-settings`-Paket hast (wie z. B. `cachyos-kde-settings`), kannst du das konfliktierende Paket löschen, da diese Pakete keine Auswirkung auf die aktuellen Benutzer haben.
+1. Um einen neuen Benutzer zu erstellen, führe `sudo useradd -m <new_user> -s /bin/fish` aus. Du kannst auch eine andere Shell deiner Wahl, z.B. /bin/zsh verwenden.
 1. Führe `sudo passwd <new_user>` aus, um ein Passwort für das Konto festzulegen.
     * Wenn du _wirklich_ dasselbe Konto verwenden möchtest (wovon dringend abgeraten wird), kopiere stattdessen die Dots in den Benutzerordner `cp -r /etc/skel/. ~` (erstelle zuerst ein Backup/Snapshot!)
-1. Aktiviere optional sddm als deinen Display-Manager, falls das noch nicht der Fall ist. Führe dazu `systemctl disable display-manager` und `systemctl enable sddm` aus. Der [Noctalia-Greeter](https://github.com/noctalia-dev/noctalia-greeter) passt ebenfalls gut zu Noctalia, ist aber etwas aufwendiger einzurichten.
+1. Installiere optional `noctalia-greeter` oder `sddm` als Display-Manager. `noctalia-greeter` integriert sich besser in Noctalia, ist jedoch etwas aufwendiger einzurichten. 
+    * Um sddm als Display-Manager zu verwenden, installiere es mit `sudo pacman -Syu sddm` und führe anschließend `systemctl disable display-manager` sowie `systemctl enable sddm` aus. 
+    * Um [Noctalia Greeter](https://github.com/noctalia-dev/noctalia-greeter) zu installieren, führe `sudo pacman -Syu noctalia-greeter` aus und befolge den Abschnitt „Setting up greetd“ in der verlinkten Dokumentation. Führe danach `systemctl disable display-manager` und `systemctl enable greetd` aus.
 1. Führe einen Neustart durch und wähle die Hyprland (UWSM)-Sitzung in deinem Display-Manager.
     * Wenn die Shell nicht lädt, versuche, erneut neu zu starten.
 1. Melde dich an und folge dem Abschnitt [Post-Install-Einrichtung](#post-install-einrichtung).

--- a/src/content/docs/de/configuration/desktop_environments/switch_desktop.mdx
+++ b/src/content/docs/de/configuration/desktop_environments/switch_desktop.mdx
@@ -101,6 +101,7 @@ Hier ist eine Liste aller Repositories der verschiedenen DEs und WMs, die von Ca
 - [KDE Plasma](https://github.com/CachyOS/cachyos-kde-settings)
 - [GNOME](https://github.com/CachyOS/cachyos-gnome-settings)
 - [Niri](https://github.com/cachyos/cachyos-niri-noctalia)
+- [Hyprland](https://github.com/CachyOS/cachyos-hypr-noctalia)
 - [MangoWM](https://github.com/CachyOS/cachyos-mangowc-dms)
 - [i3](https://github.com/CachyOS/cachyos-i3wm-settings)
 - [Qtile](https://github.com/CachyOS/cachyos-qtile-settings)


### PR DESCRIPTION
Updated the German translation for the desktop_environments/hyprland.mdx file based on [this link in the CachyOS localization status](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/desktop_environments/hyprland.mdx?since=2026-07-22T13:13:46.000Z).