### PR TITLE
Updated the German configuration/dual_gpu.mdx

### DIFF
--- a/src/content/docs/de/configuration/dual_gpu.mdx
+++ b/src/content/docs/de/configuration/dual_gpu.mdx
@@ -158,14 +158,3 @@ die Anwendung über das Symbol startest, wird sie mit der integrierten Grafik an
 Falls sie nicht verfügbar ist, stelle sicher, dass du `switcheroo-control` installiert und
 dessen Dienst aktiviert hast, da alle Desktop-Umgebungen für diese
 Funktionalität darauf angewiesen sind.
-
-## Fehlerbehebung
-
-### "Mein externer Monitor ist bei PRIME sehr laggy"
-
-Das ist ein bekanntes Problem des NVIDIA-Treibers. Du solltest den neuesten NVIDIA-
-Treiber installiert haben und Wayland mit einem Compositor verwenden, der expliziten Sync unterstützt.
-Für GNOME wurde dies in Version 46.2 behoben. Für Plasma 6 wird es wahrscheinlich
-mit 6.1 behoben, obwohl einige Benutzer bereits bei 6.0 von normaler Leistung berichten.
-Andere Umgebungen/Fenstermanager haben dieses Problem immer noch, also musst du auf die
-neueste Version von GNOME oder Plasma wechseln, um es zu beheben.


### PR DESCRIPTION
Updated the German translation for configuration/dual_gpu.mdx file based on [this link in the CachyOS localization status](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/dual_gpu.mdx?since=2026-07-22T13:17:47.000Z).
Note: I only did the configuration/dual_gpu.mdx part of the commit, otherwise I would overwrite what still needs to be done on configuration/gaming.mdx