### PR TITLE
[DOCS]: Fix typo in Hyprland window management table in hyprland.mdx

### DIFF
--- a/src/content/docs/configuration/desktop_environments/hyprland.mdx
+++ b/src/content/docs/configuration/desktop_environments/hyprland.mdx
@@ -78,7 +78,7 @@ Most of the key combinations require the use of the mod key which in our case is
 | Move focused window to next monitor | <Kbd linux="Super+Shift+Scroll&nbsp;down" /> |
 | Move focused window to previous monitor | <Kbd linux="Super+Shift+Scroll&nbsp;up" /> |
 | Move window (mouse) | <Kbd linux="Super+Left&nbsp;Click" /> |
-| Reize window (mouse) | <Kbd linux="Super+Right&nbsp;Click" /> |
+| Resize window (mouse) | <Kbd linux="Super+Right&nbsp;Click" /> |
 
 ### Launcher
 


### PR DESCRIPTION
Fixed typo where it says "Reize" instead of "Resize"