### PR TITLE
hyprland.mdx: updated German translation

### DIFF
--- a/src/content/docs/de/configuration/desktop_environments/hyprland.mdx
+++ b/src/content/docs/de/configuration/desktop_environments/hyprland.mdx
@@ -23,11 +23,11 @@ Bei Problemen im Zusammenhang mit Noctalia schau bitte in die [Noctalia-Dokument
 Du solltest nach der Einrichtung einige benutzerspezifische Dinge konfigurieren. Weitere Einstellungen findest du im Hyprland-Wiki unter https://wiki.hypr.land/Configuring/Start/
 
 ### Verzeichnis `~/.config/hypr/config`
-* `monitors.lua` richtet deine Monitore ein. (weitere Informationen unter https://wiki.hypr.land/Configuring/Basics/Monitors/)
-  * `output` sollte deine Monitor-ID sein; du kannst `hyprctl monitors` ausführen, um diese ID zu erhalten (z. B. `DP-1`).
+* `monitors.lua` richtet deine Monitore ein. (weitere Informationen unter https://wiki.hypr.land/Configuring/Basics/Monitors/) Ein standardmäßiger Block ist bereits erstellt, für zusätzliche Monitore kannst du weitere hinzufügen.
+  * `output` passe den Wert deines Monitors lieber in `variables.lua` an; du kannst `hyprctl monitors` ausführen, um diese ID zu erhalten (z. B. `DP-1`). Wenn du weitere Monitore hinzufügst, nenne sie MONITOR2, MONITOR3, usw. und füge sie ebenfalls `variables.lua` hinzu.
   * `mode` sollte in einem Format wie `1920x1080@60` angegeben werden (horizontal x vertikal @ Bildwiederholrate).
   * `scale` Standardmäßig solltest du `1` verwenden, aber bei Monitoren mit höherer Auflösung kann ein höherer Wert sinnvoll sein.
-  * Nach der ersten Anpassung musst du einen Neustart durchführen, zukünftige Anpassungen sollten aber sofort in Effekt treten.
+  * Nach der ersten Anpassung musst du eventuell einen Neustart durchführen, zukünftige Anpassungen sollten aber sofort in Effekt treten.
 * `variables.lua`
   * Füge hier deine Monitor-Zuweisungen hinzu. Dein `PRIMARY_MONITOR` und `MONITOR1` sollten generell derselbe Monitor sein. Du kannst `MONITOR#`-Variablen nach Bedarf entfernen/hinzufügen.
   * Definiere die Anzahl der Arbeitsflächen pro Monitor. Überschreite nicht 10.


### PR DESCRIPTION
Updated the German translation of the configuration/desktop_environments/hyprland.mdx file based on the [link in the CachyOS localization status](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/desktop_environments/hyprland.mdx?since=2026-07-26T21:19:01.000Z).