### PR TITLE
btrfs_snapshots.mdx: Updated Russian translation

### DIFF
--- a/src/content/docs/ru/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/ru/configuration/btrfs_snapshots.mdx
@@ -255,10 +255,31 @@ EMPTY_PRE_POST_MIN_AGE="1800"
     <details>
         <summary>Пример вывода:</summary>
         ```bash
-        ❯ snapper list-configs
-        Config │ Subvolume
-        ───────┼──────────
-        root   │ /
+        Key                    │ Value
+        ───────────────────────┼──────
+        ALLOW_GROUPS           │
+        ALLOW_USERS            │
+        BACKGROUND_COMPARISON  │ yes
+        EMPTY_PRE_POST_CLEANUP │ yes
+        EMPTY_PRE_POST_MIN_AGE │ 1800
+        FREE_LIMIT             │ 0.2
+        FSTYPE                 │ btrfs
+        NUMBER_CLEANUP         │ yes
+        NUMBER_LIMIT           │ 10
+        NUMBER_LIMIT_IMPORTANT │ 10
+        NUMBER_MIN_AGE         │ 3600
+        QGROUP                 │
+        SPACE_LIMIT            │ 0.5
+        SUBVOLUME              │ /
+        SYNC_ACL               │ no
+        TIMELINE_CLEANUP       │ yes
+        TIMELINE_CREATE        │ no
+        TIMELINE_LIMIT_DAILY   │ 0
+        TIMELINE_LIMIT_HOURLY  │ 0
+        TIMELINE_LIMIT_MONTHLY │ 0
+        TIMELINE_LIMIT_WEEKLY  │ 0
+        TIMELINE_LIMIT_YEARLY  │ 0
+        TIMELINE_MIN_AGE       │ 1800
         ```
     </details>
 </details>
@@ -311,14 +332,14 @@ EMPTY_PRE_POST_MIN_AGE="1800"
 <details>
     <summary>Создать новый снимок:</summary>
     ```bash
-    sudo snapper create --type single --description "Мое описание снимка"
+    sudo snapper create --type single --description "My Snapshot Description"
     ```
 </details>
 
 <details>
     <summary>Изменить снимок:</summary>
     ```bash
-    sudo snapper modify <опция> <номер_снимка>
+    sudo snapper modify <option> <snapshot_number>
     ```
     <details>
         <summary>Доступные опции:</summary>
@@ -334,7 +355,7 @@ EMPTY_PRE_POST_MIN_AGE="1800"
         <details>
             <summary>Пример: Изменение описания снимка 729:</summary>
             ```bash
-            sudo snapper modify 729 --description 'Мое новое описание снимка'
+            sudo snapper modify 729 --description 'My New Snapshot Description'
             ```
         </details>
     </details>
@@ -348,7 +369,7 @@ EMPTY_PRE_POST_MIN_AGE="1800"
     <details>
     <summary>Удалить один снимок:</summary>
     ```bash
-    sudo snapper delete <номер_снимка>
+    sudo snapper delete <snapshot_number>
     ```
     </details>
     <details>


### PR DESCRIPTION
As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one and if things are or aren't translated.

---

I want the process to be as transparent as possible, which is why I'm listing prompt, model, soft- and hardware:

Prompt used: "Today we are going to translate some technical documentation. Specifically we are translating the wiki of the Arch-based Linux distribution CachyOS.

In general, the wiki is supposed to be English-first with the translations being there to complement it. A lot of the words and phrases should therefore be kept in English.
For example it makes no sense to translate things which are likely to be displayed in English anyway like an exemplary terminal output. Further, it makes no sense to translate the actual names of things into the requested language, "bootloader" being an example, as people know what a bootloader is.
Keeping that in mind, the overall goal isn't to literally translate every word, rather it's to translate the context around it so a native reader can grasp the concept and what he has to do. As an Arch-based Linux distro it's expected for the user to, at least on a very shallow level, to be aware of the concepts of a bootloader, a kernel and so on, but maybe the user doesn't have the reading-comprehension to understand what he has to do if he only reads the English wiki.

Structurally the wiki has the regular English files in a directory like /src/content/docs/configuration/gaming.mdx while the files in other languages have the exact same file name but are in a directory with an ISO language code like the corresponding German translation being in /src/content/docs/de/configuration/gaming.mdx. That has to be kept in mind when a link refers to another site of the wiki, as the language code has to be added in the translation, otherwise the link will send the user to the English page. For links that point outward of the wiki itself, they can simply be kept the same.

The translated pages usually already exist but are outdated by a few months compared to the main English ones, therefore a lot of the translation can and should be kept. You should apply all the differences but keep what doesn't need to be changed so it's only an update with minimal lines changed, not a total rewrite of the entire page. The formating should be the exact same as the English one with every line-break and every punctuation mark being the exact same as that changes how the page is rendered. A ` stays a `, a ' stays a ' and so on, they are not interchangeable.

Now, we are going to translate the English file /home/c/Dokumente/GitHub/wiki/src/content/docs/configuration/btrfs_snapshots.mdx to Russian which is the /home/c/Dokumente/GitHub/wiki/src/content/docs/ru/configuration/btrfs_snapshots.mdx file."

Model used: [A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

Software used: My own AUR packages [llama.cpp-sycl](https://aur.archlinux.org/packages/llama.cpp-sycl) and [intel-deep-learning-essentials](https://aur.archlinux.org/packages/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

Hardware used: Sparkle Intel Arc Pro B70 with 32GB VRAM
