### PR TITLE
enabling_(...)_in_google_chrome.mdx: Updated Russian translation

### DIFF
--- a/src/content/docs/ru/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/ru/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -18,7 +18,6 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 * **amdgpu_top:** Установите `amdgpu_top` из репозитория через менеджер пакетов, если вы хотите отслеживать активность ГП AMD через терминал.
 * **nvtop:** (только для ГП Intel) Установите `nvtop` (Lunar Lake) и `intel-gpu-tools` (до Lunar Lake) через менеджер пакетов Shelly, если вы хотите отслеживать активность ГП Intel через терминал.
 
-
 ## Ваш вклад
 
 Это руководство можно расширять. Если у вас есть рабочая настройка аппаратного ускорения для определённого ГП и браузера на базе Chromium, внесите свой вклад, добавив новый раздел в «Конфигурации ГП и браузеров». Укажите:
@@ -29,7 +28,42 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 * **Путь к файлу:** Полный путь к файлу флагов.
 * **Примечания (необязательно):** Ключевые драйверы, пакеты или особенности настройки.
 
-## Шаги настройки
+### Шаблон для вашего вклада
+
+#### [Ваш браузер] - [Ваша модель ГП] (Автор: [Ваше имя/Ник])
+
+* **Браузер:** [например, Brave, Ungoogled Chromium, Microsoft Edge, Vivaldi, Opera, Chromium]
+
+* **ГП:** [например, NVIDIA GeForce RTX 3080, Intel Iris Xe]
+
+* **Путь к файлу флагов:** (Очень важно, различается для каждого браузера!)
+
+  * Распространённые пути к `.conf` файлам:
+
+    * Chromium: `~/.config/chromium-flags.conf`
+
+    * Brave Browser: `~/.config/brave-flags.conf`
+
+    * Ungoogled Chromium: `~/.config/ungoogled-chromium-flags.conf`
+
+* Изменение `.desktop` файла:
+    * Некоторые браузеры (Brave, Edge, Vivaldi, Opera) могут требовать редактирования строки `Exec=` в их `.desktop` файле (сначала скопируйте его из `/usr/share/applications/` в `~/.local/share/applications/`).
+
+Содержимое флагов (для `.conf` файла или строки `Exec=`):
+
+```bash
+# Вставьте ваши флаги сюда.
+# Для .desktop файлов флаги перечисляются через пробел после исполняемого файла.
+```
+
+**Примечания (необязательно):**
+
+* Требуемые драйверы (например, `nvidia-dkms`, `intel-media-driver`).
+
+* Особые соображения по настройке или инструкции по изменению `.desktop` файла.
+
+
+### Шаги настройки
 
 <Steps>
 
@@ -75,7 +109,7 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
     ```bash
     sudo nvtop
     ```
-2. Начните воспроизведение видео в вашем браузere (например, на YouTube).
+2. Начните воспроизведение видео в вашем браузере (например, на YouTube).
 3. Наблюдайте за процентом `ENC/DEC` в `nvtop`, процент должен увеличиться, если декодирование видео работает аппаратно.
 
 </Steps>
@@ -139,10 +173,10 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 --use-gl=angle
 --use-angle=vulkan
 --enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
---ozone-platform-hint=x11
 ```
 
-**Примечания:** Использует Vulkan (через ANGLE) и VA-API. Флаг `--ozone-platform-hint=x11` может быть полезен даже в Wayland для определённых путей ускорения.
+**Примечания:** Использует Vulkan (через ANGLE) и VA-API. Флаг `--ozone-platform=x11` может быть полезен в Wayland для определённых путей ускорения.
+
 
 ### Nvidia RTX 4090 (Vivaldi)
 
@@ -171,12 +205,13 @@ Exec=/usr/bin/vivaldi-stable --enable-features=VaapiVideoDecoder,AcceleratedVide
 В качестве альтернативы для KDE можно сделать следующее:
 1. Удалите все ярлыки Vivaldi с панели задач / менеджера задач
 2. Найдите `Vivaldi` в списке меню приложений
-3. Щёлкните правой кнопкой мыши по записи в меню приложений и выберите `Изменить приложение...`
-4. В разделе `Аргументы командной строки` добавьте следующие аргументы перед последним аргументом `%U`:
+3. Щёлкните правой кнопкой мыши по записи в меню приложений и выберите `Edit Application...`
+4. В разделе `Command-line arguments` добавьте следующие аргументы перед последним аргументом `%U`:
 ```
 --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL
 ```
 5. Запустите Vivaldi и закрепите процесс на вашей панели задач / менеджере задач
+
 
 ### AMD Radeon RX 550 (UnGoogled Chromium)
 
@@ -188,17 +223,9 @@ Exec=/usr/bin/vivaldi-stable --enable-features=VaapiVideoDecoder,AcceleratedVide
 
 ```bash
 --enable-wayland-ime
---ozone-platform=wayland
 --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,WaylandSessionManagement,WaylandTextInputV3,WaylandUiScale,WaylandWindowDecorations
 ```
 
-**Примечания:**
-
-Если вы используете X11, используйте это:
-```bash
---ozone-platform=x11
---enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder
-```
 
 ### Nvidia RTX 5070 TI (Brave)
 
@@ -230,11 +257,11 @@ Exec=/usr/bin/vivaldi-stable --enable-features=VaapiVideoDecoder,AcceleratedVide
 --enable-gpu-rasterization
 --enable-zero-copy
 --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,CanvasOopRasterization,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
---ozone-platform-hint=auto
 ```
 
 **Примечания:**
-Работает на Wayland. Для предотвращения торможения интерфейса необходимо отключить «Ambient Mode» в настройках YouTube.
+Необходимо отключить «Ambient Mode» в настройках YouTube, чтобы предотвратить торможение интерфейса.
+
 
 ### Vivaldi - AMD Radeon RX 9070 XT (Автор: tTrmc)
 
@@ -248,7 +275,6 @@ Exec=/usr/bin/vivaldi-stable --enable-features=VaapiVideoDecoder,AcceleratedVide
 --ignore-gpu-blocklist
 --enable-gpu-rasterization
 --enable-zero-copy
---ozone-platform=wayland
 --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
 ```
 
@@ -256,39 +282,106 @@ Exec=/usr/bin/vivaldi-stable --enable-features=VaapiVideoDecoder,AcceleratedVide
 - Протестировано на CachyOS с ядром 6.19.11-1-cachyos, Mesa 26.0.3, GNOME (Wayland), разрешение 2560x1440.
 - Подтверждено: `vivaldi://gpu` отображает Video Decode и Video Encode как «Hardware accelerated». Полная поддержка кодеков: декодирование H264, VP9, HEVC, AV1 и кодирование H264, AV1. Вкладка DevTools Media показывает `VaapiVideoDecoder` как активный декодер.
 - RX 9070 XT (RDNA 4) может находиться в списке блокировок ГП Chromium, поэтому флаг `--ignore-gpu-blocklist` обязателен.
-- В логе может появиться предупреждение: `'--ozone-platform=wayland' is not compatible with Vulkan` — это не мешает работе аппаратного ускорения. Как вариант, можно использовать `--ozone-platform-hint=auto`.
+- В логе может появиться предупреждение: `'--ozone-platform=wayland' is not compatible with Vulkan` — это не мешает работе аппаратного ускорения.
 
----
 
-### Шаблон для вашего вклада
+### Google Chrome - AMD Radeon RX 9070 XT (Автор: naknak)
 
-### [Ваш браузер] - [Ваша модель ГП] (Автор: [Ваше имя/Ник])
+* **Браузер:** Google Chrome
 
-* **Браузер:** [например, Brave, Ungoogled Chromium, Microsoft Edge, Vivaldi, Opera, Chromium]
+* **ГП:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
 
-* **ГП:** [например, NVIDIA GeForce RTX 3080, Intel Iris Xe]
-
-* **Путь к файлу флагов:** (Очень важно, различается для каждого браузера!)
-
-  * Распространённые пути к `.conf` файлам:
-
-    * Chromium: `~/.config/chromium-flags.conf`
-
-    * Brave Browser: `~/.config/brave-flags.conf`
-
-    * Ungoogled Chromium: `~/.config/ungoogled-chromium-flags.conf`
-
-  * Изменение `.desktop` файла: Некоторые браузеры (Brave, Edge, Vivaldi, Opera) могут требовать редактирования строки `Exec=` в их `.desktop` файле (сначала скопируйте его из `/usr/share/applications/` в `~/.local/share/applications/`).
-
-Содержимое флагов (для `.conf` файла или строки `Exec=`):
+* **Путь к файлу флагов:** `~/.config/chrome-flags.conf`
 
 ```bash
-# Вставьте ваши флаги сюда.
-# Для .desktop файлов флаги перечисляются через пробел после исполняемого файла.
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--use-gl=angle
+--use-angle=vulkan
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo,Vulkan,VulkanFromANGLE,DefaultANGLEVulkan
 ```
 
-**Примечания (необязательно):**
+**Примечания:**
+- Декодирование **и** кодирование видео отображаются как `Hardware accelerated` на странице `chrome://gpu`.
+- Иногда проверка вкладки `media` на видео с YouTube показывает аппаратное ускорение, а иногда нет.
 
-* Требуемые драйверы (например, `nvidia-dkms`, `intel-media-driver`).
+### Vivaldi - AMD Ryzen AI Max+ 395 (Автор: woutervanelten)
 
-* Особые соображения по настройке или инструкции по изменению `.desktop` файла.
+* **Браузер:** Vivaldi (8.0.4033.35)
+
+* **APU:** AMD Radeon 8060S (GFX1151/Strix Halo)
+
+* **Путь к файлу флагов:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--ozone-platform=wayland
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```
+
+**Примечания:**
+- Протестировано на CachyOS с ядром 7.0.10-2-cachyos, Mesa 26.1.1, GNOME (Wayland), разрешение 5120x1440.
+- Подтверждено: `vivaldi://gpu` отображает Canvas, Compositing, Rasterization, Video Decode, Video Encode, WebGL, WebGPU и WebGPU interop как «Hardware accelerated». Полная поддержка кодеков: декодирование H264, H265, VP9, AV1 и кодирование H264, H265 и AV1.
+
+### Vivaldi - NVIDIA RTX 5090 (Автор: icetea)
+
+* **Браузер:** Vivaldi (8.1)
+
+* **ГП:** NVIDIA GeForce RTX 5090 (Blackwell)
+
+* **Путь к файлу флагов:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks
+--use-gl=angle
+--use-angle=gl
+--disable-features=Vulkan
+--ignore-gpu-blocklist
+--ozone-platform=wayland
+```
+
+**Примечания:**
+- Требуется `libva-nvidia-driver`. Протестировано в июле 2026: драйвер 610.43.03, KDE Plasma (Wayland), Vivaldi 8.1.
+- `VaapiIgnoreDriverChecks` — ключевой флаг для NVIDIA — без него декодирование инициализируется и `vivaldi://gpu` заявляет «Hardware accelerated», но декодирование во время выполнения не работает (`vaEndPicture failed, VA error: internal decoding error`) и молча откатывается к программному декодированию.
+- Проверьте через DevTools → вкладку Media (`VaapiVideoDecoder` как имя декодера) и `nvidia-smi dmon -s u` (столбец DEC > 0 во время воспроизведения). Не полагайтесь только на `vivaldi://gpu`.
+- Декодирование AV1 сломано в `libva-nvidia-driver` 0.0.17 (исправление в upstream master, ещё не выпущено — см. [elFarto/nvidia-vaapi-driver#419](https://github.com/elFarto/nvidia-vaapi-driver/issues/419)). Блокируйте AV1 (например, enhanced-h264ify), чтобы YouTube отдавал VP9.
+
+### Google Chrome - NVIDIA RTX 5070 (Автор: pisyukaev)
+
+* **Браузер:** Google Chrome
+
+* **ГП:** NVIDIA GeForce RTX 5070 (Blackwell / GB205)
+
+* **Путь к файлу флагов:** `~/.config/chrome-flags.conf`
+
+```bash
+--enable-features=AcceleratedVideoDecodeLinuxGL,VaapiVideoDecoder,VaapiIgnoreDriverChecks,VaapiOnNvidiaGPUs
+--ignore-gpu-blocklist
+```
+
+**Примечания:**
+- Требуется `libva-nvidia-driver` и `nvidia-utils` (протестировано с драйвером 610.43.03).
+- **Критический флаг:** `VaapiOnNvidiaGPUs` — это ключевой флаг, который включает VA-API на ГП NVIDIA в Chrome/Chromium. Без него Chrome жёстко блокирует устройства NVIDIA в `vaapi_wrapper.cc` и молча откатывается к программному декодированию.
+- `VaapiIgnoreDriverChecks` также рекомендуется, чтобы предотвратить сбои декодирования во время выполнения.
+- `AcceleratedVideoDecodeLinuxGL` включает аппаратно ускоренное декодирование видео через OpenGL-бэкенд ANGLE.
+- Подтверждено: `chrome://gpu` → Video Acceleration Information показывает поддержку декодирования H264 (baseline, main, high), VP8, VP9 (profile0, profile2), HEVC (main, main 10, main still-picture) и AV1.
+- Для проверки: откройте `chrome://gpu` и убедитесь, что в «Video Acceleration Information» перечислены кодеки декодирования. Воспроизведите видео HEVC и проверьте DevTools → вкладку Media на наличие `VaapiVideoDecoder` как активного декодера.
+- Флаг `--ozone-platform=wayland` не нужен — Chrome автоматически определяет Wayland в CachyOS. Если возникнут проблемы, можно явно добавить `--ozone-platform=wayland`.
+
+### Brave Origin - AMD Radeon RX 7600 (Автор: RyuuPendragon)
+
+* **Браузер:** Brave Origin
+
+* **ГП:** AMD Radeon RX 7600
+
+* **Путь к файлу флагов:** `~/.config/brave-origin-flags.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,CanvasOopRasterization,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```


### PR DESCRIPTION
As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one and if things are or aren't translated.

---

I want the process to be as transparent as possible, which is why I'm listing prompt, model, soft- and hardware:

Prompt used: "Today we are going to translate some technical documentation. Specifically we are translating the wiki of the Arch-based Linux distribution CachyOS.

In general, the wiki is supposed to be English-first with the translations being there to complement it. A lot of the words and phrases should therefore be kept in English.
For example it makes no sense to translate things which are likely to be displayed in English anyway like an exemplary terminal output. Further, it makes no sense to translate the actual names of things into the requested language, "bootloader" being an example, as people know what a bootloader is.
Keeping that in mind, the overall goal isn't to literally translate every word, rather it's to translate the context around it so a native reader can grasp the concept and what he has to do. As an Arch-based Linux distro it's expected for the user to, at least on a very shallow level, to be aware of the concepts of a bootloader, a kernel and so on, but maybe the user doesn't have the reading-comprehension to understand what he has to do if he only reads the English wiki.

Structurally the wiki has the regular English files in a directory like /src/content/docs/configuration/gaming.mdx while the files in other languages have the exact same file name but are in a directory with an ISO language code like the corresponding German translation being in /src/content/docs/de/configuration/gaming.mdx. That has to be kept in mind when a link refers to another site of the wiki, as the language code has to be added in the translation, otherwise the link will send the user to the English page. For links that point outward of the wiki itself, they can simply be kept the same.

The translated pages usually already exist but are outdated by a few months compared to the main English ones, therefore a lot of the translation can and should be kept. You should apply all the differences: adding anything that was added, removing anything that has been removed and changing anything that was changed. However you should keep what wasn't changed so it's only an update with minimal lines changed, not a total rewrite of the entire page. The formating should be the exact same as the English one with every line-break and every punctuation mark being the exact same as that changes how the page is rendered. A ` stays a `, a ' stays a ' and so on, they are not interchangeable.

Now, we are going to translate the English file /home/c/Dokumente/GitHub/wiki/src/content/docs/configuration/enabling_hardware_acceleration_in_google_chrome.mdx to Russian which is the /home/c/Dokumente/GitHub/wiki/src/content/docs/ru/configuration/enabling_hardware_acceleration_in_google_chrome.mdx file."

Model used: [A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

Software used: My own AUR packages [llama.cpp-sycl](https://aur.archlinux.org/packages/llama.cpp-sycl) and [intel-deep-learning-essentials](https://aur.archlinux.org/packages/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

Hardware used: Sparkle Intel Arc Pro B70 with 32GB VRAM
