### PR TITLE
gaming.mdx: Updated Russian translation

### DIFF
--- a/src/content/docs/ru/configuration/gaming.mdx
+++ b/src/content/docs/ru/configuration/gaming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Руководство по играм в CachyOS
-description: 'Оно охватывает установку необходимых пакетов, игры в Steam с помощью Proton, различные версии Proton, Lutris как центральный хаб для всех игр и установщики-скрипты для популярных игр.'
+description: 'Охватывает установку необходимых пакетов, игры в Steam с помощью Proton, различные версии Proton, Lutris как центральный хаб для всех игр и установщики-скрипты для популярных игр.'
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
@@ -8,15 +8,13 @@ tableOfContents:
 
 import ImageComponent from '~/components/image-component.astro';
 import MultipleImageComponent from '~/components/multiple-images-component.astro';
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
 
-Добро пожаловать в руководство по играм в CachyOS. Оно поможет вам разобраться с основными аспектами настройки всего необходимого для игр.
+Добро пожаловать в руководство по играм в CachyOS! Оно проведёт вас через всё, что вам нужно знать для настройки системы для игр.
 
-Прежде всего.
+*Прежде всего, поймите, что добиться двузначного прироста FPS не всегда возможно. Иногда оптимизации могут привести к незначительным улучшениям или вообще не дать эффекта, в зависимости от игры и конфигурации оборудования.*
 
-*Помните, что добиться двузначного прироста FPS не всегда возможно, а иногда и вовсе нереально. В зависимости от игры и конфигурации оборудования оптимизация может дать лишь незначительное улучшение или не дать его совсем.*
-
-*Не стоит ожидать, что программная оптимизация сработает как бесплатный апгрейд железа.*
+*Не стоит ожидать, что программные оптимизации сработают как бесплатный апгрейд оборудования.*
 
 <ImageComponent imgsrc={import('~/assets/images/gaming-meme.jpeg')} />
 
@@ -28,33 +26,33 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 ### Основные пакеты
 
-Чтобы упростить настройку CachyOS для игр, все необходимые игровые пакеты сгруппированы в один мета-пакет, который включает все необходимые зависимости и библиотеки для игр в Linux, а также отдельный мета-пакет для инструментов и лаунчеров/магазинов.
+Чтобы упростить настройку CachyOS для игр, все необходимые игровые пакеты сгруппированы в один мета-пакет, который включает все необходимые зависимости и библиотеки для игр в Linux, а также отдельный мета-пакет для популярных инструментов и магазинов/лаунчеров.
 
 *Если вы обнаружите, что каких-либо пакетов не хватает, не стесняйтесь сообщить об этом команде CachyOS.*
 
 Выполните следующие шаги, чтобы начать настройку для игр.
 <Tabs>
-    <TabItem label= 'CachyOS Hello'>
-    - Откройте CachyOS Hello. Перейдите в **Apps/Tweaks** (Приложения/Настройки) и нажмите на `Install Gaming packages` (Установить игровые пакеты).
-        <ImageComponent imgsrc={import('~/assets/images/cachyos_hello-gaming.png')} />
+  <TabItem label='CachyOS Hello'>
+    - Откройте CachyOS Hello. Перейдите в **Apps/Tweaks** и нажмите на `Install Gaming packages`.
+    <ImageComponent imgsrc={import('~/assets/images/cachyos_hello-gaming.png')} />
     *CachyOS Hello устанавливает и `cachyos-gaming-meta`, и `cachyos-gaming-applications`.*
-    </TabItem>
-    <TabItem label='Мета-пакет'>
-        Мета-пакет `cachyos-gaming-meta` включает в себя множество библиотек, связанных с играми.
-        ```sh
-        sudo pacman -S cachyos-gaming-meta
-        ```
-    </TabItem>
-    <TabItem label='Инструменты и магазины'>
-        Мета-пакет `cachyos-gaming-applications` включает в себя следующее:
-          - Инструменты
-            - Gamescope, Goverlay, MangoHud
-          - Лаунчеры
-            - Steam, Heroic Games Launcher, Lutris
-        ```sh
-        sudo pacman -S cachyos-gaming-applications
-        ```
-    </TabItem>
+  </TabItem>
+  <TabItem label='Мета-пакет'>
+    Мета-пакет `cachyos-gaming-meta` включает в себя множество библиотек, связанных с играми.
+    ```sh
+    sudo pacman -S cachyos-gaming-meta
+    ```
+  </TabItem>
+  <TabItem label='Инструменты и магазины'>
+    Мета-пакет `cachyos-gaming-applications` включает в себя следующее:
+    - Инструменты
+      - Gamescope, GOverlay, MangoHud
+    - Лаунчеры
+      - Steam, Heroic Games Launcher, Lutris, Faugus Launcher
+    ```sh
+    sudo pacman -S cachyos-gaming-applications
+    ```
+  </TabItem>
 </Tabs>
 
 ## Proton-CachyOS
@@ -75,17 +73,17 @@ Proton-CachyOS основан на ветке Proton `bleeding-edge` и прим
 Параметры запуска в Steam строятся по следующему шаблону.
 
 ```bash
-<переменные окружения> <обертки> %command% <аргументы приложения>
+[переменные окружения] [обертки] %command% [аргументы приложения]
 ```
 
-- **`<переменные окружения>`**: Это опции в формате `ПЕРЕМЕННАЯ=значение`
+- **`[переменные окружения]`**: Это опции в формате `ПЕРЕМЕННАЯ=значение`
   ```bash title="Примеры"
   PROTON_DXVK_D3D8=1
   # Или
   DXVK_HUD="fps,memory,version,api"
   ```
 
-- **`<обертки>`**: Это приложения и скрипты, которые изменяют способ запуска реального приложения. Аргументы для обертки обычно идут после ее исполняемого файла.
+- **`[обертки]`**: Это приложения и скрипты, которые изменяют способ запуска реального приложения. Аргументы для обертки обычно идут после её исполняемого файла.
   ```bash title="Примеры"
   mangohud --dlsym
   # Или
@@ -94,100 +92,42 @@ Proton-CachyOS основан на ветке Proton `bleeding-edge` и прим
 
 - **`%command%`**: Это реальное приложение. Это следует указывать именно так, и Steam заменит его на соответствующую команду при запуске приложения.
 
-- **`<аргументы приложения>`**: Это различные аргументы для реального приложения, и они зависят от самого приложения.
+- **`[аргументы приложения]`**: Это различные аргументы для реального приложения, и они зависят от самого приложения.
   ```bash title="Пример"
   %command% -dx11
   ```
 
 **Пример полной опции запуска, объединяющей все элементы:**
-
-  ```bash
-  __GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1 prime-run game-performance %command% -dx11
-  ```
+```bash
+__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1 prime-run game-performance %command% -dx11
+```
 
 :::caution
 Не добавляйте несколько `%command%`, используя их в качестве разделителей для нескольких опций запуска.
 
 Пример: `__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1 %command% game-performance %command% prime-run %command%`
 
-В этом случае все, что идет после первого `%command%`, будет проигнорировано, так как будет рассматриваться как аргументы игры, поэтому только `__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1` будет распознана как опция запуска.
+В этом случае всё, что идёт после первого `%command%`, будет проигнорировано, так как будет рассматриваться как аргументы игры, поэтому только `__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1` будет распознана как опция запуска.
 :::
 
 #### Переменные окружения
+:::note
+Кастомные версии Proton имеют нестабильные параметры конфигурации по умолчанию. Для получения последней информации об их параметрах конфигурации обращайтесь к их документации.
 
-<Tabs>
-<TabItem label="Графика и апскейлинг">
+Ссылки на документы Proton-CachyOS:
 
-- DLSS и функции Nvidia
-    - `PROTON_DLSS_UPGRADE=1`: Автоматически обновлять DLSS до последней версии.
-    - `PROTON_DLSS_INDICATOR=1`: Показывать индикатор статуса DLSS в игре.
-    - `PROTON_NVIDIA_LIBS=1`: Включить библиотеки Nvidia (PhysX, CUDA) - не требуется для DLSS/трассировки лучей.
+<LinkButton icon="external" href="https://github.com/CachyOS/proton-cachyos/blob/cachyos_main/README.md#proton-cachyos-config-options">Readme</LinkButton>
+<LinkButton icon="external" href="https://github.com/CachyOS/proton-cachyos/blob/cachyos_main/CHANGELOG.md">Changelog</LinkButton>
 
-<details>
-<summary>Расширенные настройки Nvidia</summary>
+Ссылки на документы Proton-EM:
 
-- `PROTON_NVIDIA_NVCUDA=1`: Включить только поддержку CUDA.
-- `PROTON_NVIDIA_NVENC=1`: Включить только кодирование NVENC.
-- `PROTON_NVIDIA_NVML=1`: Включить мониторинг NVML.
-- `PROTON_NVIDIA_NVOPTIX=1`: Включить трассировку лучей OptiX.
-- `PROTON_NVIDIA_LIBS_NO_32BIT=1`: Ограничить библиотеки только 64-битными (исправляет проблемы с производительностью на RTX 4000+).
-</details>
-
-- Апскейлинг AMD и Intel
-    - `PROTON_FSR4_UPGRADE=1`: Автоматически обновлять FSR до последней версии.
-    - `PROTON_FSR4_RDNA3_UPGRADE=1`: Использовать DLL FSR4, оптимизированную для RDNA3.
-    - `PROTON_XESS_UPGRADE=1`: Автоматически обновлять XeSS до последней версии.
-
-</TabItem>
-
-<TabItem label="Дисплей и HDR">
-
-- Wayland и дисплей
-    - `PROTON_ENABLE_WAYLAND=1`: Включить нативную поддержку Wayland.
-      - **Преимущества**: Позволяет использовать HDR без Gamescope; улучшает задержку/плавность кадров
-      - **Недостатки**: Ломает оверлей Steam, на данный момент экспериментально
-    - `PROTON_NO_WM_DECORATION=1`: Отключить декорации оконного менеджера.
-      - **Исправляет**: Проблемы с полноэкранным режимом без рамки, прокликивание мыши сквозь окна
-
-- Поддержка HDR
-    - `PROTON_ENABLE_HDR=1`: Включить поддержку вывода HDR.
-      - **Требования**: Gamescope с флагом `--hdr-enabled` ИЛИ `PROTON_ENABLE_WAYLAND=1`
-      - **Настройка**: [Требуется дополнительная конфигурация](https://wiki.archlinux.org/title/HDR_monitor_support)
-
-</TabItem>
-
-<TabItem label="Производительность и кэширование">
-
-- Производительность ЦП и синхронизации
-    - `PROTON_NO_NTSYNC=1`: Использовать FSync вместо NTSync.
-        - **Преимущество**: Возможность исправления проблем в некоторых играх, плохо совместимых с NTSync.
-
-- Управление шейдерами и кэшем
-    - `PROTON_LOCAL_SHADER_CACHE=1`: Включить кэш шейдеров для каждой игры, аналогично "Предварительному кэшированию шейдеров" в Steam.
-        - **Примечание**: Это НЕ компилирует шейдеры заранее, а ТОЛЬКО изолирует кэш шейдеров каждой игры. Шейдеры все равно будут компилироваться во время игрового процесса.
-    - `PROTON_ENABLE_MEDIACONV=1`: Включить Proton Media Converter.
-        - **Примечание**: Только для целей тестирования
-
-- AMD Anti-Lag
-    - `ENABLE_LAYER_MESA_ANTI_LAG=1`: Включить AMD Anti-Lag для снижения задержки ввода.
-
-</TabItem>
-
-<TabItem label="Ввод и совместимость">
-
-- Контроллер и ввод
-    - `PROTON_PREFER_SDL=1`: Обходной путь для проблем с обнаружением контроллера
-    - `PROTON_NO_STEAMINPUT=1`: Отключить поддержку Steam Input.
-        - **Исправляет**: Проблемы с контроллером/геймпадом в Wayland
-
-</TabItem>
-</Tabs>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-11-hdr/README.md">Readme</LinkButton>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/EM-ADDITIONS.md">EM-ADDITIONS</LinkButton>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/FSR4.md">FSR4</LinkButton>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/CHANGES.md">Winewayland</LinkButton>
+:::
 
 ### Настройка Proton-CachyOS с Lutris и Heroic
-
-:::note
-Следующая конфигурация применяется только к proton-cachyos. Если вы используете proton-cachyos-slr, -GE или -EM, вы можете пропустить этот раздел.
-:::
 
 Убедитесь, что в вашей системе установлен umu-launcher из CachyOS. Установите его следующей командой.
 ```sh
@@ -195,60 +135,54 @@ sudo pacman -S cachyos/umu-launcher
 ```
 
 <Tabs>
-    <TabItem label='Lutris (глобально)'>
+  <TabItem label='Lutris Глобально'>
     <Steps>
-    1. На главном экране Lutris нажмите на значок шестеренки рядом с Wine.
-    2. Перейдите на вкладку **Runner Options** (Параметры исполнителя) и убедитесь, что ваши настройки соответствуют следующим:
-        - **Wine version** (Версия Wine) = `proton-cachyos`
-        - **Use System winetricks** (Использовать системный winetricks) = *Отключено*
-        - **Graphics** (Графика)
-            - **Enable DXVK** (Включить DXVK) = `Enabled` (Включено)
-              - Примечание: Пользовательские версии **DXVK**, **VKD3D** и **DXVK-NVAPI** не применяются при использовании `umu-launcher`.
-    3. Перейдите на вкладку **System Options** (Системные параметры).
-        - **Lutris**
-            - **Disable Lutris Runtime** (Отключить среду выполнения Lutris) = `Enabled` (Включено)
-            - **Prefer system libraries** (Предпочитать системные библиотеки) = `Enabled` (Включено)
-    4. Прокрутите вниз до раздела **Game execution** (Выполнение игры) и найдите таблицу **Environment variables** (Переменные окружения).
-    5. Добавьте следующие переменные окружения:
-        - **Key** (Ключ): `UMU_RUNTIME_UPDATE` *опционально*
-            - **Value** (Значение): `0`
-            - *Это пропустит обновления Steam Linux Runtime для proton-cachyos. Не используйте это с любой версией Proton, которая использует Steam Linux Runtime, такой как proton-cachyos-slr, -GE или -EM.*
-        - **Key** (Ключ): `PROTON_VERB` *опционально*
-            - **Value** (Значение): `waitforexitandrun`
+      1. На главном экране Lutris нажмите на значок шестерёнки рядом с Wine.
+      2. Перейдите на вкладку **Runner Options** и убедитесь, что ваши настройки соответствуют следующим:
+          - **Wine version** = `proton-cachyos-slr` или `proton-cachyos-native`
+          - **Use System winetricks** = *Отключено*
+          - **Graphics**
+          - **Enable DXVK** = `Enabled`
+            - Примечание: Пользовательские версии **DXVK**, **VKD3D** и **DXVK-NVAPI** не применяются при использовании `umu-launcher`.
+      3. Перейдите на вкладку **System Options**.
+          - **Lutris**
+          - **Disable Lutris Runtime** = `Enabled`
+          - **Prefer system libraries** = `Enabled`
+      4. Продолжайте прокручивать вниз до раздела **Game execution** и найдите таблицу **Environment variables**.
+      5. Добавьте следующие переменные окружения:
+          - **Key**: `PROTON_VERB` *опционально*
+          - **Value**: `waitforexitandrun`
             - *Это позволяет protonfixes работать с соответствующим GAMEID.*
-    6. Нажмите **Save** (Сохранить), чтобы применить изменения.
+      6. Нажмите **Save**, чтобы применить изменения.
     </Steps>
-    </TabItem>
-    <TabItem label='Lutris (для игры)'>
+  </TabItem>
+  <TabItem label='Lutris Для игры'>
     <Steps>
-    1. Щелкните правой кнопкой мыши по игре, которую хотите настроить, затем нажмите **Configure** (Настроить).
-    2. Перейдите на вкладку **Runner Options** (Параметры исполнителя) и убедитесь, что ваши настройки соответствуют следующим:
-        - **Wine version** (Версия Wine) = `proton-cachyos`
-        - **Use System winetricks** (Использовать системный winetricks) = *Отключено*
-        - **Graphics** (Графика)
-            - **Enable DXVK** (Включить DXVK) = `Enabled` (Включено)
-              - Примечание: Пользовательские версии **DXVK**, **VKD3D** и **DXVK-NVAPI** не применяются при использовании `umu-launcher`.
-    3. Перейдите на вкладку **System Options** (Системные параметры).
-        - **Lutris**
-            - **Disable Lutris Runtime** (Отключить среду выполнения Lutris) = `Enabled` (Включено)
-            - **Prefer system libraries** (Предпочитать системные библиотеки) = `Enabled` (Включено)
-    4. Прокрутите вниз до раздела **Game execution** (Выполнение игры) и найдите таблицу **Environment variables** (Переменные окружения).
-    5. Добавьте следующие переменные окружения:
-        - **Key** (Ключ): `UMU_RUNTIME_UPDATE` *опционально*
-            - **Value** (Значение): `0`
-            - *Это пропустит обновления Steam Linux Runtime для proton-cachyos. Не используйте это с любой версией Proton, которая использует Steam Linux Runtime, такой как proton-cachyos-slr, -GE или -EM.*
-        - **Key** (Ключ): `PROTON_VERB` *опционально*
-            - **Value** (Значение): `waitforexitandrun`
+      1. Щёлкните правой кнопкой мыши по игре, которую хотите настроить, затем нажмите **Configure**.
+      2. Перейдите на вкладку **Runner Options** и убедитесь, что ваши настройки соответствуют следующим:
+          - **Wine version** = `proton-cachyos-slr` или `proton-cachyos-native`
+          - **Use System winetricks** = *Отключено*
+          - **Graphics**
+          - **Enable DXVK** = `Enabled`
+            - Примечание: Пользовательские версии **DXVK**, **VKD3D** и **DXVK-NVAPI** не применяются при использовании `umu-launcher`.
+      3. Перейдите на вкладку **System Options**.
+          - **Lutris**
+          - **Disable Lutris Runtime** = `Enabled`
+          - **Prefer system libraries** = `Enabled`
+      4. Продолжайте прокручивать вниз до раздела **Game execution** и найдите таблицу **Environment variables**.
+      5. Добавьте следующие переменные окружения:
+          - **Key**: `PROTON_VERB` *опционально*
+          - **Value**: `waitforexitandrun`
             - *Это позволяет protonfixes работать с соответствующим GAMEID.*
-    6. Нажмите **Save** (Сохранить), чтобы применить изменения.
+      6. Нажмите **Save**, чтобы применить изменения.
     </Steps>
-    </TabItem>
-    <TabItem label='Heroic Games Launcher'>
-        <Steps>
-            1. Нажмите на кнопку `Configure` (Настроить) рядом с кнопкой `Play Now` (Играть сейчас) у игры, которую вы хотите запустить.
-            2. На вкладке `WINE` установите Wine Version (Версию Wine) на `Proton - proton-cachyos`.
-        </Steps>
-    </TabItem>
+  </TabItem>
+  <TabItem label='Heroic Games Launcher'>
+    <Steps>
+      1. Нажмите на кнопку `Configure` рядом с кнопкой `Play Now` у игры, которую вы хотите запустить.
+      2. На вкладке `WINE` установите Wine Version на `Proton - proton-cachyos-slr`.
+    </Steps>
+  </TabItem>
 </Tabs>
 
 ### Поддержка античитов
@@ -264,52 +198,49 @@ sudo pacman -S cachyos/umu-launcher
 
 <Tabs>
 
-<TabItem label='protonup'>
-
-<Steps>
-1. Откройте терминал и установите `protonup`.
-    ```sh
-    sudo pacman -S protonup-qt
+  <TabItem label='pacman'>
+    ```sh title='Выполните следующую команду'
+    sudo pacman -S proton-cachyos-slr
     ```
-2. Откройте **protonup-qt** и следуйте скриншоту:
-    <ImageComponent imgsrc={import('~/assets/images/steam-protonup.png')} />
-    :::note
-    Выберите версию `x86-64_v3`, если ваш процессор поддерживает **[AVX2](/installation/installation_prepare#x86_64-microarchitecture-level-support)**.
+  </TabItem>
 
-    В противном случае загрузите версию, оканчивающуюся на `x86-64`.
-    :::
-3. Перезапустите Steam, если он был у вас открыт.
+  <TabItem label='protonup'>
 
-</Steps>
-
-</TabItem>
-
-<TabItem label='pacman'>
-```sh title='Выполните следующую команду'
-sudo pacman -S proton-cachyos-slr
-```
-</TabItem>
+    <Steps>
+      1. Откройте терминал и установите `protonup`.
+          ```sh
+          sudo pacman -S protonup-qt
+          ```
+      2. Откройте **protonup-qt** и следуйте скриншоту:
+          <ImageComponent imgsrc={import('~/assets/images/steam-protonup.png')} />
+          :::note
+          Выберите версию `x86-64_v3`, если ваш процессор поддерживает **[AVX2](/ru/installation/installation_prepare#x86_64-microarchitecture-level-support)**.
+          В противном случае загрузите версию, оканчивающуюся на `x86-64`.
+          :::
+      3. Перезапустите Steam, если он был у вас открыт.
+    </Steps>
+  </TabItem>
 
 </Tabs>
 
 <details>
-<summary>Ручная установка (для продвинутых)</summary>
+  <summary>Ручная установка (для продвинутых)</summary>
 
-<Steps>
-1. Загрузите последнюю версию [здесь](https://github.com/CachyOS/proton-cachyos/releases) (прокрутите вниз до **Assets**).
-    :::note
-    Выберите версию, оканчивающуюся на `x86-64_v3`, если ваш процессор поддерживает **[AVX2](/installation/installation_prepare#x86_64-microarchitecture-level-support)**.
-    В противном случае загрузите версию, оканчивающуюся на `x86-64`.
-    :::
-2. Распакуйте файл и переместите папку в `~/.steam/steam/compatibilitytools.d/`
-3. Перезапустите Steam, если он был у вас открыт.
-</Steps>
+  <Steps>
+    1. Загрузите последнюю версию [здесь](https://github.com/CachyOS/proton-cachyos/releases) (прокрутите вниз до **Assets**).
+        :::note
+        Выберите версию, оканчивающуюся на `x86-64`. Это версия, которую предпочтут большинство пользователей.
+        Выберите версию, оканчивающуюся на `x86-64_v3`, только если ваш процессор поддерживает **[AVX2](/ru/installation/installation_prepare#x86_64-microarchitecture-level-support)** и вы хотите поэкспериментировать.
+        :::
+    2. Распакуйте файл и переместите папку в `~/.steam/steam/compatibilitytools.d/`
+    3. Перезапустите Steam, если он был у вас открыт.
+  </Steps>
 
 </details>
 
 ## Wine-CachyOS
 
-Это тот же `wine`, который лежит в основе `proton-cachyos`, но в виде отдельного пакета. Его можно использовать в Lutris, Heroic, Bottles и других программах.
+Это тот же `Wine`, который лежит в основе `Proton-CachyOS`, но в виде отдельного пакета. Его можно использовать в Lutris, Heroic, Bottles и других программах. **Имейте в виду, что он не предназначен для использования в Steam.**
 
 - **Все модификации Wine, включённые в Proton-CachyOS**
 - **Добавляет ранние исправления/обходные пути для игр**
@@ -326,47 +257,42 @@ sudo pacman -S proton-cachyos-slr
 
 **Дополнительные параметры конфигурации**
 
-- `WINE_WMCLASS="<имя>"`: Устанавливает `WM_CLASS` для всех окон Wine, позволяя оконному менеджеру управлять окнами Wine через правила.
-- `WINEUSERSANDBOX=1`: Отключает создание символических ссылок из папок пользователя Wine (таких как Documents и Pictures) на аналогичные папки в `HOME` каталоге пользователя.
+- `WINE_WMCLASS="[name]"`: Устанавливает `WM_CLASS` для всех окон Wine, позволяя оконному менеджеру управлять окнами Wine через правила.
+- `WINEUSERSANDBOX=1`: Отключает создание символических ссылок из папок пользователя Wine (таких как Documents и Pictures) на аналогичные папки в каталоге `HOME` пользователя.
 - `WINE_NO_WM_DECORATION=1`: Отключает декорации окон. Это может исправить проблемы с **полноэкранным режимом без рамок** и прокликиванием мыши сквозь окно.
-- `WINE_PREFER_SDL_INPUT=1`: Обходной путь для проблем с определением контроллера.
+- `WINE_PREFER_SDL_INPUT=1`: Обходной путь для проблем с определением контроллера
 
 ### Как использовать wine-cachyos-opt
 
 <Tabs>
-    <TabItem label='Автономно'>
+  <TabItem label='Автономно'>
     Обычно запуска `/opt/wine-cachyos/bin/wine` вместо просто `wine` должно быть достаточно для запуска приложения с использованием `wine-cachyos-opt`.
 
     Если требуется более строгая конфигурация, она может выглядеть так:
-    ```shell
+    ```sh
     export PATH="/opt/wine-cachyos/bin/:$PATH"
     export WINEDLLPATH="/opt/wine-cachyos/lib/wine:/opt/wine-cachyos/lib32/wine:$WINEDLLPATH"
     export LD_LIBRARY_PATH="/opt/wine-cachyos/lib/:/opt/wine-cachyos/lib32/:$LD_LIBRARY_PATH"
     ```
 
     Если вы хотите использовать `winetricks` с `wine-cachyos-opt`, вы можете вызвать его так:
-    ```shell
-    WINE=/opt/wine-cachyos/bin/wine WINEPREFIX=<ваш_префикс> winetricks <команда>
+    ```sh
+    WINE=/opt/wine-cachyos/bin/wine WINEPREFIX=[ваш префикс] winetricks [verb]
     ```
-    </TabItem>
-    <TabItem label='Lutris'>
-      :::note
-      Второе изображение также применимо для настройки для каждой игры в отдельности.
-      :::
-      <MultipleImageComponent
-      images={[
-      import('~/assets/images/lutris-guide-1.png'),
-      import('~/assets/images/lutris-guide-2.png')]}
-      />
-    </TabItem>
-    <TabItem label='Heroic Games Launcher'>
-      <MultipleImageComponent
-      images={[
-      import('~/assets/images/heroic-wine.png'),
-      import('~/assets/images/heroic-wine-2.png'),
-      import('~/assets/images/heroic-wine-3.png')]}
-      />
-    </TabItem>
+  </TabItem>
+  <TabItem label='Lutris'>
+    :::note
+    Второе изображение также применимо для настройки для каждой игры в отдельности.
+    :::
+    <MultipleImageComponent
+      images={[import('~/assets/images/lutris-guide-1.png'), import('~/assets/images/lutris-guide-2.png')]}
+    />
+  </TabItem>
+  <TabItem label='Heroic Games Launcher'>
+    <MultipleImageComponent
+      images={[import('~/assets/images/heroic-wine.png'), import('~/assets/images/heroic-wine-2.png'), import('~/assets/images/heroic-wine-3.png')]}
+    />
+  </TabItem>
 </Tabs>
 
 ## Steam: FAQ и советы
@@ -377,27 +303,79 @@ sudo pacman -S proton-cachyos-slr
 
 :::tip
 CachyOS предоставляет различные версии Proton, которые создаются и поддерживаются для дальнейшего улучшения производительности:
-- `proton-cachyos` (включён в мета-пакет `cachyos-gaming-meta`) разработан с добавлением улучшений качества жизни, отобранных патчей.
+- `proton-cachyos` (включён в мета-пакет `cachyos-gaming-meta`) разработан с добавлением улучшений качества жизни, отобранных патчей и т.д.
 :::
 
 :::tip
-Чтобы проверить, совместима ли игра с Linux или как она работает на Linux, посетите **[ProtonDB](https://www.protondb.com/)** или **[Are We Anti-Cheat Yet?](https://areweanticheatyet.com/)**.
+Чтобы проверить, совместима ли игра с Linux или как она работает на Linux, посетите
+**[ProtonDB](https://www.protondb.com/)**,
+**[Are We Anti-Cheat Yet?](https://areweanticheatyet.com/)**
+или **[раздел античитов на Gaming On Linux](https://www.gamingonlinux.com/anticheat/)**
 :::
+
+### Как установить кастомные версии Proton в Steam
+
+:::caution[НАСТОЯТЕЛЬНО РЕКОМЕНДУЕТСЯ оставить Proton от Valve в качестве глобального значения по умолчанию.]
+:::
+
+- Чтобы установить кастомный Proton для конкретной игры, перейдите в Библиотеку, щёлкните правой кнопкой мыши по игре,
+войдите в **Properties** > **Compatibility**
+
+отметьте чекбокс `Force the use of a specific Steam Play compatibility tool`
+и выберите желаемую версию Proton.
+
+- Чтобы установить Proton от Valve в качестве глобального значения по умолчанию, перейдите в **Settings** > **Compatibility** > **Default Compatibility tool**
+и установите последнюю стабильную версию Proton от Valve или Proton Experimental.
 
 ### Какую версию Proton следует использовать в Steam?
 
-:::note
-Поскольку на **Reddit** возникла некоторая путаница, нативная версия `Proton-CachyOS` не будет прекращена из-за устаревания `steam-native-runtime`.
-
-Они не связаны и не имеют отношения друг к другу. В последнее время мы рекомендуем использовать SLR, **который мы также устанавливаем по умолчанию**, чтобы уменьшить путаницу и проблемы для новичков в CachyOS и Linux в целом. Если вам нравится нативная версия и она у вас работает, продолжайте её использовать.
+:::tip
+Новым пользователям мы рекомендуем использовать Proton от Valve или Proton Experimental.
 :::
 
-- `Proton 10.0` — это стабильный релиз от `Valve`. Используйте его, если игра, в которую вы хотите играть, хорошо с ним работает.
-- `Proton Experimental` — это самый свежий релиз от `Valve`. Используйте его, если игра, в которую вы хотите играть, относительно новая, плохо работает с текущей стабильной версией Proton, или если люди рекомендуют его на **[ProtonDB](https://www.protondb.com/)**.
-- `proton-cachyos-slr` — версия, создаваемая и поддерживаемая мейнтейнерами CachyOS. Её использование настоятельно рекомендуется из-за различных улучшений качества жизни, исправлений и оптимизаций. Для игр, использующих античиты, такие как **BattlEye** или **Easy Anti-Cheat**, или кастомные лаунчеры, предпочтительнее `proton-cachyos-slr`.
-- `proton-cachyos` — та же версия, что и `proton-cachyos-slr`, но собранная без зависимости от Steam Linux Runtime. Используйте её, только если вы понимаете значение этого различия, и возвращайтесь к `proton-cachyos-slr` в случае возникновения проблем.
-- `Proton-GE` — это кастомная сборка от [GloriousEggroll](https://github.com/GloriousEggroll/proton-ge-custom). Она включает различные исправления и может быть полезна в определённых ситуациях.
-- `Proton 9.0.4 или ниже` — это стабильные релизы от `Valve`. Используйте их, если игра, в которую вы хотите играть, работает только с предыдущей версией Proton.
+Официальные версии Proton:
+
+**Proton Experimental:** это самый свежий релиз от **Valve**. Используйте его, если игра, в которую вы хотите играть, относительно новая, плохо работает с текущей стабильной версией Proton или если люди рекомендуют его на **[ProtonDB](https://www.protondb.com/)**.
+
+**Proton 11.0:** это стабильный релиз от **Valve**. Используйте его, если игра, в которую вы хотите играть, хорошо с ним работает.
+
+**Proton 10.0 или ниже:** это стабильные релизы от **Valve**. *Используйте их, если игра, в которую вы хотите играть, работает только с предыдущей версией Proton.*
+
+:::tip
+Для более опытных пользователей, которые хотят поэкспериментировать с дополнительными функциями, использовать Proton вне Steam или нуждаются в исправлениях, отсутствующих в Proton от Valve, есть несколько кастомных версий Proton, которые они могут использовать. Имейте в виду, что они не поддерживаются Valve, это усилия сообщества и они экспериментальны по своей природе.
+:::
+
+Сторонние форки Proton:
+
+**Proton-CachyOS:**
+Создаётся и поддерживается [CachyOS](https://github.com/CachyOS/proton-cachyos), содержит дополнительные функции качества жизни, исправления и экспериментальные изменения.
+
+В репозиториях CachyOS можно найти две версии: [`proton-cachyos-native`](https://packages.cachyos.org/package/cachyos/x86_64/proton-cachyos-native) и [`proton-cachyos-slr`](https://packages.cachyos.org/package/cachyos/x86_64/proton-cachyos-slr).
+
+Мы рекомендуем использовать пакет `proton-cachyos-slr` вместо `proton-cachyos-native`.
+
+**Proton-EM:**
+Кастомная сборка, ориентированная на разработку, созданная [Etaash-mathamsetty](https://github.com/Etaash-mathamsetty/Proton). Это отличный вариант, если вы хотите использовать **winewayland** и **FSR4** без дополнительных функций Proton-CachyOS. Это также источник различных улучшений, которые включает Proton-CachyOS.
+
+*Если вас интересует последнее и лучшее в разработке **winewayland**, это для вас.*
+
+**dwproton:**
+Кастомная сборка от [Dawn Winery](https://dawn.wine/dawn-winery/dwproton), это форк Proton-CachyOS с **дополнительными исправлениями и патчами для определённых аниме-игр**.
+
+Если вы столкнулись с проблемами с такими играми с другими версиями Proton, **dwproton** — ваш лучший вариант.
+
+**Proton-GE**:
+Кастомная сборка от [GloriousEggroll](https://github.com/GloriousEggroll/proton-ge-custom). Включает различные исправления и может быть полезна в определённых ситуациях.
+
+### Исправление неработающих видео H264 или отображения цветных полос в играх с Proton от Valve
+:::caution
+Это опционально. Используйте только если вы сталкиваетесь с этой проблемой.
+:::
+Запустите Steam следующей командой. Дождитесь загрузки, затем выйдите из Steam и запустите его как обычно.
+
+```sh
+steam steam://unlockh264/
+```
 
 ### Исправление заиканий, вызванных функцией записи игр в Steam
 
@@ -422,22 +400,22 @@ LD_PRELOAD="" %command%
 Чтобы включить логирование Proton для игры:
 
 <Steps>
-    1. Нажмите правой кнопкой мыши на игру в Steam и выберите **Свойства**.
-    2. В разделе **Параметры запуска** установите переменную окружения `PROTON_LOG`:
-        ```sh
-        PROTON_LOG=1 %command%
-        ```
-        Это создаст файл лога в вашем домашнем каталоге с именем `steam-<AppID>.log` (например, Counter Strike 2 использует AppID **730**, поэтому файл будет называться `steam-730.log`).
+  1. Нажмите правой кнопкой мыши на игру в Steam и выберите **Properties**.
+  2. В разделе **Launch Options** установите переменную окружения `PROTON_LOG`:
+      ```sh
+      PROTON_LOG=1 %command%
+      ```
+      Это создаст файл лога в вашем домашнем каталоге с именем `steam-[AppID].log` (например, Counter Strike 2 использует AppID **730**, поэтому файл будет называться `steam-730.log`).
 </Steps>
 
 <details>
-<summary>Пользовательский каталог для логов</summary>
+  <summary>Пользовательский каталог для логов</summary>
 
-Чтобы установить пользовательский каталог для логов, используйте `PROTON_LOG_DIR`:
+  Чтобы установить пользовательский каталог для логов, используйте `PROTON_LOG_DIR`:
 
-```bash title='Пример'
-PROTON_LOG=1 PROTON_LOG_DIR=/home/cachyos/steam-logs %command%
-```
+  ```sh title='Пример'
+  PROTON_LOG=1 PROTON_LOG_DIR=/home/cachyos/steam-logs %command%
+  ```
 </details>
 
 ### Предварительное кэширование шейдеров с Proton-CachyOS, -GE и -EM
@@ -445,16 +423,16 @@ PROTON_LOG=1 PROTON_LOG_DIR=/home/cachyos/steam-logs %command%
 :::note
 Рекомендуется отключать функцию предварительного кэширования шейдеров в Steam при использовании Proton-CachyOS, Proton-GE или Proton-EM. Они уже содержат все необходимые кодеки для воспроизведения видео в играх, а в наши дни относительно современная связка GPU-CPU должна быть более чем способна справиться с компиляцией шейдеров в игре.
 
-Однако, если у вас есть свободное время, вы можете проигнорировать этот совет и позволить Steam предварительно скомпилировать некоторые шейдеры для вашей игры.
+Если у вас есть свободное время, вы можете проигнорировать этот совет и позволить Steam предварительно скомпилировать некоторые шейдеры для вашей игры.
 
 **Имейте в виду, что не всё кэшируется во время этого процесса, и обновления версии Proton, использованной для компиляции шейдеров, могут потребовать полной перекомпиляции шейдеров.**
 :::
 
 #### Как отключить эту функцию в Steam
 
-В Steam нажмите `Steam`->`Настройки`, перейдите в `Загрузки` и снимите галочки с этих настроек:
-- **Разрешить фоновую обработку шейдеров Vulkan**
-- **Включить предварительное кэширование шейдеров**
+В Steam нажмите `Steam`->`Settings`, перейдите в `Downloads` и снимите галочки с этих настроек:
+- **Allow background processing of Vulkan shaders**
+- **Enable Shader Pre-caching**
 
 :::note
 Настоятельно рекомендуется [увеличить максимальный размер кэша шейдеров](#увеличить-максимальный-размер-кэша-шейдеров) после отключения предварительного кэширования шейдеров в Steam.
@@ -465,10 +443,18 @@ PROTON_LOG=1 PROTON_LOG_DIR=/home/cachyos/steam-logs %command%
 :::caution
 Избегайте использования Proton на дисках с NTFS. Valve не поддерживает такую конфигурацию, и это может привести к непредсказуемому поведению игр.
 
-Если вы готовы продолжить, следуйте их **[неофициальному руководству](<https://github.com/ValveSoftware/Proton/wiki/Using-a-NTFS-disk-with-Linux-and-Windows>)**.
+Если вы готовы продолжить, следуйте их **[неофициальному руководству](https://github.com/ValveSoftware/Proton/wiki/Using-a-NTFS-disk-with-Linux-and-Windows)**.
 :::
 
-## [Lutris](<https://lutris.net/>)
+### Запуск в сессии gamescope
+
+Сессия Gamescope запускает ваш рабочий стол внутри gamescope, предоставляя специализированную полноэкранную игровую среду с улучшенной обработкой дисплея, управлением вводом и оптимизациями производительности.
+
+Она идеально подходит для игровых систем или портативных устройств, предлагая опыт, похожий на консольный, при сохранении доступа к вашему рабочему столу при необходимости.
+
+Для её использования установите пакет `gamescope-session-cachyos` (`pacman -S gamescope-session-cachyos`) и установите сессию gamescope в качестве сессии по умолчанию.
+
+## [Lutris](https://lutris.net/)
 
 Lutris — это игровой лаунчер в CachyOS. С помощью Lutris вы можете легко управлять своими игровыми ранерами, включая Wine, Proton и эмуляторы.
 
@@ -489,16 +475,21 @@ Lutris — это игровой лаунчер в CachyOS. С помощью Lu
 
 - Опции запуска, такие как `-dx11` или `-fullscreen`, следует добавлять в поле **Arguments** на вкладке **Game options**, разделяя их пробелом.
 - Обёртки команд, например `mangohud --dlsym` или `game-performance`, следует добавлять в поле **Command prefix** на вкладке **System options**, разделяя их пробелом.
-- Переменные окружения, такие как `PROTON_ENABLE_HDR=1`, следует добавлять в таблицу **Environment variables** на вкладке **System options**, используя кнопку `+` для добавления новой записи.
+- Переменные окружения, такие как `DXVK_HDR=1`, следует добавлять в таблицу **Environment variables** на вкладке **System options**, используя кнопку `+` для добавления новой записи.
 :::note
 Не включайте `=` в поле Key. Оно должно содержать только имя переменной.
 :::
+
+### Как правильно генерировать логи в Lutris
+- Установите Output debugging info в значение `Inherit from environment`.
+- В Environment variables добавьте `PROTON_LOG` со значением `1`.
+
 
 ## Советы по производительности и прочее
 
 ### Не совмещайте gamemode и ananicy-cpp
 
-Из-за того, что `gamemode` и `ananicy-cpp` оба пытаются одновременно изменить приоритет процесса (niceness), это может привести к конфликтам и неожиданному поведению. Рекомендуется использовать gamemode без ananicy-cpp.
+Из-за того, что `gamemode` и `ananicy-cpp` оба пытаются одновременно изменить приоритет процесса (niceness), это может привести к конфликтам и неожиданному поведению. Если вы хотите использовать gamemode, рекомендуется сначала отключить или остановить ananicy-cpp.
 
 Чтобы остановить ananicy-cpp, выполните следующую команду:
 
@@ -528,48 +519,48 @@ CachyOS включает в себя скрипт-обёртку [game-performan
 
 <Tabs>
 
-<TabItem label='Steam'>
+  <TabItem label='Steam'>
 
-<Steps>
-1. Откройте вашу `Библиотеку Steam`.
-2. Щёлкните правой кнопкой мыши по названию игры и выберите `Свойства`.
-3. На вкладке `Общие` вы найдёте раздел `Параметры запуска`.
-4. Добавьте следующую опцию запуска:
-    ```sh
-    game-performance %command%
-    ```
-</Steps>
+    <Steps>
+        1. Откройте вашу `Библиотеку Steam`.
+        2. Щёлкните правой кнопкой мыши по названию игры и выберите `Properties`.
+        3. На вкладке `General` вы найдёте раздел `Launch Options`.
+        4. Добавьте следующую опцию запуска:
+            ```sh
+            game-performance %command%
+            ```
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Heroic Games Launcher'>
+  <TabItem label='Heroic Games Launcher'>
 
-<Steps>
-1. На левой панели откройте `Настройки`.
-2. Перейдите в `Настройки игр по умолчанию`, затем нажмите `Расширенные`.
-3. В разделе команды `обёртки` (wrapper). Добавьте следующую строку без аргументов:
-   ```sh
-   game-performance
-   ```
-4. Нажмите на знак `+`, чтобы сохранить изменения.
-</Steps>
+    <Steps>
+        1. На левой панели откройте `Settings`.
+        2. Перейдите в `Game defaults`, затем нажмите `Advanced`.
+        3. В разделе команды `wrapper`. Добавьте следующую строку без аргументов:
+            ```sh
+            game-performance
+            ```
+        4. Нажмите на знак `+`, чтобы сохранить изменения.
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Lutris'>
+  <TabItem label='Lutris'>
 
-<Steps>
-1. В правом верхнем углу откройте `гамбургер-меню`.
-2. Перейдите в `Настройки/Глобальные опции`.
-3. Включите `Расширенный режим` в правом верхнем углу.
-4. Прокрутите вниз до `Префикс команды` и добавьте следующую строку:
-   ```sh
-   game-performance
-   ```
-5. Сохраните изменения.
-</Steps>
+    <Steps>
+      1. В правом верхнем углу откройте `гамбургер-меню`.
+      2. Перейдите в `Preferences/Global options`.
+      3. Включите `Advanced Mode` в правом верхнем углу.
+      4. Прокрутите вниз до `Command prefix` и добавьте следующую строку:
+          ```sh
+          game-performance
+          ```
+      5. Сохраните изменения.
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
 </Tabs>
 
@@ -583,35 +574,35 @@ CachyOS включает в себя скрипт-обёртку [game-performan
 
 <Steps>
 
-1. Откройте терминал.
-2. Создайте каталог `environment.d` в вашей папке с конфигурациями, если он ещё не существует:
-	```sh
-	mkdir -p ~/.config/environment.d
-    ```
-3. Создайте новый файл конфигурации:
-    ```sh
-    touch ~/.config/environment.d/gaming.conf
-    ```
-4. Откройте файл с помощью **Micro** (текстовый редактор).
-    ```sh
-    micro ~/.config/environment.d/gaming.conf
-    ```
-    И вставьте следующее содержимое в зависимости от производителя вашей видеокарты:
-   <details>
-       <summary>AMD</summary>
-            ```sh
-            # Увеличить размер кэша шейдеров AMD до 12 ГБ
-            MESA_SHADER_CACHE_MAX_SIZE=12G
-            ```
-   </details>
-   <details>
-       <summary>NVIDIA</summary>
-           ```sh
-           # Увеличить размер кэша шейдеров Nvidia до 12 ГБ
-           __GL_SHADER_DISK_CACHE_SIZE=12000000000
-           ```
-   </details>
-5. Сохраните файл, нажав `CTRL+S`, и выйдите из Micro, нажав `CTRL+Q`. Перезагрузите систему.
+  1. Откройте терминал.
+  2. Создайте каталог `environment.d` в вашей папке с конфигурациями, если он ещё не существует:
+      ```sh
+      mkdir -p ~/.config/environment.d
+      ```
+  3. Создайте новый файл конфигурации:
+      ```sh
+      touch ~/.config/environment.d/gaming.conf
+      ```
+  4. Откройте файл с помощью **Micro** (текстовый редактор).
+      ```sh
+      micro ~/.config/environment.d/gaming.conf
+      ```
+      И вставьте следующее содержимое в зависимости от производителя вашей видеокарты:
+      <details>
+        <summary>AMD</summary>
+        ```sh
+        # Увеличить размер кэша шейдеров AMD до 12 ГБ
+        MESA_SHADER_CACHE_MAX_SIZE=12G
+        ```
+      </details>
+      <details>
+        <summary>NVIDIA</summary>
+        ```sh
+        # Увеличить размер кэша шейдеров Nvidia до 12 ГБ
+        __GL_SHADER_DISK_CACHE_SIZE=12000000000
+        ```
+      </details>
+  5. Сохраните файл, нажав `CTRL+S`, и выйдите из Micro, нажав `CTRL+Q`. Перезагрузите систему.
 
 </Steps>
 
@@ -623,55 +614,55 @@ CachyOS включает в себя скрипт-обёртку [game-performan
 
 <Tabs>
 
-<TabItem label='Steam'>
+  <TabItem label='Steam'>
 
-<Steps>
-1. Откройте вашу `Библиотеку Steam`.
-2. Щёлкните правой кнопкой мыши по названию игры и выберите `Свойства`.
-3. На вкладке `Общие` вы найдёте раздел `Параметры запуска`.
-4. Добавьте следующую опцию запуска:
-    ```sh
-    dlss-swapper %command%
-    ```
-</Steps>
+    <Steps>
+      1. Откройте вашу `Библиотеку Steam`.
+      2. Щёлкните правой кнопкой мыши по названию игры и выберите `Properties`.
+      3. На вкладке `General` вы найдёте раздел `Launch Options`.
+      4. Добавьте следующую опцию запуска:
+          ```sh
+          dlss-swapper %command%
+          ```
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Heroic Games Launcher'>
+  <TabItem label='Heroic Games Launcher'>
 
-<Steps>
-1. На левой панели откройте `Настройки`.
-2. Перейдите в `Настройки игр по умолчанию`, затем нажмите `Расширенные`.
-3. В разделе команды `обёртки` (wrapper). Добавьте следующую строку без аргументов:
-   ```sh
-   dlss-swapper
-   ```
-4. Нажмите на знак `+`, чтобы сохранить изменения.
-</Steps>
+    <Steps>
+      1. На левой панели откройте `Settings`.
+      2. Перейдите в `Game defaults`, затем нажмите `Advanced`.
+      3. В разделе команды `wrapper`. Добавьте следующую строку без аргументов:
+          ```sh
+          dlss-swapper
+          ```
+      4. Нажмите на знак `+`, чтобы сохранить изменения.
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Lutris'>
+  <TabItem label='Lutris'>
 
-<Steps>
-1. В правом верхнем углу откройте `гамбургер-меню`.
-2. Перейдите в `Настройки/Глобальные опции`.
-3. Включите `Расширенный режим` в правом верхнем углу.
-4. Прокрутите вниз до `Префикс команды` и добавьте следующую строку:
-   ```sh
-   dlss-swapper
-   ```
-5. Сохраните изменения.
-</Steps>
+    <Steps>
+      1. В правом верхнем углу откройте `гамбургер-меню`.
+      2. Перейдите в `Preferences/Global options`.
+      3. Включите `Advanced Mode` в правом верхнем углу.
+      4. Прокрутите вниз до `Command prefix` и добавьте следующую строку:
+          ```sh
+          dlss-swapper
+          ```
+      5. Сохраните изменения.
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
 </Tabs>
 
 <details>
-<summary>Метод ручной замены DLL</summary>
+  <summary>Метод ручной замены DLL</summary>
 
-Если `dlss-swapper` не работает или вызывает проблемы, попробуйте обновить реализацию DLSS в игре вручную, заменив `nvngx_dlss.dll` на актуальную версию и используя вместо этого скрипт-обёртку `dlss-swapper-dll`.
+  Если `dlss-swapper` не работает или вызывает проблемы, попробуйте обновить реализацию DLSS в игре вручную, заменив `nvngx_dlss.dll` на актуальную версию и используя вместо этого скрипт-обёртку `dlss-swapper-dll`.
 </details>
 
 ### Поддержка трассировки лучей


### PR DESCRIPTION
As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one and if things are or aren't translated.

---

I want the process to be as transparent as possible, which is why I'm listing prompt, model, soft- and hardware:

Prompt used: "Today we are going to translate some technical documentation. Specifically we are translating the wiki of the Arch-based Linux distribution CachyOS.

In general, the wiki is supposed to be English-first with the translations being there to complement it. A lot of the words and phrases should therefore be kept in English.
For example it makes no sense to translate things which are likely to be displayed in English anyway like an exemplary terminal output. Further, it makes no sense to translate the actual names of things into the requested language, "bootloader" being an example, as people know what a bootloader is.
Keeping that in mind, the overall goal isn't to literally translate every word, rather it's to translate the context around it so a native reader can grasp the concept and what he has to do. As an Arch-based Linux distro it's expected for the user to, at least on a very shallow level, to be aware of the concepts of a bootloader, a kernel and so on, but maybe the user doesn't have the reading-comprehension to understand what he has to do if he only reads the English wiki.

Structurally the wiki has the regular English files in a directory like /src/content/docs/configuration/gaming.mdx while the files in other languages have the exact same file name but are in a directory with an ISO language code like the corresponding German translation being in /src/content/docs/de/configuration/gaming.mdx. That has to be kept in mind when a link refers to another site of the wiki, as the language code has to be added in the translation, otherwise the link will send the user to the English page. For links that point outward of the wiki itself, they can simply be kept the same.

The translated pages usually already exist but are outdated by a few months compared to the main English ones, therefore a lot of the translation can and should be kept. You should apply all the differences: adding anything that was added, removing anything that has been removed and changing anything that was changed. However you should keep what wasn't changed so it's only an update with minimal lines changed, not a total rewrite of the entire page. The formating should be the exact same as the English one with every line-break and every punctuation mark being the exact same as that changes how the page is rendered. A ` stays a `, a ' stays a ' and so on, they are not interchangeable.

Now, we are going to translate the English file /home/c/Dokumente/GitHub/wiki/src/content/docs/configuration/gaming.mdx to Russian which is the /home/c/Dokumente/GitHub/wiki/src/content/docs/ru/configuration/gaming.mdx file."

Model used: [A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

Software used: My own AUR packages [llama.cpp-sycl](https://aur.archlinux.org/packages/llama.cpp-sycl) and [intel-deep-learning-essentials](https://aur.archlinux.org/packages/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

Hardware used: Sparkle Intel Arc Pro B70 with 32GB VRAM
