### PR TITLE
general_system_tweaks.mdx: Updated Russian translation

### DIFF
--- a/src/content/docs/ru/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/ru/configuration/general_system_tweaks.mdx
@@ -6,7 +6,7 @@ tableOfContents:
   maxHeadingLevel: 4
 ---
 
-import { Tabs, TabItem, Steps, LinkButton } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
 ## Настройки производительности AMD
@@ -74,8 +74,9 @@ AMD опубликовала патч для оптимизации планир
 Вам нужно установить в BIOS в опции CPPC значение "Driver". Это позволит переопределить используемый режим через sysfs.
 
 Существует два режима:
-1. Frequency (Частота)
-2. Cache (Кэш)
+
+1. Frequency
+2. Cache
 
 Если установлен режим `cache`, драйвер будет пытаться размещать задачи в первую очередь на CCD с большим объёмом кэша, что в основном выгодно в играх.
 Опция `frequency` будет пытаться размещать задачи на втором CCD, у которого более высокая частота, чем у CCD с 3D V-Cache.
@@ -194,7 +195,7 @@ FAQ:
 ### NVIDIA Smooth Motion (серии RTX 40xx и 50xx)
 
 :::note[Совместимость с играми.]
-Игры, работающие на DX11, DX12 и Vulkan.
+Игры, работающие на DX11, DX12 и Vulkan. См. FAQ для обходного пути для OpenGL.
 
 И DXVK, и VKD3D работают исправно.
 
@@ -212,7 +213,7 @@ FAQ:
     NVPRESENT_ENABLE_SMOOTH_MOTION=1
     ```
 
-Часто задаваемые вопросы:
+FAQ:
 
 - Зачем использовать Smooth Motion вместо DLSS Frame Generation?
   - Когда в игре отсутствует поддержка DLSS Frame Generation, Smooth Motion служит альтернативой благодаря своей ИИ-модели на уровне драйвера.
@@ -233,8 +234,43 @@ FAQ:
   - Нет. Внутриигровой ограничитель должен работать нормально.
 - Можно ли использовать Smooth Motion вместе с DLSS Frame Generation?
   - Нет. Одновременно может быть активен только один метод генерации кадров.
+- Можно ли использовать Smooth Motion с приложениями OpenGL?
+  - Не напрямую, поскольку она реализована как слой Vulkan, но это возможно с помощью [Zink](https://docs.mesa3d.org/drivers/zink.html) для перевода вызовов OpenGL в Vulkan:
+    ```text
+    NVPRESENT_ENABLE_SMOOTH_MOTION=1 zink-run <command>
+    ```
+    :::note
+    Использование Zink, вероятно, повлияет на производительность и может вызвать графические сбои в некоторых играх.
+
+    Пользователям с двумя GPU необходимо установить `DRI_PRIME=1`, чтобы использовать дискретную GPU Nvidia вместо более типичных методов выбора GPU.
+    :::
 
 ## Настройки энергосбережения
+
+### thermald
+
+`thermald` — это демон управления тепловым режимом для систем Intel. Он отслеживает датчики температуры и применяет охлаждающие действия, такие как ограничения мощности ЦП или изменения состояний производительности, до того, как прошивке потребуется использовать более агрессивное троттлинг.
+
+Он в основном полезен на ноутбуках Intel, трансформерах, планшетах, портативных устройствах и ПК малого форм-фактора, которые предоставляют элементы управления температурой Intel через `/sys/class/thermal`. Поддерживаемые системы обычно используют датчики температуры CPU Intel, Intel P-state, Intel power clamp, RAPL, `INT340X` или ACPI DPTF/adaptive thermal tables. Процессоры AMD не поддерживаются `thermald`.
+
+Установите и включите его с помощью:
+
+```sh
+sudo pacman -S thermald
+sudo systemctl enable --now thermald.service
+```
+
+Проверьте, запустился ли он корректно:
+
+```sh
+systemctl status thermald.service
+journalctl -u thermald.service -b
+```
+
+Дополнительная информация:
+
+<LinkButton icon="external" href="https://github.com/intel/thermal_daemon">upstream-репозиторий thermald</LinkButton>
+<LinkButton icon="external" href="https://man.archlinux.org/man/thermald.8">man-страница thermald</LinkButton>
 
 ### Включить RCU Lazy
 
@@ -248,19 +284,6 @@ rcutree.enable_rcu_lazy=1
 ```
 
 ## Устранение неполадок с NVIDIA
-
-### Отключение бэкенда SDDM Wayland
-
-:::note
-Начиная с cachyos-kde-settings 4.3, SDDM по умолчанию использует KWin в качестве своего Wayland-композитора.
-:::
-
-Хотя это хороший шаг вперед, он может вызывать некоторые неудобства, такие как нарушение поддержки разгона с помощью nvidia-settings или несовместимость со старыми видеокартами, которые с трудом работают под Wayland.
-
-Чтобы отменить это изменение, удалите пакет cachyos-kde-settings:
-```sh
-sudo pacman -R cachyos-kde-settings
-```
 
 ### Прошивка NVIDIA GSP
 


### PR DESCRIPTION
As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one and if things are or aren't translated.

---

I want the process to be as transparent as possible, which is why I'm listing prompt, model, soft- and hardware:

Prompt used: "Today we are going to translate some technical documentation. Specifically we are translating the wiki of the Arch-based Linux distribution CachyOS.

In general, the wiki is supposed to be English-first with the translations being there to complement it. A lot of the words and phrases should therefore be kept in English.
For example it makes no sense to translate things which are likely to be displayed in English anyway like an exemplary terminal output. Further, it makes no sense to translate the actual names of things into the requested language, "bootloader" being an example, as people know what a bootloader is.
Keeping that in mind, the overall goal isn't to literally translate every word, rather it's to translate the context around it so a native reader can grasp the concept and what he has to do. As an Arch-based Linux distro it's expected for the user to, at least on a very shallow level, to be aware of the concepts of a bootloader, a kernel and so on, but maybe the user doesn't have the reading-comprehension to understand what he has to do if he only reads the English wiki.

Structurally the wiki has the regular English files in a directory like /src/content/docs/configuration/gaming.mdx while the files in other languages have the exact same file name but are in a directory with an ISO language code like the corresponding German translation being in /src/content/docs/de/configuration/gaming.mdx. That has to be kept in mind when a link refers to another site of the wiki, as the language code has to be added in the translation, otherwise the link will send the user to the English page. For links that point outward of the wiki itself, they can simply be kept the same.

The translated pages usually already exist but are outdated by a few months compared to the main English ones, therefore a lot of the translation can and should be kept. You should apply all the differences: adding anything that was added, removing anything that has been removed and changing anything that was changed. However you should keep what wasn't changed so it's only an update with minimal lines changed, not a total rewrite of the entire page. The formating should be the exact same as the English one with every line-break and every punctuation mark being the exact same as that changes how the page is rendered. A ` stays a `, a ' stays a ' and so on, they are not interchangeable.

Now, we are going to translate the English file /home/c/Dokumente/GitHub/wiki/src/content/docs/configuration/general_system_tweaks.mdx to Russian which is the /home/c/Dokumente/GitHub/wiki/src/content/docs/ru/configuration/general_system_tweaks.mdx file."

Model used: [A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

Software used: My own AUR packages [llama.cpp-sycl](https://aur.archlinux.org/packages/llama.cpp-sycl) and [intel-deep-learning-essentials](https://aur.archlinux.org/packages/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

Hardware used: Sparkle Intel Arc Pro B70 with 32GB VRAM
