### PR TITLE
post_install_setup.mdx: Updated German translation

### DIFF
--- a/src/content/docs/de/configuration/post_install_setup.mdx
+++ b/src/content/docs/de/configuration/post_install_setup.mdx
@@ -3,23 +3,27 @@ title: Nach der Installation
 description: Schritte zur Konfiguration nach der Installation von CachyOS
 tableOfContents:
   minHeadingLevel: 1
-  maxHeadingLevel: 3
+  maxHeadingLevel: 4
 ---
 
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
-## Das System aktualisieren
+## Empfohlene Schritte nach der Installation
+
+### Das System aktualisieren
 
 :::tip
-Schau dir unbedingt unsere [Sicherheit & bewährte Vorgehensweisen](/de/cachyos_basic/faq#sicherheit--bewährte-praktiken) an, um häufige Fehler zu vermeiden und dein System sicher zu halten.
+Schau dir unbedingt unsere [Sicherheit & bewährte Praktiken](/de/cachyos_basic/faq#sicherheit--bewährte-praktiken) an, um häufige Fehler zu vermeiden und dein System sicher zu halten.
 :::
 
 <Tabs>
 
 <TabItem label="Shelly (GUI & CLI)">
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/overview/">Shellys Wiki</LinkButton>
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/docs/cli-reference/">Shelly CLI</LinkButton>
 
-    [Shelly](https://github.com/Seafoam-Labs/Shelly-ALPM) ist eine moderne Interpretation des Arch Linux Package Managers, entworfen um eine intuitivere and und benutzerfreundlichere Alternative zu Pacman and Octopi zu sein.
+    [Shelly](https://github.com/Seafoam-Labs/Shelly-ALPM) ist eine moderne Interpretation des Arch Linux Package Managers, entworfen um eine intuitivere und benutzerfreundlichere Alternative zu Pacman und Octopi zu sein.
 
     Entwickelt von: [Seafoam-Labs](https://github.com/Seafoam-Labs)
 
@@ -29,12 +33,11 @@ Schau dir unbedingt unsere [Sicherheit & bewährte Vorgehensweisen](/de/cachyos_
 
     Installieren/Deinstallieren von Paketen vom AUR, offiziellen Repositories, AppImages, Flatpaks und lokalen Paketen, Paket-Details einsehen, Paket Gruppen verwalten und vieles mehr.
 
-    Für mehr Details lese dir [das Shelly README](https://github.com/Seafoam-Labs/Shelly-ALPM?tab=readme-ov-file#features) durch.
-
     Warum Shelly anstatt Octopi?
-    - Moderneres und benutzerfreundlicheres Interface.
-    - Stetige Weiterentwicklung und Updates mit neuen Features and Verbesserungen.
-    - Unterstützt mehr Paket-Formate (AUR, AppImages, Flatpaks, etc.).
+    - Es hat ein moderneres und benutzerfreundlicheres Interface.
+    - Stetige Weiterentwicklung und Updates mit neuen Features und Verbesserungen.
+    - Unterstützt mehr Paket-Formate (AUR, AppImages, Flatpaks, etc.)
+    - Sicherheitsfeatures wie PKGBUILDs-Verifizierung, sieh dir die [Security Checks](https://www.seafoam-labs.org/shelly-alpm/docs/security/) für mehr Informationen an.
 
     <details>
         <summary>Shelly Homepage Screenshot</summary>
@@ -43,6 +46,36 @@ Schau dir unbedingt unsere [Sicherheit & bewährte Vorgehensweisen](/de/cachyos_
     <details>
         <summary>Paket Management Tab</summary>
         <ImageComponent imgsrc={import('~/assets/images/shelly-package-management.png')} />
+    </details>
+    Hier sind einige nützliche Befehle, um mit Shelly's CLI zu starten:
+
+    <details>
+    <summary>Alle Pakete upgraden (AUR, offizielle Repositories, Flatpak, etc.):</summary>
+    ```sh
+    shelly
+    ```
+    </details>
+    <details>
+    <summary>Standard-Pakete upgraden (Arch-Derivate) + Paket installieren:</summary>
+    ```sh
+    shelly install --upgrade {pkg}
+    # Beispiel:
+    shelly install --upgrade discord
+    ```
+    </details>
+    <details>
+    <summary>Paket und Abhängigkeiten entfernen:</summary>
+    ```sh
+    shelly remove {pkg}
+    # Beispiel:
+    shelly remove discord
+    ```
+    </details>
+    <details>
+    <summary>AUR-Paket suchen:</summary>
+    ```sh
+    shelly aur search {pkg}
+    ```
     </details>
 </TabItem>
 
@@ -212,7 +245,25 @@ Fork von [Arch-Update](https://github.com/Antiz96/arch-update)
 Ein Update-Benachrichtiger & -Anwender für Arch Linux, der dich bei wichtigen Aufgaben vor/nach dem Update unterstützt.
 Enthält ein dynamisches & klickbares Systray-Applet für eine einfache Integration in jede Desktop-Umgebung / jeden Window Manager.
 
-Aktiviere Cachy-Update in CachyOS Hello > Apps/Tweaks > Cachy Update enabled
+<details>
+    <summary>Wie man Cachy-Update aktiviert</summary>
+    Aktiviere Cachy-Update in `CachyOS Hello > Apps/Tweaks > Cachy Update enabled`
+</details>
+<details>
+    <summary>Wie man Cachy-Update deaktiviert</summary>
+        Deaktiviere Cachy-Update in `CachyOS Hello > Apps/Tweaks > Cachy Update disabled`
+            :::tip
+            Wenn du Cachy-Update behalten und nur das Systray-Applet deaktivieren möchtest, öffne ein Terminal und führe die folgenden Befehle aus:
+            ```bash
+            mkdir -p ~/.config/autostart
+            echo -e "[Desktop Entry]\nHidden=true" > ~/.config/autostart/arch-update-tray.desktop"
+            ```
+            Wenn du das System-Tray-Applet aktiviert lassen willst und einfach die automatische Update-Prüfung deaktivieren möchtest, führe den folgenden Befehl aus:
+            ```bash
+            sudo systemctl --global disable --now arch-update.timer
+            ```
+            :::
+</details>
 
 - Features:
   - Automatische Überprüfung und Auflistung verfügbarer Updates.
@@ -223,7 +274,7 @@ Aktiviere Cachy-Update in CachyOS Hello > Apps/Tweaks > Cachy Update enabled
   - Überprüfung auf Dienste, die nach einem Upgrade einen Neustart erfordern (und bietet an, dies zu tun, falls vorhanden).
   - Unterstützung für `sudo`, `sudo-rs`, `doas` & `run0`.
 
-**Intervall für die Update-Prüfung:** `Einmal 15 Sekunden nach dem Booten und dann jede Stunde.`
+**Intervall für die Update-Prüfung:** `Einmal zwei Minuten nach dem Booten und dann einmal täglich mit einer einstündigen zufälligen Verzögerung.`
 
 - Wie man das Intervall für die Update-Prüfung ändert:
 
@@ -232,13 +283,16 @@ systemctl --user edit --full arch-update.timer
 # Tipp: Du kannst statt `nano` auch jeden anderen Texteditor deiner Wahl verwenden
 # z.B. EDITOR=micro systemctl --user edit --full arch-update.timer
 ```
-Standardinhalt der Datei:
-```systemd
-[Timer]
-OnStartupSec=15 # Prüfe auf Updates 15 Sekunden nach dem Booten
-OnUnitActiveSec=1h # Prüfe stündlich auf Updates
-```
 
+<details>
+<summary>Standardinhalt der Datei:</summary>
+    ```systemd
+    [Timer]
+    OnStartupSec=2min # Prüfe zwei Minuten nach dem Booten auf Updates
+    RandomizedDelaySec=1h # Einstündige zufällige Verzögerung
+    OnUnitActiveSec=1d # Prüfe einmal täglich auf Updates
+    ```
+</details>
 Im Grunde kannst du den Wert `OnUnitActiveSec` auf alles ändern, was du willst. Wenn du zum Beispiel alle 30 Minuten auf Updates prüfen möchtest, ändere ihn auf `30m`. Oder alle 6 Stunden, ändere ihn auf `6h`. Schau dir dieses [Dokument](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans) an für mehr Details, wie man das Zeitintervall einstellt.
 
 Falls du möchtest, dass Cachy-Update nur einmal beim Booten auf neue Updates prüft, kannst du einfach die Zeile `OnUnitActiveSec` komplett löschen.
@@ -278,17 +332,27 @@ sudo ufw disable
 Ufw ignoriert standardmäßig eingehenden Traffic und lässt ausgehenden durch. Du kannst aber eigene Regeln zur Firewall hinzufügen, um bestimmte Verbindungen zu blockieren oder zu erlauben.
 
 ```bash
-# Zum Beispiel:
+# Beispiel 1, SSH-Traffic erlauben:
 sudo ufw allow ssh
+# Beispiel 2, Port 12345 für TCP & UDP Traffic öffnen:
+sudo ufw allow 12345
+
+# Text oder Portnummer kann angepasst werden, wie 12345/udp um nur UDP-Traffic zu erlauben oder ssh durch einen Programmnamen zu ersetzen
 ```
 
 </TabItem>
 
 <TabItem label="Verweigern">
 
+Ufw ignoriert standardmäßig eingehenden Traffic und lässt ausgehenden durch. Du kannst aber eigene Regeln zur Firewall hinzufügen, um bestimmte Verbindungen zu blockieren oder zu erlauben.
+
 ```bash
-# Um einen bestimmten Port zu verweigern, schau dir das folgende Beispiel an:
-sudo ufw deny 80
+# Beispiel 1, SSH-Traffic verweigern:
+sudo ufw deny ssh
+# Beispiel 2, Port 12345 für TCP & UDP Traffic schließen:
+sudo ufw deny 12345
+
+# Text oder Portnummer kann angepasst werden, wie 12345/udp um nur UDP-Traffic zu verweigern oder ssh durch einen Programmnamen zu ersetzen
 ```
 
 </TabItem>
@@ -298,7 +362,15 @@ sudo ufw deny 80
 ```bash
 sudo ufw status verbose
 ```
-
+:::tip
+Wenn du nicht vergessen willst, warum du einen Port geöffnet/geschlossen hast, füge einen Kommentar zur Regel hinzu.
+```bash
+# Beispiel 1, Port 12345 für TCP & UDP Traffic mit einem Kommentar öffnen:
+sudo ufw allow 12345 comment 'Beispiel'
+# Beispiel 2, Port 6789 für TCP mit einem Kommentar schließen:
+sudo ufw deny 6789/tcp comment 'Kommentare können Leerzeichen haben'
+```
+:::
 </TabItem>
 
 </Tabs>
@@ -311,7 +383,11 @@ Sei vorsichtig beim Konfigurieren von Firewall-Regeln, da falsch konfigurierte R
 Du kannst sie auch grafisch über den Abschnitt "Firewall" in den KDE Plasma-Einstellungen konfigurieren.
 :::
 
-## Globales Menü aktivieren
+:::note
+Änderungen an allow/deny treten in Kraft, nachdem ufw neu gestartet wurde. Deaktiviere und aktiviere ufw erneut für sofortige Ergebnisse.
+:::
+
+### Globales Menü aktivieren
 Bei einigen Apps wie Visual Studio Code funktioniert das globale Menü möglicherweise nicht oder ist an die übergeordnete App statt an das Panel angeheftet.
 
 ```sh
@@ -319,40 +395,9 @@ Bei einigen Apps wie Visual Studio Code funktioniert das globale Menü mögliche
 sudo pacman -S appmenu-gtk-module libdbusmenu-glib
 ```
 
-## AppArmor-Unterstützung mit AppArmor.d-Profilen aktivieren (Optional)
+## Optionale Einstellungen
 
-<Steps>
-
-1. Füge die folgenden Kernel-Parameter zu deinem Boot-Manager hinzu, siehe [Konfiguration des Boot-Managers](/de/configuration/boot_manager_configuration) als Referenz
-
-   ```text
-   lsm=landlock,lockdown,yama,integrity,apparmor,bpf
-   ```
-
-2. Installiere die Pakete apparmor und apparmord **(Set mit über +1500 Profilen)**
-   ```bash
-   sudo pacman -S apparmor apparmor.d
-   ```
-
-3. Aktiviere/Starte den AppArmor-Dienst
-
-   ```bash
-   systemctl enable --now apparmor.service
-   ```
-
-4. Aktiviere das Caching für AppArmor-Profile
-
-   ```shell
-   # /etc/apparmor/parser.conf
-   ## Füge die folgenden Zeilen hinzu:
-   write-cache
-   Optimize=compress-fast
-   cache-loc /etc/apparmor/earlypolicy/
-   ```
-   Speichere die Datei und starte neu.
-</Steps>
-
-## Die Standard-Shell ändern
+### Die Standard Shell ändern
 
 Derzeit verwendet CachyOS [fish](https://fishshell.com/) als Standard-Login-Shell des Benutzers. Du kannst jedoch
 die Standard-Shell nach Belieben ändern.
@@ -361,8 +406,7 @@ die Standard-Shell nach Belieben ändern.
    <TabItem label='bash'>
 
       Dies ist die Standard-Shell auf fast jeder Linux-Distribution. Sie wird auch immer noch als Login-Shell des root-Benutzers verwendet. bash
-      verfügt über grundlegende Autovervollständigungsfunktionen und eine einfache Verlaufsverwaltung. Es unterscheidet sich von zsh und fish dadurch, dass es nicht
-      das ausgefallene Anpassungs- und Plugin-Ökosystem hat, das sowohl fish als auch zsh besitzen.
+      verfügt über grundlegende Autovervollständigungsfunktionen und eine einfache Verlaufsverwaltung. Es unterscheidet sich von zsh und fish dadurch, dass es nicht das ausgefallene Anpassungs- und Plugin-Ökosystem hat, das sowohl fish als auch zsh besitzen.
 
 
       ```sh title='Ändere deine Standard-Shell auf bash'
@@ -384,7 +428,7 @@ die Standard-Shell nach Belieben ändern.
    </TabItem>
 </Tabs>
 
-## [tldr](https://github.com/tldr-pages/tldr) aktualisieren/verwenden
+### Updaten mit [tldr](https://github.com/tldr-pages/tldr)
 
 :::note
 CachyOS verwendet [tealdeer](https://github.com/tealdeer-rs/tealdeer), eine schnellere, auf Rust basierende Implementierung des ursprünglichen tldr
@@ -427,25 +471,24 @@ sudo pacman -S fuse2
 ```
 :::
 
-Um AppImages zu verwalten, kannst du [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) verwenden, der eine einfache Möglichkeit bietet, AppImages in dein System zu integrieren.
-<Tabs>
-  <TabItem label='Verwendung von AppImageLauncher (GUI)'>
-    AppImageLauncher ist ein grafisches Werkzeug, das die Verwaltung von AppImages auf deinem System vereinfacht. Es integriert sich in deine Desktop-Umgebung und macht es einfach, AppImages auszuführen und zu verwalten.
-        <Steps>
-        1. Installiere AppImageLauncher:
-              ```sh
-              paru appimagelauncher
-              ```
-        2. Lade ein Appimage deiner Wahl von einer vertrauenswürdigen Quelle herunter.
+Um AppImages zu verwalten, kannst du [gearlever](https://github.com/mijorus/gearlever) verwenden, der eine einfache Möglichkeit bietet, AppImages in dein System zu integrieren.
 
-        3. Doppelklicke auf die heruntergeladene AppImage-Datei. AppImageLauncher wird dich auffordern, die Anwendung in dein System zu integrieren.
+`gearlever` ist ein grafisches Werkzeug, das die Verwaltung von AppImages auf deinem System vereinfacht. Es integriert sich in deine Desktop-Umgebung und macht es einfach, AppImages auszuführen und zu verwalten.
 
-        4. Folge den Anweisungen, um den Integrationsprozess abzuschließen.
+Um gearlever zu installieren, befolge diese Schritte:
 
-        5. Sobald es integriert ist, kannst du die Anwendung aus deinem Anwendungsmenü oder durch Doppelklick auf die AppImage-Datei starten.
-        </Steps>
-    </TabItem>
-</Tabs>
+<Steps>
+    1. Installiere flatpak, falls du es noch nicht getan hast:
+        ```sh
+        sudo pacman -S flatpak
+        ```
+    2. Starte dein System neu.
+    3. Installiere gearlever mit flatpak:
+        ```sh
+        flatpak install flathub it.mijorus.gearlever
+        ```
+    4. Nach der Installation. Logge dich aus und wieder ein, um gearlever in deinem Anwendungsmenü zu sehen.
+</Steps>
 
 ## Zugriff auf Samba-Freigaben konfigurieren
 
@@ -473,4 +516,48 @@ Um die praktische smb.conf-Datei zu verwenden, installiere zuerst ein spezifisch
     6. Greife auf der Client-Maschine über deinen Dateimanager auf deine freigegebenen Ressourcen zu (z.B., `smb://<deine_server_ip>/<freigabename>`).
 
         Wenn alles richtig konfiguriert ist, wirst du nach Anmeldeinformationen gefragt. Denke daran, die Option zum Speichern deiner Anmeldeinformationen auszuwählen, wenn du das möchtest.
+</Steps>
+
+### Ünterstützung von AppArmor durch AppArmor.d-Profile
+
+Zitat von Wikipedia:
+
+*AppArmor ("Application Armor") ist ein Linux-Kernel-Sicherheitsmodul, das dem Systemadministrator erlaubt, die Fähigkeiten von Programmen mit per-Programm-Profilen einzuschränken. Profile können Fähigkeiten wie Netzwerkzugriff, Raw-Socket-Zugriff und die Berechtigung zum Lesen, Schreiben oder Ausführen von Dateien auf passenden Pfaden erlauben.*
+
+Dies ist nur eine Einführung, wie man ein grundlegendes AppArmor-Setup installiert, falls du mit AppArmor nicht vertraut bist. Fahre bitte nicht fort, ohne die Implikationen zu verstehen.
+
+Für detailliertere Informationen über AppArmor.d und wie man eigene Profile erstellt, schau dir die [AppArmor.d-Dokumentation](https://github.com/roddhjav/apparmor.d?tab=readme-ov-file#configuration) an.
+
+:::caution[Sei vorsichtig. Ein schlecht konfiguriertes AppArmor-Setup kann Probleme verursachen.]
+:::
+
+<Steps>
+
+1. Füge die folgenden Kernel-Parameter zu deinem Boot-Manager hinzu, siehe [Boot Manager Configuration](/de/configuration/boot_manager_configuration) als Referenz
+
+   ```text
+   lsm=landlock,lockdown,yama,integrity,apparmor,bpf
+   ```
+
+2. Installiere die Pakete apparmor und apparmord **(Set mit über +1500 Profilen)**
+   ```bash
+   sudo pacman -S apparmor apparmor.d
+   ```
+
+3. Aktiviere/Starte den AppArmor-Dienst
+
+   ```bash
+   systemctl enable --now apparmor.service
+   ```
+
+4. Aktiviere das Caching für AppArmor-Profile
+
+   ```shell
+   # /etc/apparmor/parser.conf
+   ## Füge die folgenden Zeilen hinzu:
+   write-cache
+   Optimize=compress-fast
+   cache-loc /etc/apparmor/earlypolicy/
+   ```
+   Speichere die Datei und starte dein System neu.
 </Steps>


### PR DESCRIPTION
Updated the German translation of the configuration/post_install_setup.mdx file based on [this link from the CachyOS Wiki Localization Status page](https://github.com/CachyOS/wiki/commits/next/src/content/docs/configuration/post_install_setup.mdx?since=2026-07-22T13:15:16.000Z).

Additionally I noticed a LOT of content missing, which is why I updated not only my recent commit to the English page, but also all the other diffs the German file had compared to the English one. No idea why that page was labeled as up-to-date before (maybe I made a mistake when I started translating a while ago?) but now it is!