### PR TITLE
post_install_setup.mdx: Updated Russian transl.

### DIFF
--- a/src/content/docs/ru/configuration/post_install_setup.mdx
+++ b/src/content/docs/ru/configuration/post_install_setup.mdx
@@ -6,7 +6,7 @@ tableOfContents:
   maxHeadingLevel: 4
 ---
 
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
 ## Рекомендуемые шаги после установки
@@ -20,6 +20,8 @@ import ImageComponent from '~/components/image-component.astro';
 <Tabs>
 
 <TabItem label="Shelly (GUI & CLI)">
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/overview/">Shelly's Wiki</LinkButton>
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/docs/cli-reference/">Shelly CLI</LinkButton>
 
     [Shelly](https://github.com/Seafoam-Labs/Shelly-ALPM) — это современное переосмысление менеджера пакетов Arch Linux, разработанное как более интуитивная и удобная альтернатива pacman и octopi.
 
@@ -31,12 +33,11 @@ import ImageComponent from '~/components/image-component.astro';
 
     Установку/удаление пакетов из AUR, официальных репозиториев, AppImages, Flatpaks и локальных пакетов, просмотр информации о пакетах, управление группами пакетов и многое другое.
 
-    Подробнее в [README Shelly](https://github.com/Seafoam-Labs/Shelly-ALPM?tab=readme-ov-file#features)
-
     Почему выбрать Shelly вместо Octopi?
     - Более современный и удобный интерфейс.
     - Постоянная разработка и обновления с новыми функциями и улучшениями.
     - Поддержка большего количества форматов пакетов (AUR, AppImages, Flatpaks и т.д.)
+    - Функции безопасности, такие как проверка PKGBUILDs, см. [Security Checks](https://www.seafoam-labs.org/shelly-alpm/docs/security/) для получения дополнительной информации.
 
     <details>
         <summary>Снимок главной страницы Shelly</summary>
@@ -45,6 +46,36 @@ import ImageComponent from '~/components/image-component.astro';
     <details>
         <summary>Вкладка управления пакетами</summary>
         <ImageComponent imgsrc={import('~/assets/images/shelly-package-management.png')} />
+    </details>
+    Вот несколько полезных команд для начала работы с CLI Shelly:
+
+    <details>
+    <summary>Обновить все пакеты (AUR, официальные репозитории, Flatpak и т.д.):</summary>
+    ```sh
+    shelly
+    ```
+    </details>
+    <details>
+    <summary>Обновить стандартные пакеты (Arch derivates) + установить пакет:</summary>
+    ```sh
+    shelly install --upgrade {pkg}
+    # Пример:
+    shelly install --upgrade discord
+    ```
+    </details>
+    <details>
+    <summary>Удалить пакет и зависимости:</summary>
+    ```sh
+    shelly remove {pkg}
+    # Пример:
+    shelly remove discord
+    ```
+    </details>
+    <details>
+    <summary>Поиск пакета в AUR:</summary>
+    ```sh
+    shelly aur search {pkg}
+    ```
     </details>
 </TabItem>
 
@@ -56,9 +87,9 @@ Octopi — это графический менеджер пакетов для 
 <Steps>
 
 1. Запустите **Octopi** из меню приложений.
-2. В главном окне нажмите на кнопку **Check updates** (Проверить обновления) (вверху слева), а затем рядом с ней — **System upgrade** (Обновление системы).
+2. В главном окне нажмите на кнопку **Check updates** (вверху слева), а затем рядом с ней — **System upgrade**.
 3. Octopi проверит наличие доступных обновлений и предложит установить их либо в самом Octopi, либо в терминале.
-4. Чтобы продолжить обновление, нажмите кнопку **Apply** (Применить).
+4. Чтобы продолжить обновление, нажмите кнопку **Apply**.
 5. Octopi загрузит и установит обновления.
 6. Рекомендуется перезагрузить компьютер после большого обновления **(особенно если было обновлено ядро)**.
 
@@ -220,13 +251,17 @@ Octopi — это графический менеджер пакетов для 
 </details>
 <details>
     <summary>Как отключить Cachy-Update</summary>
-        Откройте терминал и выполните следующие команды:
-            ```bash
-            sudo systemctl --global disable arch-update-tray.service
-            sudo systemctl --global disable arch-update.timer
-            ```
+        Отключите Cachy-Update в `CachyOS Hello > Apps/Tweaks > Cachy Update disabled`
             :::tip
-            Если вы хотите оставить апплет в системном трее включённым, но только отключить автоматическую проверку обновлений, вы можете просто отключить таймер, не отключая службу.
+            Если вы хотите оставить Cachy-Update и просто отключить апплет в системном трее, откройте терминал и выполните следующие команды:
+            ```bash
+            mkdir -p ~/.config/autostart
+            echo -e "[Desktop Entry]\nHidden=true" > ~/.config/autostart/arch-update-tray.desktop"
+            ```
+            Если вы хотите оставить апплет в системном трее включённым и просто отключить автоматическую проверку обновлений, выполните следующую команду:
+            ```bash
+            sudo systemctl --global disable --now arch-update.timer
+            ```
             :::
 </details>
 
@@ -239,7 +274,7 @@ Octopi — это графический менеджер пакетов для 
   - Проверка служб, требующих перезапуска после обновления (и предложение сделать это, если они есть).
   - Поддержка `sudo`, `sudo-rs`, `doas` и `run0`.
 
-**Интервал проверки обновлений:** `Один раз через 15 секунд после загрузки, а затем каждый час.`
+**Интервал проверки обновлений:** `Один раз через две минуты после загрузки, а затем один раз в день со случайной задержкой в один час.`
 
 - Как изменить интервал проверки обновлений:
 
@@ -248,20 +283,21 @@ systemctl --user edit --full arch-update.timer
 # Совет: Вы также можете использовать любой текстовый редактор по вашему выбору вместо `nano`
 # например, EDITOR=micro systemctl --user edit --full arch-update.timer
 ```
+
 <details>
 <summary>Содержимое файла по умолчанию:</summary>
     ```systemd
     [Timer]
-    OnStartupSec=15 # Check for updates 15 seconds after boot
-    OnUnitActiveSec=1h # Check for updates every hour
+    OnStartupSec=2min # Проверка обновлений через две минуты после загрузки
+    RandomizedDelaySec=1h # Случайная задержка в один час
+    OnUnitActiveSec=1d # Проверка обновлений один раз в день
     ```
 </details>
-
-В основном, вы можете изменить значение `OnUnitActiveSec` на любое другое. Например, если вы хотите проверять обновления каждые 30 минут, измените его на `30m`. Или каждые 6 часов — на `6h`. Ознакомьтесь с этим [документом](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans) для получения более подробной информации о том, как установить временной интервал.
+В основном вы можете изменить значение `OnUnitActiveSec` на любое другое. Например, если вы хотите проверять обновления каждые 30 минут, измените его на `30m`. или каждые 6 часов — на `6h`. Ознакомьтесь с этим [документом](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans) для получения более подробной информации о том, как установить временной интервал.
 
 Если вы хотите, чтобы Cachy-Update проверял наличие новых обновлений только один раз при загрузке, вы можете просто полностью удалить строку `OnUnitActiveSec`.
 
-Спасибо [Antiz](https://github.com/Antiz96) за поддержку основного проекта Arch-Update и за реализацию Cachy-Update.
+Спасибо [Antiz](https://github.com/Antiz96) за поддержку основного проекта Arch-Update и за реализацию Cachy-Update
 
 </TabItem>
 
@@ -296,17 +332,27 @@ sudo ufw disable
 По умолчанию ufw игнорирует входящий и разрешает исходящий трафик; вы можете добавлять в брандмауэр определённые правила, чтобы блокировать или разрешать конкретные соединения.
 
 ```bash
-# Например:
+# Пример 1, разрешить ssh-трафик:
 sudo ufw allow ssh
+# Пример 2, открыть порт 12345 для TCP & UDP трафика:
+sudo ufw allow 12345
+
+# Текст или номер порта можно изменить по необходимости, например 12345/udp, чтобы разрешить только UDP-трафик, или заменив ssh на название программы
 ```
 
 </TabItem>
 
 <TabItem label="Запретить">
 
+По умолчанию ufw игнорирует входящий и разрешает исходящий трафик; вы можете добавлять в брандмауэр определённые правила, чтобы блокировать или разрешать конкретные соединения.
+
 ```bash
-# Чтобы запретить определённый порт, посмотрите следующий пример:
-sudo ufw deny 80
+# Пример 1, запретить ssh-трафик:
+sudo ufw deny ssh
+# Пример 2, закрыть порт 12345 для TCP & UDP трафика:
+sudo ufw deny 12345
+
+# Текст или номер порта можно изменить по необходимости, например 12345/udp, чтобы запретить только UDP-трафик, или заменив ssh на название программы
 ```
 
 </TabItem>
@@ -316,7 +362,15 @@ sudo ufw deny 80
 ```bash
 sudo ufw status verbose
 ```
-
+:::tip
+Если вы не хотите забывать, почему вы открыли/закрыли порт, добавьте комментарий к правилу.
+```bash
+# Пример 1, открыть порт 12345 для TCP & UDP трафика с комментарием:
+sudo ufw allow 12345 comment 'Example'
+# Пример 2, закрыть порт 6789 для TCP с комментарием:
+sudo ufw deny 6789/tcp comment 'Comments can have spaces'
+```
+:::
 </TabItem>
 
 </Tabs>
@@ -329,6 +383,10 @@ sudo ufw status verbose
 Вы также можете настроить его графически, используя раздел "Firewall" в настройках KDE Plasma.
 :::
 
+:::note
+Изменения разрешений/запретов вступают в силу после перезапуска ufw. Отключите, а затем снова включите ufw для немедленного результата.
+:::
+
 ### Включение глобального меню
 Для некоторых приложений, таких как Visual Studio Code, глобальное меню может не работать или быть прикреплено к родительскому приложению вместо панели.
 
@@ -338,50 +396,6 @@ sudo pacman -S appmenu-gtk-module libdbusmenu-glib
 ```
 
 ## Дополнительные конфигурации
-
-### Поддержка AppArmor с использованием профилей AppArmor.d
-
-Цитата из Wikipedia:
-
-*AppArmor («Application Armor») — это модуль безопасности ядра Linux, который позволяет системному администратору ограничивать возможности программ с помощью профилей для каждой программы. Профили могут разрешать такие возможности, как доступ к сети, доступ к необработанным сокетам и разрешение на чтение, запись или выполнение файлов по соответствующим путям.*
-
-Это лишь краткое руководство по установке базовой конфигурации AppArmor. Если вы не знакомы с AppArmor, не продолжайте, не разобравшись в последствиях.
-
-Для получения более подробной информации об AppArmor.d и о том, как создавать собственные профили, ознакомьтесь с [документацией AppArmor.d](https://github.com/roddhjav/apparmor.d?tab=readme-ov-file#configuration).
-
-:::caution[Будьте осторожны. Неправильно настроенная конфигурация AppArmor может вызвать проблемы.]
-:::
-
-<Steps>
-
-1. Добавьте следующие параметры ядра в ваш загрузчик, см. [Настройка загрузчика](/ru/configuration/boot_manager_configuration) для справки
-
-   ```text
-   lsm=landlock,lockdown,yama,integrity,apparmor,bpf
-   ```
-
-2. Установите пакеты apparmor и apparmord **(набор из более чем 1500 профилей)**
-   ```bash
-   sudo pacman -S apparmor apparmor.d
-   ```
-
-3. Включите/запустите службу AppArmor
-
-   ```bash
-   systemctl enable --now apparmor.service
-   ```
-
-4. Включите кэширование для профилей AppArmor
-
-   ```shell
-   # /etc/apparmor/parser.conf
-   ## Добавьте следующие строки:
-   write-cache
-   Optimize=compress-fast
-   cache-loc /etc/apparmor/earlypolicy/
-   ```
-   Сохраните файл и перезагрузитесь.
-</Steps>
 
 ### Изменение оболочки по умолчанию
 
@@ -449,7 +463,7 @@ Appimages — это портативные приложения, которые
 ```sh
 chmod +x /path/to/your/appimage
 ```
-Или щелкните правой кнопкой мыши по файлу AppImage, перейдите в `Свойства` > `Права` и установите флажок `Разрешить исполнение файла как программы.`
+Или щелкните правой кнопкой мыши по файлу AppImage, перейдите в `Properties` > `Permissions`, и установите флажок `Allow executing file as program.`
 :::
 
 :::note[Перед запуском AppImages убедитесь, что на вашей системе установлена FUSE (Filesystem in Userspace).]
@@ -481,7 +495,7 @@ sudo pacman -S fuse2
 
 Samba — это свободная программная реализация сетевого протокола SMB. Чтобы подключиться к вашему samba-серверу, пользователям CachyOS доступна полезная конфигурация, но она требует изменения конфигурации вашего samba-сервера.
 
-### Установка и использование файла smb.conf от CachyOS
+#### Установка и использование файла smb.conf от CachyOS
 
 Чтобы использовать удобный файл smb.conf, сначала установите специальный пакет, который предоставляет необходимый файл smb.conf. Затем замените существующий smb.conf вашего сервера этим файлом и перенастройте ваши общие тома.
 
@@ -503,4 +517,48 @@ Samba — это свободная программная реализация 
     6. На клиентской машине получите доступ к вашим общим ресурсам через файловый менеджер (например, `smb://<ip_вашего_сервера>/<имя_ресурса>`).
 
         Если все настроено правильно, вам будет предложено ввести учетные данные. Не забудьте выбрать опцию сохранения вашей информации для входа, если это необходимо.
+</Steps>
+
+### Поддержка AppArmor с использованием профилей AppArmor.d
+
+Цитата из Wikipedia:
+
+*AppArmor («Application Armor») — это модуль безопасности ядра Linux, который позволяет системному администратору ограничивать возможности программ с помощью профилей для каждой программы. Профили могут разрешать такие возможности, как доступ к сети, доступ к необработанным сокетам и разрешение на чтение, запись или выполнение файлов по соответствующим путям.*
+
+Это лишь краткое руководство по установке базовой конфигурации AppArmor. Если вы не знакомы с AppArmor, не продолжайте, не разобравшись в последствиях.
+
+Для получения более подробной информации об AppArmor.d и о том, как создавать собственные профили, ознакомьтесь с [документацией AppArmor.d](https://github.com/roddhjav/apparmor.d?tab=readme-ov-file#configuration).
+
+:::caution[Будьте осторожны. Неправильно настроенная конфигурация AppArmor может вызвать проблемы.]
+:::
+
+<Steps>
+
+1. Добавьте следующие параметры ядра в ваш загрузчик, см. [Настройка загрузчика](/ru/configuration/boot_manager_configuration) для справки
+
+   ```text
+   lsm=landlock,lockdown,yama,integrity,apparmor,bpf
+   ```
+
+2. Установите пакеты apparmor и apparmord **(набор из более чем 1500 профилей)**
+   ```bash
+   sudo pacman -S apparmor apparmor.d
+   ```
+
+3. Включите/запустите службу AppArmor
+
+   ```bash
+   systemctl enable --now apparmor.service
+   ```
+
+4. Включите кэширование для профилей AppArmor
+
+   ```shell
+   # /etc/apparmor/parser.conf
+   ## Добавьте следующие строки:
+   write-cache
+   Optimize=compress-fast
+   cache-loc /etc/apparmor/earlypolicy/
+   ```
+   Сохраните файл и перезагрузитесь.
 </Steps>


### PR DESCRIPTION
As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one and if things are or aren't translated.

---

As I have strong critical opinions on AI-use myself, I want the process to be ran on local hardware and as transparent as possible, which is why I'm listing prompt, model, soft- and hardware that were used:

Prompt used: "Today we are going to translate some technical documentation. Specifically we are translating the wiki of the Arch-based Linux distribution CachyOS.

In general, the wiki is supposed to be English-first with the translations being there to complement it. A lot of the words and phrases should therefore be kept in English.
For example the headings and titles should be translated, the comments in the terminal too, but it makes no sense to translate things which are likely to be displayed in English anyway like the contents of a terminal output. Further, it makes no sense to translate the actual names of things into the requested language, "bootloader" being an example, as people know what a bootloader is.
Keeping that in mind, the overall goal isn't to literally translate every word, rather it's to translate the context around it so a native reader can grasp the concept and what he has to do. As an Arch-based Linux distro it's expected for the user to, at least on a very shallow level, to be aware of the concepts of a bootloader, a kernel and so on, but maybe the user doesn't have the reading-comprehension to understand what he has to do if he only reads the English wiki.

Structurally the wiki has the regular English files in a directory like /src/content/docs/configuration/gaming.mdx while the files in other languages have the exact same file name but are in a directory with an ISO language code like the corresponding German translation being in /src/content/docs/de/configuration/gaming.mdx. That has to be kept in mind when a link refers to another site of the wiki, as the language code has to be added in the translation, otherwise the link will send the user to the English page. For links that point outward of the wiki itself, they can simply be kept the same.

The translated pages usually already exist but are outdated by a few months compared to the main English ones, therefore a lot of the translation can and should be kept. You should apply all the differences: adding anything that was added, removing anything that has been removed and changing anything that was changed. However you should keep what wasn't changed so it's only an update with minimal lines changed, not a total rewrite of the entire page. The formating should be the exact same as the English one with every line-break and every punctuation mark being the exact same as that changes how the page is rendered. For example a ' stays a ' and can't be changed to a ` or " and so on, punctuation is not interchangeable.

Now, we are going to translate the English file /home/c/Dokumente/GitHub/wiki/src/content/docs/configuration/post_install_setup.mdx to Russian which is the /home/c/Dokumente/GitHub/wiki/src/content/docs/ru/configuration/post_install_setup.mdx"

Model used: [A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

Software used: My own AUR packages [llama.cpp-sycl](https://aur.archlinux.org/packages/llama.cpp-sycl) and [intel-deep-learning-essentials](https://aur.archlinux.org/packages/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

Hardware used: Sparkle Intel Arc Pro B70 with 32GB VRAM
