### PR TITLE
optimized_repos.mdx: Updated Russian translation

### DIFF
--- a/src/content/docs/ru/features/optimized_repos.mdx
+++ b/src/content/docs/ru/features/optimized_repos.mdx
@@ -135,12 +135,8 @@ rpdid, rdrnd, rdseed, sha, sse4a, vaes, vockmulqdq, wbnoinvd, savec, xsaveopt, x
 
 ## Добавление наших репозиториев в существующую установку Arch Linux
 
-:::caution
-Установка CachyOS Pacman установит форк pacman с функциями, добавленными CachyOS, такими как "INSTALLED_FROM" и автоматическая проверка архитектуры. В Pacman 6.1 была добавлена функция проверки функций, что может приводить к предупреждениям при использовании pacman от Arch Linux. Мы работаем с Arch Linux, чтобы снова обеспечить должную совместимость. Если вы хотите этого избежать, не добавляйте репозиторий "cachyos", который содержит модифицированный pacman. Все остальные репозитории, такие как cachyos-v3, cachyos-v4, cachyos-extra/core-v3/4, можно добавлять безопасно.
-:::
-
 :::tip
-Прежде чем рассматривать добавление наших репозиториев, пожалуйста, ознакомьтесь со **[списком совместимости процессоров](/ru/installation/installation_prepare#поддержка-уровня-микроархитектуры-x86_64)**
+Прежде чем рассматривать добавление наших репозиториев, пожалуйста, ознакомьтесь со **[списком совместимости процессоров](/ru/installation/installation_prepare#x86_64-microarchitecture-level-support)**
 :::
 
 <Tabs>
@@ -162,6 +158,9 @@ sudo ./cachyos-repo.sh
 </TabItem>
 
 <TabItem label='Вручную'>
+    :::caution
+    Установка CachyOS Pacman установит форк pacman с функциями, добавленными CachyOS, такими как "INSTALLED_FROM" и автоматическая проверка архитектуры. В Pacman 6.1 была добавлена функция проверки функций, что может приводить к предупреждениям при использовании pacman от Arch Linux. Мы работаем с Arch Linux, чтобы снова обеспечить должную совместимость. Если вы хотите этого избежать, не добавляйте репозиторий "cachyos", который содержит модифицированный pacman. Все остальные репозитории, такие как cachyos-v3, cachyos-v4, cachyos-extra/core-v3/4, можно добавлять безопасно.
+    :::
 
 <Steps>
 
@@ -180,7 +179,7 @@ sudo ./cachyos-repo.sh
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-mirrorlist-27-1-any.pkg.tar.zst' \
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst' \
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v4-mirrorlist-27-1-any.pkg.tar.zst' \
-   'https://mirror.cachyos.org/repo/x86_64/cachyos/pacman-7.1.0.r7.gb9f7d4a-3-x86_64.pkg.tar.zst'
+   'https://mirror.cachyos.org/repo/x86_64/cachyos/pacman-7.1.0.r9.g54d9411-4-x86_64.pkg.tar.zst'
    ```
 3. Добавьте репозитории CachyOS в конфигурационный файл pacman:
    :::note
@@ -305,13 +304,13 @@ sudo ./cachyos-repo.sh --remove
   * [RFC: Use x86_64-v2 architecture](https://lists.archlinux.org/pipermail/arch-general/2021-March/048739.html)
 
 * **09/12/2022:** Первый бенчмарк, выполненный Майклом.
-  * [The Performance Of Arch Linux Powered CachyOS](https://www.phoronix.com/review/cachyos-linux-perf)
+  * [Производительность CachyOS на базе Arch Linux](https://www.phoronix.com/review/cachyos-linux-perf)
 
 * **29/02/2024:** Phoronix провел еще один бенчмарк, демонстрирующий разницу между пакетами x86-64-v4, x86-64-v3 и x86-64 (generic). Если посмотреть на примеры, такие как PHP или GCC, где мы модифицируем наши PKGBUILD, заметно значительное улучшение производительности.
-  * [Arch Linux CachyOS Benchmarks Of x86-64-v3 & x86-64-v4 Repositories](https://www.phoronix.com/review/cachyos-x86-64-v3-v4)
+  * [Бенчмарки CachyOS для репозиториев x86-64-v3 и x86-64-v4 на Arch Linux](https://www.phoronix.com/review/cachyos-x86-64-v3-v4)
 
 * **20/08/2024:** Майкл опубликовал новый бенчмарк для AMD Ryzen 9 9950x, в котором участвует CachyOS и некоторые другие дистрибутивы Linux.
-  * [Intel Continues To Show AMD The Importance Of Software Optimizations: 16% More Ryzen 9 9950X Performance](https://www.phoronix.com/review/linux-os-amd-ryzen9-9950x)
+  * [Intel продолжает показывать AMD важность оптимизаций программного обеспечения: на 16% больше производительности Ryzen 9 9950X](https://www.phoronix.com/review/linux-os-amd-ryzen9-9950x)
    :::note
    Liquid-DSP и RocksDB были скомпилированы с помощью Phoronix Benchmark Suite, игнорируя флаги компиляции, указанные в /etc/makepkg.conf, что привело к неожиданным результатам производительности для CachyOS.
    :::


### PR DESCRIPTION
As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one and if things are or aren't translated.

## As I have strong critical opinions on AI-use myself, I want the process to be ran on local hardware and as transparent as possible, which is why I'm listing prompt, model, soft- and hardware that were used. Feel free to suggest any changes or request any clarification of my approach.

### Prompt used:
"Today we are going to translate technical documentation for the CachyOS wiki (Arch-based Linux distro).                                                                                 
                                                                                                                                                                                           
TRANSLATION RULES:                                                                                                                                                                      
                                                                                                                                                                                           
TRANSLATE:                                                                                                                                                                              
- Body text and explanatory content                                                                                                                                                     
- Headings, titles, section labels                                                                                                                                                      
- UI labels (TabItem labels, button text, etc.)                                                                                                                                         
- Link display text (visible text, not the URL itself)                                                                                                                                  
- Explanatory comments (in code blocks and around terminal output)                                                                                                                      
                                                                                                                                                                                           
DO NOT TRANSLATE:                                                                                                                                                                       
- Actual commands and code                                                                                                                                                              
- Terminal output                                                                                                                                                                       
- Program/package/file names and paths (pacman, gcc, /etc/pacman.conf, etc.)                                                                                                            
- URLs                                                                                                                                                                                  
- Technical terms (bootloader, kernel, PGO, LTO, BOLT, etc.)                                                                                                                            
- External link URLs                                                                                                                                                                    
                                                                                                                                                                                           
GOAL: Translate the context so a native reader understands what to do, without over-translating. Users are expected to know basic Linux concepts by their English names.                
                                                                                                                                                                                           
INTERNAL LINKS: English files live at /src/content/docs/<path>.mdx, translations at /src/content/docs/<lang-code>/<path>.mdx. When a link points to another wiki page, add the language code (e.g., /ru/installation/...) so users stay on the translated site. External links stay unchanged.                                                                                    
                                                                                                                                                                                           
UPDATING EXISTING TRANSLATIONS:                                                                                                                                                         
- Translated pages usually exist but are outdated; keep existing translation for unchanged content                                                                                     
- Apply all differences from English: add new content, remove deleted content, update changed content                                                                                   
- Minimal changes only; do not rewrite unchanged sections                                                                                                                              
- Match English formatting EXACTLY: same line breaks, same punctuation marks (' stays ', not ` or "), same spacing                                                                      
                                                                                                                                                                                           
Now, translate/update the English file /home/c/Dokumente/GitHub/wiki/src/content/docs/features/optimized_repos.mdx to Russian at /home/c/Dokumente/GitHub/wiki/src/content/docs/ru/features/optimized_repos.mdx"

### Model used:
[A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

### Software used:
My own AUR packages [llama.cpp-sycl](https://github.com/cantosun99/llama.cpp-sycl) and [intel-deep-learning-essentials](https://github.com/cantosun99/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

### Hardware used:
Sparkle Intel Arc Pro B70 with 32GB VRAM
