### PR TITLE
installation_on_root.mdx: Updated Russian transl.

### DIFF
--- a/src/content/docs/ru/installation/installation_on_root.mdx
+++ b/src/content/docs/ru/installation/installation_on_root.mdx
@@ -69,14 +69,14 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 5. Создайте новый раздел со следующими параметрами в зависимости от выбранного загрузчика:
     <Tabs>
-        <TabItem label='systemd-boot и rEFInd'>
-            - ##### Размер: не менее **2048 МиБ**
+        <TabItem label='Limine'>
+            - ##### Размер: не менее **4096 МиБ**
             - ##### Файловая система: **FAT32**
             - ##### Точка монтирования: **/boot**
             - ##### Флаги: **boot**
         </TabItem>
-        <TabItem label='Limine'>
-            - ##### Размер: не менее **4096 МиБ**
+        <TabItem label='systemd-boot и rEFInd'>
+            - ##### Размер: не менее **2048 МиБ**
             - ##### Файловая система: **FAT32**
             - ##### Точка монтирования: **/boot**
             - ##### Флаги: **boot**
@@ -196,6 +196,12 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
   - Обратитесь к разделу [Создание загрузочного USB-накопителя CachyOS](/ru/installation/installation_prepare#создание-загрузочного-usb-накопителя-cachyos).
 
 <Tabs>
+    <TabItem label='Limine'>
+        Limine должна автоматически обнаружить раздел Windows EFI и добавить его в меню загрузки. Если Windows не появляется в меню загрузки, выполните следующую команду:
+        ```bash
+        sudo limine-scan
+        ```
+    </TabItem>
     <TabItem label='systemd-boot'>
         **Нам нужно скопировать бинарные файлы Windows EFI в раздел Linux EFI, чтобы загрузчик мог их распознать.**
 
@@ -241,7 +247,9 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
         </Steps>
     </TabItem>
 
-    <TabItem label='GRUB'>
+    <TabItem label='GRUB (Только для старых установок)'>
+        :::tip[CachyOS включает os-prober по умолчанию.]
+        :::
         **GRUB использует os-prober для автоматического обнаружения раздела Windows EFI и добавления его в меню загрузки.**
 
         <Steps>


### PR DESCRIPTION
As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one and if things are or aren't translated.

## As I have strong critical opinions on AI-use myself, I want the process to be ran on local hardware and as transparent as possible, which is why I'm listing prompt, model, soft- and hardware that were used. Feel free to suggest any changes or request any clarification of my approach.

### Prompt used:
"Today we are going to translate technical documentation for the CachyOS wiki (Arch-based Linux distro).

TRANSLATION RULES:

TRANSLATE:
- Body text and explanatory content
- Headings, titles, section labels
- UI labels (TabItem labels, button text, etc.)
- Link display text (visible text, not the URL itself)
- Explanatory comments (in code blocks and around terminal output)

DO NOT TRANSLATE:
- Actual commands and code
- Terminal output
- Program/package/file names and paths (pacman, gcc, /etc/pacman.conf, etc.)
- URLs
- Technical terms (bootloader, kernel, PGO, LTO, BOLT, etc.)
- External link URLs

GOAL: Translate the context so a native reader understands what to do, without over-translating. Users are expected to know basic Linux concepts by their English names.

INTERNAL LINKS: English files live at /src/content/docs/<path>.mdx, translations at /src/content/docs/<lang-code>/<path>.mdx. When a link points to another wiki page, add the language code (e.g., /ru/installation/...) so users stay on the translated site. External links stay unchanged.

UPDATING EXISTING TRANSLATIONS:
- Translated pages usually exist but are outdated; keep existing translation for unchanged content
- Apply all differences from English: add new content, remove deleted content, update changed content
- Minimal changes only; do not rewrite unchanged sections
- Match English formatting EXACTLY: same line breaks, same punctuation marks (' stays ', not ` or "), same spacing

Now, translate/update the English file /home/c/Dokumente/GitHub/wiki/src/content/docs/installation/installation_on_root.mdx to Russian at /home/c/Dokumente/GitHub/wiki/src/content/docs/ru/installation/installation_on_root.mdx"

### Model used:
[A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

### Software used:
My own AUR packages [llama.cpp-sycl](https://github.com/cantosun99/llama.cpp-sycl) and [intel-deep-learning-essentials](https://github.com/cantosun99/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

### Hardware used:
Sparkle Intel Arc Pro B70 with 32GB VRAM
