### PR TITLE
Updated Portuguese translations

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -664,6 +664,7 @@ export default defineConfig({
                 ja: 'デスクトップ環境',
                 ru: 'Окружения рабочего стола',
                 bg: 'Графични среди',
+                pt: 'Ambientes de Desktop',
               },
             },
           ],

--- a/src/content/docs/pt/cachyos_basic/faq.mdx
+++ b/src/content/docs/pt/cachyos_basic/faq.mdx
@@ -4,6 +4,7 @@ description: Perguntas frequentes e dicas
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 5
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
@@ -50,8 +51,8 @@ tldr git add
 - [GitHub](https://github.com/CachyOS/distribution)
 - [Fórum](https://discuss.cachyos.org/c/feedback/bugreports/10)
 - **Discord:** [Fórum de Suporte](https://discord.com/channels/862292009423470592/1400865136373403708)
-  - Antes de criar uma nova publicação, lê as [Diretrizes e Informações de Suporte](https://discord.com/channels/862292009423470592/1402210965700739082) fixadas no canal.
-  - Ou, se achares que o teu problema pode ser resolvido rapidamente, utiliza o [canal #support](https://discord.com/channels/862292009423470592/862294383470051348)
+  - Antes de criar uma nova publicação, lê as [diretrizes de suporte](https://discord.com/channels/862292009423470592/1522310323250397274) fixadas no canal.
+    - Ou, se achares que o teu problema pode ser resolvido rapidamente, utiliza o [canal #support](https://discord.com/channels/862292009423470592/862294383470051348)
 - [Reddit](https://www.reddit.com/r/cachyos/)
 
 ### Sê Paciente e Respeitoso
@@ -210,7 +211,6 @@ Procura por corrupção de memória ou problemas de deteção.
 ```bash
 # Do arranque (boot) atual:
 journalctl -u bluetooth -b 0
-journalctl -u bluetooth -b 0
 # Do arranque (boot) anterior:
 journalctl -u bluetooth -b -1
 ```
@@ -273,7 +273,7 @@ journalctl -p err..emerg --since "9:00" --until "10:00"
 
 <details>
 <summary>Mostrar logs de um serviço específico do sistema:</summary>
-```bash title='Examples'
+```bash title='Exemplos'
 # Visualizar logs do serviço NetworkManager:
 journalctl -u NetworkManager
 # Visualizar logs do serviço GDM (GNOME Display Manager):
@@ -555,13 +555,13 @@ Isto acontece quando o instalador tem dificuldade em descarregar os pacotes. Ger
 ## Recuperação do Carregador de Arranque
 
 :::note
-No caso de uma partição `/boot` eliminada, por favor crie uma nova seguindo o respetivo [esquema de partição](/installation/installation_on_root#uefigpt) a partir do passo 5.
+No caso de uma partição `/boot` eliminada, por favor crie uma nova seguindo o respetivo [esquema de partição](/pt/installation/installation_on_root#uefigpt) a partir do passo 5.
 :::
 
 ### Passos para recuperar o seu carregador de arranque (bootloader)
 
 :::tip
-Se não tiver a certeza de como utilizar o `cachy-chroot`, por favor consulte primeiro a documentação do [CachyOS chroot Helper](/features/cachy_chroot).
+Se não tiver a certeza de como utilizar o `cachy-chroot`, por favor consulte primeiro a documentação do [CachyOS chroot Helper](/pt/features/cachy_chroot).
 :::
 
 <Steps>
@@ -572,7 +572,7 @@ Se não tiver a certeza de como utilizar o `cachy-chroot`, por favor consulte pr
         sudo cachy-chroot
         ```
         Se o sistema estiver a utilizar BTRFS com o nosso preset, responda `y` (sim) no prompt:
-         ```bash title='Example'
+         ```bash title='Exemplo'
           Do you want to use CachyOS BTRFS preset to auto mount root subvolume? y
           Do you want to mount additional partitions? · yes
           Enter the mount point for additional partition (e.g. /boot) type 'skip' to cancel:
@@ -639,7 +639,7 @@ Se não tiver a certeza de como utilizar o `cachy-chroot`, por favor consulte pr
 
 ### Resolução de Problemas do Pacman
 
-#### error: signature is invalid (erro: a assinatura é inválida)
+#### error: signature is invalid
 
 Este erro indica um problema com a assinatura criptográfica de um pacote. Geralmente é causado por um espelho (mirror) desatualizado ou por um chaveiro (keyring) danificado no seu sistema.
 
@@ -674,7 +674,7 @@ Se a classificação dos mirrors não funcionar, é provável que os chaveiros (
 
 </Tabs>
 
-#### error: 404 Not Found (erro: 404 Não Encontrado)
+#### error: 404 Not Found
 
 Este erro significa que o pacote que está a tentar instalar não está disponível no seu mirror atual. Isto acontece geralmente quando a sua base de dados de pacotes local está dessincronizada em relação aos repositórios remotos.
 
@@ -687,20 +687,20 @@ sudo pacman -Syu
 # Depois, tente instalar novamente o pacote pretendido.
 ```
 
-#### error: could not remove (erro: não foi possível remover)
+#### error: could not remove
 
 Este erro ocorre quando a cache do pacman contém ficheiros que o sistema não consegue gerir automaticamente. Este é um problema comum que pode ser resolvido facilmente.
 
-- **Solução 1: Utilizar o CachyOS Hello.**
+- Solution 1: Utilizar o CachyOS Hello.
   - A forma mais simples de resolver isto é com o CachyOS Hello. Abra-o, vá a **Troubleshooting** e clique no botão **Clear package cache**.
 
-- **Solução 2: Remover a cache manualmente.**
+- Solution 2: Remover a cache manualmente.
   - Execute o seguinte comando para remover todos os pacotes órfãos da cache.
   ```sh
   sudo rm -r /var/cache/pacman/pkg/*
   ```
 
-#### error: File is corrupted (invalid or corrupted package (PGP signature)) (erro: o ficheiro está corrompido)
+#### error: File is corrupted (invalid or corrupted package (PGP signature))
 
 ```sh
 # Exemplo:
@@ -728,21 +728,21 @@ sudo cachyos-rate-mirrors
 sudo pacman -Scc
 ```
 
-#### error: unable to lock database (erro: não foi possível bloquear a base de dados)
+#### error: unable to lock database
 
 Este erro ocorre quando outro processo do pacman já está em execução, o que bloqueia a base de dados para evitar a sua corrupção. Se o processo anterior falhou ou foi interrompido, o ficheiro de bloqueio `db.lck` pode não ter sido removido.
 
-- **Solução 1: Utilizar o CachyOS Hello**
-  - A forma mais simples de resolver isto é com a função **Remove db lock** no separador **Troubleshooting** do CachyOS Hello.
+- Solution 1: Utilizar o CachyOS Hello
+  - A forma mais simples de resolver isto é com a função **Remove db lock** no separador **Troubleshooting** do CachyOS Hello
 
-- **Solução 2: Remover o ficheiro de bloqueio manualmente**
+- Solution 2: Remover o ficheiro de bloqueio manualmente
   - Se preferir não utilizar o CachyOS Hello, pode remover o ficheiro de bloqueio manualmente:
 
 ```sh
 sudo rm /var/lib/pacman/db.lck
 ```
 
-#### error: failed retrieving file ... Connection timed out (erro: falha ao obter o ficheiro ... Ligação expirada)
+#### error: failed retrieving file ... Connection timed out
 
 Poderá ver erros semelhantes a estes:
 
@@ -755,7 +755,7 @@ error: failed retrieving file '...' from ... : The requested URL returned error:
 
 Estes erros indicam quase sempre um problema com os seus espelhos (mirrors) atuais. Podem estar lentos, temporariamente indisponíveis ou inacessíveis a partir da sua localização.
 
-- **Solução:** A melhor forma de resolver isto é atualizar a sua lista de mirrors com espelhos mais rápidos e fiáveis.
+- Solution: A melhor forma de resolver isto é atualizar a sua lista de mirrors com espelhos mais rápidos e fiáveis.
 
 ```sh
 sudo cachyos-rate-mirrors
@@ -769,21 +769,21 @@ O comando `cachyos-rate-mirrors` testa os mirrors do CachyOS disponíveis com ba
 Considere executá-lo periodicamente, especialmente se notar lentidão durante as atualizações do sistema.
 :::
 
-#### warning: local is newer than... (aviso: a versão local é mais recente que...)
+#### warning: local is newer than...
 
 Este aviso aparece quando a versão de um pacote no seu sistema é mais recente do que a versão disponível nos repositórios oficiais. Isto pode acontecer se um mirror estiver desatualizado, se um pacote tiver sofrido um downgrade nos repositórios ou se um pacote tiver sido instalado a partir de uma fonte diferente.
 
-- **Solução:** o comando `pacman -Syuu` realiza uma atualização completa do sistema e permite a realização de downgrades, o que resolverá o aviso ao sincronizar os seus pacotes locais com as versões do repositório.
+- Solution: o comando `pacman -Syuu` realiza uma atualização completa do sistema e permite a realização de downgrades, o que resolverá o aviso ao sincronizar os seus pacotes locais com as versões do repositório.
 
 ```sh title='Para remover estes avisos, execute o seguinte comando:'
 sudo pacman -Syuu
 ```
 
-#### error: failed to commit transaction (conflicting files) (erro: falha ao submeter a transação (ficheiros em conflito))
+#### error: failed to commit transaction (conflicting files)
 
 Este erro indica que o pacman está a tentar instalar ou atualizar um pacote que contém ficheiros já presentes no seu sistema, provenientes de uma fonte diferente. Esta é uma funcionalidade de segurança integrada para evitar danos no sistema.
 
-- **Solução:** Pode resolver este problema removendo manualmente os ficheiros em conflito. Para mais informações e soluções, consulte a [Arch Wiki](https://wiki.archlinux.org/title/Pacman#%22Failed_to_commit_transaction_(conflicting_files)%22_error).
+- Solution: Pode resolver este problema removendo manualmente os ficheiros em conflito. Para mais informações e soluções, consulte a [Arch Wiki](https://wiki.archlinux.org/title/Pacman#%22Failed_to_commit_transaction_(conflicting_files)%22_error).
 
 ```sh title='Exemplo'
 error: failed to commit transaction (conflicting files)
@@ -798,7 +798,7 @@ Para corrigir este exemplo específico, deve remover o ficheiro em conflito e, e
 sudo rm /usr/lib/environment.d/10-gsk.conf
 ```
 
-#### ERROR: module not found: 'nvidia', 'nvidia_modeset', ... (ERRO: módulo não encontrado)
+#### ERROR: module not found: 'nvidia', 'nvidia_modeset', ...
 
 ```sh title='Exemplo'
 ==> ERROR: module not found: 'nvidia'
@@ -813,7 +813,7 @@ sudo rm /usr/lib/environment.d/10-gsk.conf
 
 2) Podem estar em falta os módulos NVIDIA para outros kernels instalados no seu sistema.
 
-```sh title='Instale o seguinte pacote para corrigir este erro:'
+```sh title='Install the following package to fix this error'
 sudo pacman -S nvidia
 ```
 
@@ -826,9 +826,32 @@ sudo pacman -S nvidia
 
 Isto acontece porque o Discord utiliza o seu próprio sistema de atualização, que se adianta aos repositórios oficiais. Foi lançada uma nova versão da aplicação, mas esta ainda não foi empacotada para os nossos mirrors.
 
-Para contornar este problema, siga o [guia de correção da Arch Wiki](https://wiki.archlinux.org/title/Discord#Discord_asks_for_an_update_not_yet_available_in_the_repository).
+Para contornar este problema, siga o [guia de correção da Arch Wiki](<https://wiki.archlinux.org/title/Discord#Discord_asks_for_an_update_not_yet_available_in_the_repository>).
 
 ### Questões Gerais
+
+#### Recentemente, o meu sistema está a demorar muito tempo a arrancar
+
+Uma vez que este problema pode ser causado por muitas coisas diferentes. Vamos começar pelo básico, verificando o systemd-analyze para ver onde o sistema está a ter problemas:
+
+Abra um terminal e execute um dos dois seguintes comandos:
+
+```sh
+systemd-analyze blame
+```
+
+ou:
+
+```sh
+systemd-analyze critical-chain
+```
+
+Se o output mostrar `cachyos-rate-mirrors.service` a demorar muito tempo a executar. Então deve executar o seguinte comando para mascarar este serviço, o que impedirá que este seja executado no arranque:
+
+```sh
+systemctl mask cachyos-rate-mirrors
+systemctl mask cachyos-rate-mirrors.timer
+```
 
 #### Qual é a origem do CachyOS e por que se chama "CachyOS"?
 
@@ -849,7 +872,7 @@ Não. Os pacotes `-bin` são binários pré-compilados e não incluem as mesmas 
 :::note[Isto pode resolver problemas de ecrã preto em alguns sistemas, especialmente naqueles com GPUs NVIDIA antigas.]
 :::
 
-Para desativar a animação de carregamento inicial, precisa de editar a sua [configuração do gestor de arranque (bootloader)](/configuration/boot_manager_configuration) e adicionar os seguintes parâmetros de kernel:
+Para desativar a animação de carregamento inicial, precisa de editar a sua [configuração do gestor de arranque (bootloader)](/pt/configuration/boot_manager_configuration) e adicionar os seguintes parâmetros de kernel:
 
 ```sh
 plymouth.enable=0 disablehooks=plymouth
@@ -865,7 +888,8 @@ Limine: `sudo limine-mkinitcpio`
 
 #### Submeter pedidos de pacotes ao CachyOS
 
-O CachyOS oferece uma lista extensa de pacotes do AUR pré-compilados, que são comummente utilizados. Os utilizadores podem criar pedidos para pacotes do AUR que, se aprovados, são atualizados automaticamente pelo nosso servidor de build.
+O CachyOS oferece uma lista extensa de pacotes do AUR pré-compilados, que são comummente utilizados.
+Os utilizadores podem criar pedidos para pacotes do AUR das seguintes formas:
 
 Se pretender que adicionemos um pacote, pode submeter um pedido no GitHub ou no fórum.
 
@@ -893,6 +917,10 @@ O AUR oferece uma vasta seleção, mas a segurança é primordial. Aqui está um
 
 Mantenha-se vigilante para conservar o seu sistema baseado em Arch seguro!
 
+### Manutenção Regular do CachyOS
+
+Siga a Arch Wiki para isto: https://wiki.archlinux.org/title/System_maintenance
+
 ### Escolher um Gestor de Pacotes Gráfico (GUI)
 
 Embora os gestores de pacotes gráficos ofereçam conveniência, alguns são conhecidos por causar problemas graves em sistemas rolling-release como o CachyOS e devem ser evitados para gerir pacotes do sistema.
@@ -902,4 +930,4 @@ Embora os gestores de pacotes gráficos ofereçam conveniência, alguns são con
 
 Para máxima estabilidade e fiabilidade, **recomendamos vivamente** a gestão de pacotes do sistema através da linha de comandos com o `pacman`.
 
-Se preferir uma interface gráfica, front-ends como o **[Octopi](</configuration/post_install_setup/#updating-the-system>)** ou o **CachyOS Package Installer** são considerados alternativas seguras, pois funcionam como wrappers mais diretos para as funcionalidades do pacman.
+Se preferir uma interface gráfica, front-ends como o **[Shelly](</pt/configuration/post_install_setup/#updating-the-system>)** ou o **CachyOS Package Installer** são considerados alternativas seguras, pois funcionam como wrappers mais diretos para as funcionalidades do pacman.

--- a/src/content/docs/pt/configuration/automount_with_fstab.mdx
+++ b/src/content/docs/pt/configuration/automount_with_fstab.mdx
@@ -1,61 +1,273 @@
 ---
-title: Automontar Discos Adicionais via fstab no Arranque
-description: Monte discos estáticos adicionais no arranque utilizando o ficheiro localizado em /etc/fstab
+title: Automontar Discos Adicionais no Arranque
+description: Monte discos estáticos adicionais no arranque utilizando mounts do systemd ou o ficheiro localizado em /etc/fstab
+ai_translated: true
 ---
 
-Este tutorial descreve os conceitos básicos da utilização do ficheiro fstab localizado em /etc/, de modo a montar discos estáticos durante o arranque. Explica brevemente como encontrar o UUID de uma partição ou disco, o que algumas opções fazem e leituras adicionais caso a informação fornecida seja insuficiente.
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+
+Este tutorial descreve os conceitos básicos da utilização tanto de ficheiros de montagem do systemd como do ficheiro fstab localizado em /etc/, de modo a montar discos estáticos durante o arranque. Explica brevemente como encontrar o UUID de uma partição ou disco, o que algumas opções fazem e leituras adicionais caso a informação fornecida seja insuficiente.
 
 ## Pré-requisitos
 
 - Acesso Root ou sudo
 
-## Adicionar Entradas ao /etc/fstab
-
 :::note[NTFS no Linux]
-O sistema de ficheiros NTFS pode ser instável em Linux, quer utilize o controlador ntfs3 ou o ntfs-3g. Utilize-o por sua conta e risco. Para melhor estabilidade e desempenho, considere sistemas de ficheiros nativos do Linux, como ext4, xfs ou btrfs.
+O sistema de ficheiros NTFS pode ser instável em Linux, quer utilize o controlador ntfs, ntfs3 ou ntfs-3g. Utilize-o por sua conta e risco. Para melhor estabilidade e desempenho, considere sistemas de ficheiros nativos do Linux, como ext4, xfs ou btrfs.
 :::
+
+## Método Mais Seguro e Amigável para Iniciantes: Montar Discos com Ficheiros de Montagem do Systemd
+
+A vantagem de montar via systemd é que, mesmo que cometa um erro no ficheiro de montagem, o seu sistema ainda arrancará. Ao contrário de um erro no fstab, que pode tornar o seu sistema não arrancável.
 
 ### 1. Listar os UUIDs das suas partições
 
-```sh title="Abra um terminal e execute o seguinte comando:"
+```sh title="Abra um terminal e execute o seguinte comando"
 lsblk -f
 ```
 
-```text title="Exemplo de saída:"
-# NAME        FSTYPE FSVER LABEL UUID                                 FSAVAIL FSUSE% MOUNTPOINTS
-# zram0                                                                              [SWAP]
-# nvme0n1
-# ├─nvme0n1p1 vfat   FAT32       E04D-9F05
-# ├─nvme0n1p2
-# ├─nvme0n1p3 ntfs               08A24E90A24E81E4                      715.4G    50%
-# ├─nvme0n1p4 vfat   FAT32       E09C-D4DA                             628.1M    39% /boot
-# ├─nvme0n1p5 ext4   1.0         187a9f06-9411-48d9-b941-f03c2e605812  203.6G    47% /
-# └─nvme0n1p6 ntfs
+```sh title="Exemplo de saída"
+NAME          FSTYPE FSVER LABEL UUID                                 FSAVAIL   FSUSE% MOUNTPOINTS
+zram0                                                                              [SWAP]
+nvme0n1
+├─nvme0n1p1   vfat   FAT32       E04D-9F05
+├─nvme0n1p2
+├─nvme0n1p3   ntfs               08A24E90A24E81E4                      715.4G   50%
+├─nvme0n1p4   vfat   FAT32       E09C-D4DA                             628.1M   39% /boot
+├─nvme0n1p5   ext4   1.0         187a9f06-9411-48d9-b941-f03c2e605812  203.6G   47% /
+└─nvme0n1p6   ntfs
+nvme1n1
+└─nvme1n1p1   ext4               4e55896f-3f1f-4bc5-aa8a-fec099689cd9  931.5G   0%
+
 ```
 
-No nosso exemplo, sabemos que queremos montar uma partição Windows, que é NTFS. Também sabemos que sensivelmente metade do seu espaço está disponível. Portanto, podemos determinar que a partição que queremos montar é a `nvme0n1p3` e o seu UUID é `08A24E90A24E81E4`, com um sistema de ficheiros `ntfs` neste exemplo.
+Neste exemplo, queremos montar um disco extra recém-formatado como ext4. Sabemos que é um disco de 1TB e que ainda nada foi guardado nele. Portanto, podemos determinar que a partição a montar é `nvme1n1p1` que tem o UUID `4e55896f-3f1f-4bc5-aa8a-fec099689cd9`.
 
 ### 2. Identificar a sua partição
 
-Frequentemente, o `lsblk -f` fornecerá nesta fase toda a informação de que necessita para montar o seu disco através do /etc/fstab. Se ainda não tiver a certeza de qual é a partição correta, pode executar o seguinte comando:
+Frequentemente, o `lsblk -f` fornecerá toda a informação de que precisa para montar o seu disco com systemd neste ponto. Se ainda não tiver a certeza de qual é a partição correta, pode executar o seguinte comando:
 
 ```sh
 sudo fdisk -l
 ```
 
-```text title="Exemplo de saída:"
-# Device              Start        End    Sectors  Size Type
-# /dev/nvme0n1p1       2048     206847     204800  100M EFI System
-# /dev/nvme0n1p2     206848     239615      32768   16M Microsoft reserved
-# /dev/nvme0n1p3     239616 2997384182 2997144567  1.4T Microsoft basic data
-# /dev/nvme0n1p4 2997385216 2999482367    2097152    1G EFI System
-# /dev/nvme0n1p5 2999482368 3905454079  905971712  432G Linux root (x86-64)
-# /dev/nvme0n1p6 3905454080 3907026943    1572864  768M Windows recovery environment
+```sh title="Exemplo de saída"
+Device          Start       End         Sectors     Size    Type
+/dev/nvme0n1p1  2048        206847      204800      100M    EFI System
+/dev/nvme0n1p2  206848      239615      32768       16M     Microsoft reserved
+/dev/nvme0n1p3  239616      2997384182  2997144567  1.4T    Microsoft basic data
+/dev/nvme0n1p4  2997385216  2999482367  2097152     1G      EFI System
+/dev/nvme0n1p5  2999482368  3905454079  905971712   432G    Linux root (x86-64)
+/dev/nvme0n1p6  3905454080  3907026943  1572864     768M    Windows recovery environment
+/dev/nvme1n1p1  2048        1953523711  1953521664  931.5G  Linux filesystem
+
+```
+
+Já conhecemos o nosso UUID neste exemplo. No entanto, o `fdisk -l` pode tornar tudo um pouco mais claro ao mostrar o tamanho exato da partição (931.5G), bem como o seu tipo (Linux filesystem).
+
+Isto deverá tornar perfeitamente claro que a partição que pretendemos é `nvme1n1p1` com o UUID `4e55896f-3f1f-4bc5-aa8a-fec099689cd9`, conforme descrito anteriormente. Já o sabíamos antes, mas agora temos a certeza absoluta.
+
+Assim que tiver a confiança de ter encontrado a partição correta, copie o UUID. A cópia a partir do emulador de terminal é normalmente feita com `ctrl+shift+C`.
+
+### 3. Criar o Ficheiro de Montagem do Systemd
+Digamos que queremos usar este disco principalmente para jogos, um bom local para o montar é na sua pasta pessoal (home). Pode ser em qualquer lado que queira, mas por simplicidade vamos usar /home/user (substitua user pelo seu nome de utilizador Linux). Isto é importante porque o caminho de montagem dita o nome do ficheiro de montagem do systemd. Como este disco é destinado a jogos, vamos montá-lo na pasta de jogos da home do utilizador, `/home/user/games`.
+
+Para um ficheiro de montagem do systemd, isso traduz-se em home-$USER-games.mount (as barras `/` são substituídas por hífens `-`) e os ficheiros de montagem do systemd ficam em /etc/systemd/system.
+
+:::tip
+Se quiser usar um espaço, um hífen, um caractere CJK ou um caractere acentuado no nome da sua pasta de montagem, este deve ser formatado de forma diferente. Digamos que quer usar o caminho da pasta `/home/grzegorz/brzęczyszczykiewicz`, execute o seguinte comando para obter o nome que precisa de usar com o seu ficheiro:
+```bash
+systemd-escape -p --suffix=mount "/home/grzegorz/brzęczyszczykiewicz"
+```
+Como precisa de escapar qualquer `\`, criaria o ficheiro de montagem como `/etc/systemd/system/home-grzegorz-brz\\xc4\\x99czyszczykiewicz.mount`
+:::
+
+Sinta-se à vontade para usar o editor de texto da sua preferência, neste exemplo iremos usar `micro`.
+
+```sh
+micro /etc/systemd/system/home-$USER-games.mount
+```
+:::note
+Se estiver a montar na sua pasta pessoal (home), pode manter o $USER acima no nome do ficheiro, o seu nome de utilizador tomará automaticamente o seu lugar.
+:::
+
+Cole este modelo no ficheiro vazio:
+```ini
+[Unit]
+Description=
+
+[Mount]
+What=
+Where=
+Type=
+Options=
+
+[Install]
+WantedBy=multi-user.target
+```
+Abaixo estão as descrições para cada campo no ficheiro:
+
+<Tabs>
+  <TabItem label='Description'>
+  Description pode ser qualquer coisa que queira, é para a sua própria identificação.
+  </TabItem>
+  <TabItem label= 'What'>
+  Coloque o UUID que copiou anteriormente. Aqui será `UUID=4e55896f-3f1f-4bc5-aa8a-fec099689cd9`
+  </TabItem>
+  <TabItem label= 'Where'>
+  Este é o ponto de montagem. Uma pasta será criada se não existir. Aqui, será `/home/user/games`. Substitua "user" pelo seu nome de utilizador se montar na sua pasta pessoal (home).
+  </TabItem>
+  <TabItem label= 'Type'>
+  Tipo de sistema de ficheiros, aqui será `ext4`
+  </TabItem>
+  <TabItem label= 'Options'>
+  Quaisquer opções de montagem que queira. Aqui, usaremos `defaults,exec,rw,noatime`. Não ter espaços é importante aqui.
+  </TabItem>
+</Tabs>
+---
+
+Seguindo o exemplo, o ficheiro de montagem preenchido deve parecer-se com isto:
+```ini
+[Unit]
+Description=Mount games drive (/home/user/games)
+
+[Mount]
+What=UUID=4e55896f-3f1f-4bc5-aa8a-fec099689cd9
+Where=/home/user/games
+Type=ext4
+Options=defaults,exec,rw,noatime
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### 4. Finalização
+Para montar o disco para o qual acabámos de criar uma entrada, execute o seguinte:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now home-$USER-games.mount
+```
+
+Deverá ver a pasta que escolheu para o ponto de montagem, e pode verificar o estado da montagem com `systemctl status home-$USER-games.mount`:
+
+```sh
+● home-user-games.mount - Mount games drive (/home/user/games)
+     Loaded: loaded (/proc/self/mountinfo; enabled; preset: disabled)
+     Active: active (mounted) since Sat 2026-05-02 13:02:31 CDT; 23h ago
+ Invocation: e52ef8fe3d754c64a3825bc1ee89e7da
+      Where: /home/user/games
+       What: /dev/nvme1n1p1
+      Tasks: 0 (limit: 74118)
+     Memory: 316K (peak: 3.9M)
+        CPU: 5ms
+     CGroup: /system.slice/home-user-games.mount
+
+May 02 13:02:31 cachyos systemd[1]: Mounting Mount games drive (/home/user/games)...
+May 02 13:02:31 cachyos systemd[1]: Mounted Mount games drive (/home/user/games).
+```
+
+### tl;dr
+
+- Encontre o **UUID** da sua partição
+
+```sh
+lsblk -f
+```
+
+- Crie o ficheiro de montagem
+
+```sh
+micro /etc/systemd/system/mnt-foo.mount
+```
+
+Substituindo `mnt-foo` pelo caminho completo de onde quer montar, trocando o `/` por `-`.
+
+- Preencha o ficheiro de montagem
+
+```sh
+[Unit]
+Description=Mount drive
+
+[Mount]
+What=UUID=<partition UUID>
+Where=/mnt/foo
+Type=somefs
+Options=defaults
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Substituindo `<partition UUID>`, `/mnt/foo`, e `somefs` pelo seu UUID, diretório e sistema de ficheiros. ex: ext4, bem como definindo quaisquer outras opções que possa querer após defaults, tais como `_netdev` para um NAS, ou `nofail` para qualquer disco não crítico.
+
+- Recarregue o seu daemon
+
+```sh
+sudo systemctl daemon-reload
+```
+
+- Monte o seu disco e defina-o para montar no arranque
+
+```sh
+sudo systemctl enable --now mnt-foo.mount
+```
+
+### Leitura adicional
+
+- [Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)
+- [FHS sobre /media/](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s11.html)
+- [Manual do dump](<https://linux.die.net/man/8/dump>)
+- [Manual do fsck](https://man.archlinux.org/man/fsck.8)
+- [systemd-mount](https://manual.siduction.org/systemd-mount_en.html)
+
+## Método Avançado: Adicionar Entradas ao /etc/fstab
+
+:::danger
+O ficheiro fstab é lido durante o arranque, e se houver um erro no ficheiro, pode fazer com que o seu sistema falhe ao arrancar. Certifique-se de verificar duas vezes a sua entrada para quaisquer erros de digitação antes de reiniciar. Se cometer um erro, pode normalmente corrigi-lo arrancando num ambiente live e [fazendo chroot na sua instalação](/pt/features/cachy_chroot) para editar o ficheiro.
+:::
+
+### 1. Listar os UUIDs das suas partições
+
+```sh title="Abra um terminal e execute o seguinte comando"
+lsblk -f
+```
+
+```sh title="Exemplo de saída"
+NAME        FSTYPE FSVER LABEL UUID                                 FSAVAIL FSUSE% MOUNTPOINTS
+zram0                                                                              [SWAP]
+nvme0n1
+├─nvme0n1p1 vfat   FAT32       E04D-9F05
+├─nvme0n1p2
+├─nvme0n1p3 ntfs               08A24E90A24E81E4                      715.4G    50%
+├─nvme0n1p4 vfat   FAT32       E09C-D4DA                             628.1M    39% /boot
+├─nvme0n1p5 ext4   1.0         187a9f06-9411-48d9-b941-f03c2e605812  203.6G    47% /
+└─nvme0n1p6 ntfs
+```
+
+No nosso exemplo, sabemos que queremos montar uma partição Windows, que é ntfs. Também sabemos que sensivelmente metade do seu espaço está disponível. Portanto, podemos determinar que a partição que queremos montar é `nvme0n1p3` e o seu UUID é `08A24E90A24E81E4`, com um sistema de ficheiros `ntfs` neste exemplo.
+
+### 2. Identificar a sua partição
+
+Frequentemente, o `lsblk -f` fornecerá toda a informação de que precisa para montar o seu disco através do /etc/fstab neste ponto. Se ainda não tiver a certeza de qual é a partição correta, pode executar o seguinte comando:
+
+```sh
+sudo fdisk -l
+```
+
+```sh title="Exemplo de saída"
+Device              Start        End    Sectors  Size Type
+/dev/nvme0n1p1       2048     206847     204800  100M EFI System
+/dev/nvme0n1p2     206848     239615      32768   16M Microsoft reserved
+/dev/nvme0n1p3     239616 2997384182 2997144567  1.4T Microsoft basic data
+/dev/nvme0n1p4 2997385216 2999482367    2097152    1G EFI System
+/dev/nvme0n1p5 2999482368 3905454079  905971712  432G Linux root (x86-64)
+/dev/nvme0n1p6 3905454080 3907026943    1572864  768M Windows recovery environment
 ```
 
 Já conhecemos o nosso UUID neste exemplo. No entanto, o `fdisk -l` pode tornar tudo um pouco mais claro ao mostrar o tamanho exato da partição (1.4T), bem como o seu tipo (Microsoft basic data).
 
-Isto deverá tornar perfeitamente claro que a partição que pretendemos é a `nvme0n1p3` com o UUID `08A24E90A24E81E4`, conforme descrito anteriormente. Já o sabíamos antes, mas agora temos a certeza absoluta.
+Isto deverá tornar perfeitamente claro que a partição que pretendemos é `nvme0n1p3` com o UUID `08A24E90A24E81E4`, conforme descrito anteriormente. Já o sabíamos antes, mas agora temos a certeza absoluta.
 
 Assim que tiver a confiança de ter encontrado a partição correta, copie o UUID. A cópia a partir do emulador de terminal é normalmente feita com `ctrl+shift+C`.
 
@@ -76,7 +288,7 @@ UUID=08A24E90A24E81E4 /media/windows ntfs3 defaults,nofail,uid=1000,gid=1000,rw,
 ```
 
 :::note
-`/media/windows` tem de existir no seu sistema de ficheiros. Utilize o comando `mkdir` para criar o diretório caso este não exista.
+`/media/windows` tem de existir no seu sistema de ficheiros. Utilize `mkdir` para criar o diretório caso este não exista.
 :::
 
 A decomposição desta entrada é a seguinte:
@@ -85,35 +297,43 @@ A decomposição desta entrada é a seguinte:
 
 - `/media/windows` é o ponto de montagem do nosso disco. O [Linux Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html) indica que `/media/` é o local apropriado para a montagem de discos removíveis. `windows` indica o diretório onde desejamos montar o disco. Cada disco que pretendamos montar precisará do seu próprio diretório.
 
-- `ntfs3` é o tipo de sistema de ficheiros a ser utilizado. No nosso exemplo, estamos a utilizar explicitamente o controlador (driver) de kernel `ntfs3`. Outros exemplos seriam `ext4`, `xfs` ou semelhantes. Esta declaração explícita pode ser substituída por `auto` para permitir que o comando mount faça a sua melhor estimativa.
+- `ntfs3` é o tipo de sistema de ficheiros a ser utilizado. No nosso exemplo, estamos a utilizar explicitamente o controlador (driver) de kernel ntfs3. Outros exemplos seriam `ext4`, `xfs` ou semelhantes. Esta declaração explícita de tipo de sistema de ficheiros pode ser substituída por `auto` para permitir que o comando mount faça a sua melhor estimativa.
 
-- `defaults,nofail,uid=1000,gid=1000,rw,user,exec,umask=000`: Estas são as opções de montagem:
+- `defaults,nofail,uid=1000,gid=1000,rw,user,exec,umask=000`: Estas são opções de montagem:
 
   - `defaults`: um conjunto padrão de opções que inclui `rw, suid, dev, exec, auto, nouser, e async.`
-  - `nofail`: permite que o processo de arranque continue mesmo que esta montagem falhe.
-  - `uid=1000` e `gid=1000`: define a propriedade (dono e grupo) dos ficheiros montados para o utilizador e grupo com o ID 1000.
-  - `rw`: monta o sistema de ficheiros com permissões de leitura e escrita (read-write).
-  - `user`: permite que um utilizador não-root monte o sistema de ficheiros.
-  - `exec`: permite a execução de binários no sistema de ficheiros montado.
-  - `umask=000`: define a máscara de permissões de ficheiro para permitir permissões de leitura, escrita e execução para todos.
-  - `o primeiro 0` (dump) está tipicamente em desuso em sistemas modernos. Deixá-lo em 0 não causará problemas. Pode ler mais sobre isto [aqui](https://linux.die.net/man/8/dump).
-  - `o segundo 0` define a ordem para as verificações do sistema de ficheiros (fsck) no momento do arranque. Para uma partição root, este valor deve ser 1, a menos que o seu sistema de ficheiros root seja btrfs (que deve ser 0). Todos os outros sistemas de ficheiros no seu fstab devem ser 0 (desativado) ou 2. Mais informações [aqui](https://man.archlinux.org/man/fsck.8).
 
-Para uma análise mais aprofundada de cada opção, visite as páginas de manual do [fstab](https://man7.org/linux/man-pages/man5/fstab.5.html) e do [mount](https://man7.org/linux/man-pages/man8/mount.8.html).
+  - `nofail`: permite que o processo de arranque continue mesmo que esta montagem falhe.
+
+  - `uid=1000` e `gid=1000`: define a propriedade (dono e grupo) dos ficheiros montados para o utilizador e grupo com o ID 1000.
+
+  - `rw`: monta o sistema de ficheiros com permissões de leitura e escrita.
+
+  - `user`: permite que um utilizador não-root monte o sistema de ficheiros.
+
+  - `exec`: permite a execução de binários no sistema de ficheiros montado.
+
+  - `umask=000`: define a máscara de permissões de ficheiro para permitir permissões de leitura, escrita e execução para todos.
+
+  - `o primeiro 0` dump está tipicamente em desuso em sistemas modernos. Deixá-lo em 0 não causará problemas. Sinta-se à vontade para ler mais sobre isto [aqui](https://linux.die.net/man/8/dump).
+
+  - `o segundo 0` define a ordem para as verificações do sistema de ficheiros no momento do arranque. Para uma partição root, este valor deve ser 1 a menos que o seu sistema de ficheiros root seja btrfs, que deve de outra forma ser definido para 0. Todos os outros sistemas de ficheiros no seu fstab devem ser 0 (desativado) ou 2. Mais informações [aqui](https://man.archlinux.org/man/fsck.8).
+
+Para uma análise mais aprofundada de cada opção, visite estas duas páginas de manual: [fstab man page](https://man7.org/linux/man-pages/man5/fstab.5.html) e [mount man page](https://man7.org/linux/man-pages/man8/mount.8.html)
 
 #### Mais informações
 
 Como nota lateral, todas as opções após a declaração do tipo de sistema de ficheiros são opcionais caso não as altere em relação ao padrão.
 
-Assim:
+Assim
 
-`UUID=<UUID da partição> /media/foo somefs`
+`UUID=<partition UUID> /media/foo somefs`
 
 e
 
-`UUID=<UUID da partição> /media/foo somefs defaults 0 0`
+`UUID=<partition UUID> /media/foo somefs defaults 0 0`
 
-são equivalentes. `somefs` seguido de nada é implicitamente `somefs defaults 0 0`.
+são equivalentes. `somefs` seguido de nada é implicitamente `somefs defaults 0 0`
 
 ### 4. Finalização
 
@@ -129,7 +349,7 @@ e depois:
 sudo mount -a
 ```
 
-O seu disco deverá agora aparecer em `/media/windows` e aparecerá lá sempre que reiniciar o sistema.
+O seu disco deverá agora aparecer em `/media/windows` e aparecerá lá sempre que reiniciar.
 
 ```sh
 ls /media/windows
@@ -167,7 +387,7 @@ ls /media/windows
 # Intel                    'Ship of Harkinian'
  ```
 
-## Resumo (tl;dr)
+### tl;dr
 
 - Encontre o **UUID** da sua partição
 
@@ -175,7 +395,7 @@ ls /media/windows
 lsblk -f
 ```
 
-- Abra o ficheiro `/etc/fstab`
+- Abra `/etc/fstab`
 
 ```sh
 sudo nano /etc/fstab
@@ -187,7 +407,7 @@ sudo nano /etc/fstab
 UUID=<partition UUID> /media/foo somefs defaults 0 0
 ```
 
-Substituindo `<UUID da partição>`, `foo` e `somefs` pelo seu UUID, diretório e sistema de ficheiros (ex: ext4), bem como definindo quaisquer outras opções que deseje após "defaults", tais como `_netdev` para um NAS, ou `nofail` para qualquer disco não crítico.
+Substituindo `<partition UUID>`, `foo`, e `somefs` pelo seu UUID, diretório e sistema de ficheiros. ex: ext4, bem como definindo quaisquer outras opções que possa querer após defaults, tais como `_netdev` para um NAS, ou `nofail` para qualquer disco não crítico.
 
 - Recarregue o seu daemon
 
@@ -201,13 +421,13 @@ sudo systemctl daemon-reload
 sudo mount -a
 ```
 
-Este disco está agora montado e passará também a ser montado automaticamente em cada arranque.
+Este disco está agora montado e passará também a ser montado no arranque a partir de agora.
 
-## Leitura adicional
+### Leitura adicional
 
 - [Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)
 - [FHS sobre /media/](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s11.html)
-- [Manual do dump](https://linux.die.net/man/8/dump)
+- [Manual do dump](<https://linux.die.net/man/8/dump>)
 - [Manual do fsck](https://man.archlinux.org/man/fsck.8)
 - [Página de manual do fstab](https://man.archlinux.org/man/fstab.5.en)
 - [Entrada da Arch Linux Wiki sobre o fstab](https://wiki.archlinux.org/title/Fstab)

--- a/src/content/docs/pt/configuration/boot_manager_configuration.mdx
+++ b/src/content/docs/pt/configuration/boot_manager_configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuração do Gestor de Arranque
 description: Configure as definições do gestor de arranque e passe parâmetros do kernel para a linha de comandos
+ai_translated: true
 ---
 
 ## systemd-boot
@@ -39,7 +40,7 @@ sudo sdboot-manage gen
 
 ## rEFInd
 
-Tal como o [systemd-boot](/configuration/boot_manager_configuration#systemd-boot), o rEFInd possui dois ficheiros de configuração. O `refind.conf`, localizado em `/boot/efi/EFI/refind`, serve principalmente para alterar o comportamento do rEFInd, enquanto o `/boot/refind_linux.conf` serve para gerir as suas opções de arranque. O `refind.conf` contém comentários extensos que explicam todas as suas opções.
+Tal como o [systemd-boot](/pt/configuration/boot_manager_configuration#systemd-boot), o rEFInd possui dois ficheiros de configuração. O `refind.conf`, localizado em `/boot/efi/EFI/refind`, serve principalmente para alterar o comportamento do rEFInd, enquanto o `/boot/refind_linux.conf` serve para gerir as suas opções de arranque. O `refind.conf` contém comentários extensos que explicam todas as suas opções.
 
 ### Configuração da Linha de Comandos do Kernel
 
@@ -55,7 +56,7 @@ As alterações em ambos os ficheiros de configuração terão efeito imediato. 
 
 ## GRUB
 
-Ao contrário do [systemd-boot](/configuration/boot_manager_configuration#systemd-boot) e do [rEFInd](/configuration/boot_manager_configuration#refind), o GRUB possui apenas um ficheiro de configuração localizado em `/etc/default/grub`. Existe documentação bastante boa dentro deste ficheiro que explica o que cada opção faz.
+Ao contrário do [systemd-boot](/pt/configuration/boot_manager_configuration#systemd-boot) e do [rEFInd](/pt/configuration/boot_manager_configuration#refind), o GRUB possui apenas um ficheiro de configuração localizado em `/etc/default/grub`. Existe documentação bastante boa dentro deste ficheiro que explica o que cada opção faz.
 
 ### Ocultar o Menu de Arranque do GRUB
 
@@ -220,5 +221,5 @@ Embora as entradas sejam tratadas de forma automática, pode **configurar os par
 * [Página do manual loader.conf](https://man.archlinux.org/man/loader.conf.5)
 * [rEFInd: Configurar o gestor de arranque](https://www.rodsbooks.com/refind/configfile.html)
 * [Manual do GRUB: Configuração](https://www.gnu.org/software/grub/manual/grub/grub.html#Configuration)
-* [Documentação oficial de configuração do Limine](https://github.com/limine-bootloader/limine/blob/v9.x/CONFIG.md)
+* [Documentação oficial de configuração do Limine](https://github.com/limine-bootloader/limine/blob/v12.x/CONFIG.md)
 * [Projeto limine-entry-tool](https://gitlab.com/Zesko/limine-entry-tool)

--- a/src/content/docs/pt/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/pt/configuration/btrfs_snapshots.mdx
@@ -4,6 +4,7 @@ description: Gerir snapshots Btrfs no CachyOS
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 5
+ai_translated: true
 ---
 
 import { Steps } from '@astrojs/starlight/components';
@@ -256,10 +257,31 @@ As etiquetas `< >` indicam um marcador de posição que deve substituir pelo val
     <details>
         <summary>Exemplo de resultado:</summary>
         ```bash
-        ❯ snapper list-configs
-        Config │ Subvolume
-        ───────┼──────────
-        root   │ /
+        Key                    │ Value
+        ───────────────────────┼──────
+        ALLOW_GROUPS           │
+        ALLOW_USERS            │
+        BACKGROUND_COMPARISON  │ yes
+        EMPTY_PRE_POST_CLEANUP │ yes
+        EMPTY_PRE_POST_MIN_AGE │ 1800
+        FREE_LIMIT             │ 0.2
+        FSTYPE                 │ btrfs
+        NUMBER_CLEANUP         │ yes
+        NUMBER_LIMIT           │ 10
+        NUMBER_LIMIT_IMPORTANT │ 10
+        NUMBER_MIN_AGE         │ 3600
+        QGROUP                 │
+        SPACE_LIMIT            │ 0.5
+        SUBVOLUME              │ /
+        SYNC_ACL               │ no
+        TIMELINE_CLEANUP       │ yes
+        TIMELINE_CREATE        │ no
+        TIMELINE_LIMIT_DAILY   │ 0
+        TIMELINE_LIMIT_HOURLY  │ 0
+        TIMELINE_LIMIT_MONTHLY │ 0
+        TIMELINE_LIMIT_WEEKLY  │ 0
+        TIMELINE_LIMIT_YEARLY  │ 0
+        TIMELINE_MIN_AGE       │ 1800
         ```
     </details>
 </details>
@@ -301,8 +323,8 @@ As etiquetas `< >` indicam um marcador de posição que deve substituir pelo val
         - `User`: O utilizador que criou o snapshot.
         - `Cleanup`: Indica o algoritmo de limpeza aplicado ao snapshot.
             - Existem vários algoritmos de limpeza disponíveis no Snapper, tais como `number`, `timeline` e `empty-pre-post`. Neste exemplo, é utilizado o algoritmo `number`, o que significa que os snapshots mais antigos serão eliminados com base num limite predefinido.
-            - `timeline`: Os snapshots são limpos com base na sua idade e frequência.
-            - `empty-pre-post`: Elimina pares de snapshots pre/post com diferenças (diffs) vazias.
+            - timeline: Os snapshots são limpos com base na sua idade e frequência.
+            - empty-pre-post: Elimina pares de snapshots pre/post com diferenças (diffs) vazias.
         - `Description`: Uma breve descrição do snapshot, indicando frequentemente o motivo da sua criação.
         - `Userdata`: Dados adicionais definidos pelo utilizador associados ao snapshot.
         Para mais detalhes sobre as colunas de resultado.
@@ -427,7 +449,7 @@ Se o snapshot que deseja restaurar envolver uma atualização de kernel, não po
             <MultipleImageComponent
                 images={[
                 import('~/assets/images/limine-snapshotMenu-2.jpg'),
-                import('~/assets/images/limine-snapshotMenu-1.jpg')]}
+                import('~/assets/images/limine-snapshotMenu-3.jpg')]}
             />
         3. O seu sistema está agora em `modo de leitura-apenas` (read-only mode). Deverá aparecer uma notificação indicando que um snapshot foi detetado, perguntando se deseja restaurar a partir dele:
             <ImageComponent imgsrc={import('~/assets/images/kde-snapshot-popup.png')} />
@@ -467,7 +489,7 @@ Se o snapshot que deseja restaurar envolver uma atualização de kernel, não po
             btrfs-assistant-launcher
             ```
 
-            Em alternativa::
+            Em alternativa:
 
             ```bash
             sudo -E btrfs-assistant

--- a/src/content/docs/pt/configuration/desktop_environments/hyprland.mdx
+++ b/src/content/docs/pt/configuration/desktop_environments/hyprland.mdx
@@ -1,0 +1,247 @@
+---
+title: Configuração Pós-Instalação e Atalhos do Hyprland
+description: Tarefas comuns a fazer após a instalação e visão geral dos atalhos
+ai_translated: true
+---
+
+import { Kbd } from 'starlight-kbd/components'
+import ImageComponent from '~/components/image-component.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+:::note
+O Hyprland é um compositor Wayland que suporta vários layouts como dwindle (tiling), scrolling, master, monocle e layouts personalizados. **Não** é um ambiente de desktop completo (DE).
+:::
+
+### Porque usar o Hyprland?
+
+O Hyprland é um belo gestor de mosaico dinâmico que oferece uma variedade de layouts e funcionalidades avançadas de compositor como VRR, tearing e HDR. Os dotfiles do CachyOS para o Hyprland são configurados com valores padrão gerais que devem ser completamente utilizáveis imediatamente, com aplicações que seguem o tema geral do sistema.
+
+**Dotfiles mantidos por [Jinra](https://github.com/Jinra)**
+
+Para questões relacionadas com o Noctalia, consulte a [documentação do Noctalia](https://docs.noctalia.dev/).
+
+## Tarefas Pós-Configuração
+
+Pretenderá configurar algumas coisas específicas do utilizador após a configuração. Para definições adicionais, consulte a wiki do Hyprland https://wiki.hypr.land/Configuring/Start/
+
+### Localização `~/.config/hypr/config`
+* `monitors.lua` irá configurar os seus monitores. (consulte https://wiki.hypr.land/Configuring/Basics/Monitors/). Um bloco padrão é criado para si, pode adicionar mais para monitores adicionais.
+  * `output` edite `variables.lua` em vez disso com o valor do monitor; pode executar `hyprctl monitors` para obter este id (ex: `DP-1`). Se adicionar mais monitores, use MONITOR2, MONITOR3, etc e adicione-os também ao `variables.lua`.
+  * `mode` deve estar num formato como `1920x1080@60` (horizontal x vertical @ taxa de atualização).
+  * `scale` Provavelmente pretenderá `1`, mas pode querer este valor mais alto para monitores de resolução mais elevada.
+  * Pode precisar de reiniciar após o primeiro ajuste, mas ajustes futuros devem ser refletidos em tempo real.
+* `variables.lua`
+  * Adicione as suas atribuições de monitor aqui. o seu `PRIMARY_MONITOR` e `MONITOR1` devem geralmente ser o mesmo monitor. Pode remover/adicionar variáveis `MONITOR#` conforme necessário.
+  * Defina o seu número de workspaces por monitor. Não exceda 10.
+* `input.lua` Pode definir as várias definições de input do hypr aqui. Provavelmente pretenderá ajustar a `sensitivity`.
+* `binds.lua` Revise este ficheiro para ver todos os atalhos para estes dots. Pode também consultar a visão geral geral abaixo.
+* `windowrules.lua` Se se perguntar porque certas janelas têm certos comportamentos, consulte este ficheiro; pode também adicionar/remover regras conforme achar apropriado.
+* `workspaces.lua` Adicione várias definições de workspace aqui. É recomendado adicionar 3 workspaces por monitor (como mostrado nos exemplos) mais o workspace de gaming ao monitor principal.
+* `environment.lua` é usado para definir variáveis de ambiente específicas do hypr ou do utilizador. Não é necessário ajustar se estiver a usar UWSM, e é mais preferível adicionar estas ao ficheiro de ambiente do UWSM em vez disso (veja abaixo).
+### Localização `~/.config/uwsm`
+* `env` é um ficheiro usado para definir variáveis globais, pode usar isto para variáveis gerais que precisam de ser atribuídas para a sua conta de utilizador específica (Exemplos: `HYPRCURSOR_THEME`, `XCURSOR_THEME`, `QT_QPA_PLATFORM`, etc.)
+### Localização `~/.config/noctalia` (Apenas V5; V4 terá ficheiros aqui, mas não precisa de os tocar pois podem ser configurados através das definições do Noctalia)
+* `config.toml` é aqui que vive a configuração padrão do cachyos-hypr-noctalia. Se se pergunta porque os padrões diferem de uma instalação vanilla do noctalia v5, esta é a razão. Não deverá ter de tocar em nada neste ficheiro.
+### Localização `definições do noctalia` (Super + Z)
+* Pode editar as definições do Noctalia aqui. É recomendado ir à secção de templates e ativar qualquer template de cor para quaisquer aplicações que possa usar.
+* Consulte também a loja de plugins para plugins oficiais e da comunidade úteis.
+
+## Atalhos (Keybinds)
+
+A maioria das combinações de teclas requer o uso da tecla mod que no nosso caso é a tecla Windows/Command (referenciada como SUPER), pode alterá-la em `binds.lua`.
+
+### Gestão de Janelas
+
+| Descrição | Tecla |
+|-------------|-----|
+| Forçar fechar aplicação/janela (segure combo e clique) | <Kbd linux="Super+Escape" /> |
+| Fechar janela/aplicação focada | <Kbd linux="Super+Q" /> |
+| Alternar flutuante/mosaico | <Kbd linux="Super+Alt+Space" /> |
+| Maximizar janela focada | <Kbd linux="Super+D" /> |
+| Janela focada em ecrã inteiro | <Kbd linux="Super+F" /> |
+| Alternar direção de divisão | <Kbd linux="Super+J" /> |
+| Focar esquerda | <Kbd linux="Super+Left" /> |
+| Focar direita | <Kbd linux="Super+Right" /> |
+| Focar cima | <Kbd linux="Super+Up" /> |
+| Focar baixo | <Kbd linux="Super+Down" /> |
+| Alternar foco de janela no workspace | <Kbd linux="Alt+Tab" /> |
+| Abrir alternador de janelas | <Kbd linux="Super+Tab" /> |
+| Mover janela focada para monitor | <Kbd linux="Super+Shift+#" /> |
+| Mover janela focada para workspace | <Kbd linux="Super+Shift+Control+#" /> |
+| Mover janela focada para workspace especial | <Kbd linux="Super+Shift+S" /> |
+| Mover janela focada para a direita | <Kbd linux="Super+Shift+Right" /> |
+| Mover janela focada para a esquerda | <Kbd linux="Super+Shift+Left" /> |
+| Mover janela focada para cima | <Kbd linux="Super+Shift+Up" /> |
+| Mover janela focada para baixo | <Kbd linux="Super+Shift+Down" /> |
+| Mover janela focada para o próximo workspace | <Kbd linux="Super+Control+Shift+Right" /> |
+| Mover janela focada para o workspace anterior | <Kbd linux="Super+Control+Shift+Left" /> |
+| Mover janela focada para o workspace anterior (rato) | <Kbd linux="Super+Control+Shift+Scroll&nbsp;up" /> |
+| Mover janela focada para o próximo workspace (rato) | <Kbd linux="Super+Control+Shift+Scroll&nbsp;down" /> |
+| Mover janela focada para o próximo monitor | <Kbd linux="Super+Shift+Scroll&nbsp;down" /> |
+| Mover janela focada para o monitor anterior | <Kbd linux="Super+Shift+Scroll&nbsp;up" /> |
+| Mover janela (rato) | <Kbd linux="Super+Left&nbsp;Click" /> |
+| Redimensionar janela (rato) | <Kbd linux="Super+Right&nbsp;Click" /> |
+
+### Launcher
+
+| Descrição | Tecla |
+|-------------|-----|
+| Abrir Terminal | <Kbd linux="Super+Return" /> |
+| Abrir Gestor de Ficheiros | <Kbd linux="Super+E" /> |
+| Abrir Editor | <Kbd linux="Super+T" /> |
+| Abrir Calculadora | <Kbd linux="Super+C" /> |
+| Abrir Navegador | <Kbd linux="Super+W" /> |
+| Abrir Monitor do Sistema (btop) | <Kbd linux="Control+Shift+Escape" /> |
+| Alternar Definições do Noctalia | <Kbd linux="Super+Z" /> |
+| Alternar Centro de Controlo | <Kbd linux="Super+X" /> |
+| Alternar Launcher de Aplicações | <Kbd linux="Super+Space" /> |
+| Abrir Launcher de Emoji | <Kbd linux="Super+period" /> |
+| Bloquear ecrã | <Kbd linux="Super+L" /> |
+| Alternar menu de sessão | <Kbd linux="Super+Alt+C" /> |
+
+### Controlos de Hardware
+
+| Descrição | Tecla |
+|-------------|-----|
+| Aumentar Volume | <Kbd linux="Volume Up" /> |
+| Diminuir Volume | <Kbd linux="Volume Down" /> |
+| Silenciar Saída de Áudio | <Kbd linux="Mute" /> |
+| Silenciar Entrada do Microfone | <Kbd linux="MicMute" /> |
+| Reproduzir/Pausar Média | <Kbd linux="Play" /> / <Kbd linux="Pause" /> |
+| Faixa de Média Seguinte | <Kbd linux="Next" /> |
+| Faixa de Média Anterior | <Kbd linux="Previous" /> |
+| Aumentar Brilho do Ecrã | <Kbd linux="Brightness Up" /> |
+| Diminuir Brilho do Ecrã | <Kbd linux="Brightness Down" /> |
+
+### Utilitários
+
+| Descrição | Tecla |
+|-------------|-----|
+| Seletor de Cor | <Kbd linux="Super+P" /> |
+| Captura de Ecrã & Anotar | <Kbd linux="Print" /> |
+| Captura de Janela de Ecrã & Anotar (v4) | <Kbd linux="Super+Print" /> |
+| Captura de Monitor de Ecrã & Anotar (v5) | <Kbd linux="Super+Print" /> |
+| Alternar Gravador de Ecrã (apenas v4) | <Kbd linux="Super+R" /> |
+| Alternar Menu de Wallpaper | <Kbd linux="Super+Shift+W" /> |
+| Abrir Histórico da Área de Transferência | <Kbd linux="Super+V" /> |
+| Alternar Histórico de Notificações | <Kbd linux="Super+A" /> |
+| Ampliar | <Kbd linux="Super+Plus" /> |
+| Reduzir | <Kbd linux="Super+Minus" /> |
+
+### Workspaces & Monitores
+
+| Descrição | Tecla |
+|-------------|-----|
+| Mudar para workspace [1-10] | <Kbd linux="Super+[0-9]" /> |
+| Mover janela para workspace [1-10] (seguir) | <Kbd linux="Super+Shift+[0-9]" /> |
+| Mover janela para workspace [1-10] (não seguir) | <Kbd linux="Super+Alt+[0-9]" /> |
+| Focar workspace (Relativo) | <Kbd linux="Super+Control+#" /> |
+| Focar workspace (Absoluto) | <Kbd linux="Super+Alt+#" /> |
+| Focar próximo workspace | <Kbd linux="Super+Control+Right" /> |
+| Focar workspace anterior | <Kbd linux="Super+Control+Left" /> |
+| Focar primeiro workspace vazio | <Kbd linux="Super+Control+Down" /> |
+| Focar próximo workspace (rato) | <Kbd linux="Super+Control+Scroll&nbsp;down" /> |
+| Focar workspace anterior (rato) | <Kbd linux="Super+Control+Scroll&nbsp;up" /> |
+| Focar próximo monitor (rato) | <Kbd linux="Super+Scroll&nbsp;down" /> |
+| Focar monitor anterior (rato) | <Kbd linux="Super+Scroll&nbsp;up" /> |
+| Alternar workspace especial (scratchpad) | <Kbd linux="Super+S" /> |
+
+## Migrar de outro DE/WM
+
+Se já tiver outro DE/WM instalado, pode migrar para estes dots com as instruções abaixo.
+
+:::note
+Embora seja possível usar a mesma conta de utilizador com o Hyprland, é altamente recomendado criar uma nova conta de utilizador (instruções incluídas). Adicionalmente, mesmo com uma nova conta de utilizador, pode haver conflitos de daemon com o seu DE/WM anterior, por isso é mais ideal usar um único ambiente.
+:::
+
+Certifique-se de substituir as variáveis entre parênteses angulares (\<\>) abaixo, incluindo os próprios parênteses angulares.
+
+1. Execute `sudo pacman -S cachyos-hypr-noctalia`. Se encontrar um conflito de pacote com outro pacote `-settings` (como `cachyos-kde-settings`), pode eliminar o pacote em conflito, pois estes pacotes não afetam utilizadores atuais.
+1. Para criar um novo utilizador, execute `sudo useradd -m <new_user> -s /bin/fish`. Pode também usar outra shell se preferir (ex: /bin/zsh).
+1. Execute `sudo passwd <new_user>` para definir uma password para a conta.
+    * Se _realmente_ quiser usar a mesma conta (altamente desencorajado), em vez disso copie os dots para a pasta do utilizador `cp -r /etc/skel/. ~` (certifique-se de criar um backup/snapshot primeiro!)
+1. Opcionalmente instale `noctalia-greeter` ou `sddm` como o seu gestor de ecrã. `noctalia-greeter` integra-se melhor com o Noctalia, mas a configuração é ligeiramente mais complicada.
+    * Para ativar o sddm como o seu gestor de ecrã, instale-o com `sudo pacman -Syu sddm`, depois execute `systemctl disable display-manager` e `systemctl enable sddm`.
+    * Para instalar o [Noctalia Greeter](https://github.com/noctalia-dev/noctalia-greeter), execute `sudo pacman -Syu noctalia-greeter`, e siga a secção "Setting up greetd" da documentação vinculada. Depois, execute `systemctl disable display-manager` e `systemctl enable greetd`.
+1. Reinicie e selecione a sessão Hyprland (UWSM) no seu gestor de ecrã.
+    * Se a shell falhar ao carregar, tente reiniciar mais uma vez.
+1. Inicie sessão e siga as [Tarefas Pós-Configuração](/pt/configuration/desktop_environments/hyprland/#tarefas-p%C3%B3s-configura%C3%A7%C3%A3o).
+
+## Migrar de dots v4 para V5 / Atualizar os seus dots
+
+Se atualmente estiver a usar cachyos-hypr-noctalia com Noctalia v4 e atualizou da versão de pacote 1.0 para uma versão mais recente, ou quiser atualizar os seus dots, siga as instruções abaixo.
+Consulte os registos de alterações completos no release para determinar se deve atualizar os seus dots.
+https://github.com/CachyOS/cachyos-hypr-noctalia/releases
+
+### Atualizações do Hypr
+
+:::note
+Uma vez que migrar os seus atalhos de v4 para v5, estes já não funcionarão para chamar chamadas IPC do Noctalia.
+:::
+
+1. Instale `meld` se não o tiver (`pacman -Q meld` para verificar se o tem).
+1. Execute `meld /etc/skel/.config/hypr ~/.config/hypr`.
+1. A partir do meld verá uma visão geral de todos os ficheiros com alterações. Ficheiros azuis têm alterações, enquanto ficheiros verdes são totalmente novos.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/meld_overview.png')} />
+1. Clique num ficheiro azul para ver as alterações a aplicar. Pode usar o seu melhor julgamento para determinar o que aplicar, mas se não fez quaisquer alterações, é seguro sobrescrever o ficheiro inteiro. Clique na seta para aplicar alterações e no x para remover linhas antigas.
+    <Aside type="note">Certifique-se de não sobrescrever coisas que pode ter alterado, como as suas definições de monitor.</Aside>
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/merge.png')} />
+1. Pode fundir tudo também.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/merge_all_1.png')} />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/merge_all_2.png')} />
+1. Quando terminar as suas alterações para o ficheiro, guarde e saia.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/save_exit.png')} />
+1. Os ficheiros verdes totalmente novos pedirão onde quer guardá-los. Pode guardá-los em `~/.config/hypr/config/` com o mesmo nome. Há 4 ficheiros novos.
+    * defaults.lua agora é variables.lua. Deve mover manualmente quaisquer adições/alterações personalizadas para o novo ficheiro.
+    * keybinds.lua agora é binds.lua. Deve mover manualmente quaisquer adições/alterações personalizadas para o novo ficheiro.
+    * input.lua agora é inputs.lua. Deve mover manualmente quaisquer adições/alterações personalizadas para o novo ficheiro.
+    * workspaces.lua é novo totalmente e pode ser movido limpa e simplesmente sem alterações.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/workspaces.png')} />
+
+### Atualizações do Noctalia
+
+1. Execute `rm -rf ~/.config/noctalia` para remover as configurações atuais. Alternativamente, mova-as para outro lado se pensar que pode precisar de algo lá.
+1. `cp -r /etc/skel/.config/noctalia ~/.config` irá copiar a nova configuração para a sua pasta pessoal.
+
+:::note
+O único ficheiro importante é config.toml, por isso pode copiá-lo individualmente em vez de eliminar e substituir a pasta inteira quando o pacote atualizar, se quiser.
+:::
+
+### Outras Atualizações
+
+Outros ficheiros podem ter atualizações, pode usar meld para integrar estes. Consulte o registo de alterações completo do release para ver o que mais pode ter mudado.
+
+### Remover órfãos (migração v4->v5)
+
+Após atualizar o pacote, as dependências antigas ficarão órfãs, pode removê-las executando `shelly purify -o`.
+
+### Reinício
+
+Reiniciar deve fazer com que as alterações entrem em vigor. Se a shell falhar ao carregar, tente reiniciar mais uma vez.
+
+## FAQ
+
+> _"O meu histórico da área de transferência não persiste através dos reinícios"_
+
+Precisa de configurar uma loja de segredos (secrets store) para isto funcionar corretamente. O Kwallet está instalado por predefinição, mas pode também usar gnome-keyring ou outra loja de segredos. Se quiser usar kwallet, instale `kwalletmanager` do repo, depois abra-o e crie uma nova carteira. É mais fácil deixar a password em branco, mas pode também configurar desbloqueio automático com o seu gestor de ecrã, o que está fora do âmbito desta wiki; consulte a [arch wiki](https://wiki.archlinux.org/title/KDE_Wallet#Configuration) para mais detalhes. Após configurar uma carteira, inicialize-a no seu ficheiro `autostart.lua` com `hl.exec_cmd("kwalletd6")`.
+
+> _"Como faço para o satty não aparecer após tirar uma captura de ecrã?"_
+
+Pode facilmente dispensar o satty premindo ctrl + s para guardar a sua captura de ecrã ou ctrl + c para copiar. Se não quiser que o satty apareça de todo, pode configurar a definição para copiar para a área de transferência ou guardar para ficheiro nas definições do Noctalia > shell > screenshot.
+
+> _"Como altero o meu input de teclado?"_
+
+Edite `inputs.lua` e adicione `kb_layout`. Consulte [aqui](https://wiki.hypr.land/Configuring/Basics/Variables/#input)
+
+> _"Porque é que algumas opções de tema não estão a funcionar (ícones do Dolphin, alguns elementos QT, etc)"_
+
+O repo padrão do Cachy só fornece `qt6ct` (QT6 Configuration Tool). No entanto, há outra ferramenta que funciona melhor para aplicações Plasma QT como dolphin, gwenview, etc. Descarregue `qt6ct-kde` do AUR em vez disso e aplique o tema Noctalia com ele. Isto deve ter as suas aplicações plasma com melhor tema no Hyprland.
+
+> _"Como altero o meu navegador predefinido?"_
+
+Execute `xdg-settings set default-web-browser your_browser.desktop`. Pode encontrar o nome do ficheiro desktop do seu navegador executando `ls /usr/share/applications/`

--- a/src/content/docs/pt/configuration/desktop_environments/switch_desktop.mdx
+++ b/src/content/docs/pt/configuration/desktop_environments/switch_desktop.mdx
@@ -4,6 +4,7 @@ description: Guia sobre como instalar outro DE/WM numa instalação existente do
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -101,7 +102,10 @@ Deverá ficar atento ao repositório GitHub do respetivo DE/WM para quaisquer al
 
 Aqui está uma lista de todos os repositórios dos diferentes DEs e WMs mantidos pelo CachyOS:
 - [KDE Plasma](https://github.com/CachyOS/cachyos-kde-settings)
-- [Niri](https://github.com/CachyOS/cachyos-niri-settings)
+- [GNOME](https://github.com/CachyOS/cachyos-gnome-settings)
+- [Niri](https://github.com/cachyos/cachyos-niri-noctalia)
+- [Hyprland](https://github.com/CachyOS/cachyos-hypr-noctalia)
+- [MangoWM](https://github.com/CachyOS/cachyos-mangowc-dms)
 - [i3](https://github.com/CachyOS/cachyos-i3wm-settings)
 - [Qtile](https://github.com/CachyOS/cachyos-qtile-settings)
 - [Wayfire](https://github.com/CachyOS/cachyos-wayfire-settings)

--- a/src/content/docs/pt/configuration/dual_gpu.mdx
+++ b/src/content/docs/pt/configuration/dual_gpu.mdx
@@ -1,5 +1,6 @@
 ---
 title: Guia de Configuração de GPU Duplo
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
@@ -69,6 +70,12 @@ prime-run %command%
 
 Certifique-se de adicionar `%command%` após `prime-run`. Lembre-se que as opções do jogo são colocadas após este marcador, enquanto as variáveis de ambiente do sistema ou comandos devem precedê-lo.
 
+Para executar um jogo na gráfica integrada em vez da dedicada, utilize a seguinte opção de inicialização como exemplo para gráficos integrados Radeon. Isto pode ser desejável para maior autonomia da bateria e menor ruído do ventilador em jogos de menor exigência.
+
+```bash
+VK_DRIVER_FILES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/usr/share/vulkan/icd.d/radeon_icd.i686.json %command%
+```
+
 <br />
 <ImageComponent imgsrc={import('~/assets/images/steam-prime.png')} />
 
@@ -106,9 +113,3 @@ No GNOME, deve também instalar o `switcheroo-control` como mostrado acima, clic
 <ImageComponent imgsrc={import('~/assets/images/cinnamon-prime.png')} />
 
 Se a opção não estiver disponível, certifique-se de que tem o `switcheroo-control` instalado e o seu serviço ativado, pois todos os ambientes de trabalho dependem deste para esta funcionalidade.
-
-## Resolução de problemas (Troubleshooting)
-
-### "O meu monitor externo está com muito lag em PRIME"
-
-Este é um problema conhecido do controlador da NVIDIA. Deve ter o controlador NVIDIA mais recente instalado e utilizar Wayland com um compositor que suporte sincronização explícita (explicit sync). No GNOME, isto foi corrigido na versão 46.2. No Plasma 6, será provavelmente corrigido na versão 6.1, embora alguns utilizadores já reportem um desempenho normal na versão 6.0. Outros ambientes ou gestores de janelas ainda apresentam este problema, pelo que necessitará de mudar para a versão mais recente do GNOME ou do Plasma para o resolver.

--- a/src/content/docs/pt/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/pt/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -1,6 +1,7 @@
 ---
 title: Aceleração de Hardware em Navegadores Baseados em Chromium
 description: Configure a aceleração de hardware para descodificação/codificação de vídeo em navegadores baseados em Chromium no CachyOS. Inclui configuração para GPUs AMD e um modelo para outros GPUs/navegadores.
+ai_translated: true
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -16,7 +17,7 @@ Este guia descreve como ativar a aceleração de hardware em navegadores baseado
 **Opcional:**
 
 * **amdgpu_top:** Instale o `amdgpu_top` a partir do repositório através do gestor de pacotes, caso deseje monitorizar a atividade do GPU AMD através do terminal.
-* **nvtop:** (Apenas GPUs Intel) Instale o `nvtop` (Lunar Lake) e o `intel-gpu-tools` (Anteriores a Lunar Lake) através do gestor de pacotes Octopi, caso deseje monitorizar a atividade do GPU Intel através do terminal.
+* **nvtop:** (Apenas GPUs Intel) Instale o `nvtop` (Lunar Lake) e o `intel-gpu-tools` (Anteriores a Lunar Lake) através do gestor de pacotes Shelly, caso deseje monitorizar a atividade do GPU Intel através do terminal.
 
 ## Contribuição
 
@@ -28,7 +29,42 @@ Este guia é extensível. Se tiver uma configuração de aceleração de hardwar
 * **Caminho do Ficheiro:** Caminho completo para o ficheiro de flags.
 * **Notas (Opcional):** Controladores principais, pacotes ou especificidades da configuração.
 
-## Passos de Configuração
+### Modelo para contribuir
+
+#### [O Seu Navegador] - [O Seu Modelo de GPU] (Contribuído por [O Seu Nome/Alcunha])
+
+* **Navegador:** [ex: Brave, Ungoogled Chromium, Microsoft Edge, Vivaldi, Opera, Chromium]
+
+* **GPU:** [ex: NVIDIA GeForce RTX 3080, Intel Iris Xe]
+
+* **Caminho do Ficheiro de Flags:** (Crucial, varia consoante o navegador!)
+
+  * Caminhos `.conf` comuns:
+
+    * Chromium: `~/.config/chromium-flags.conf`
+
+    * Brave Browser: `~/.config/brave-flags.conf`
+
+    * Ungoogled Chromium: `~/.config/ungoogled-chromium-flags.conf`
+
+* Modificação do ficheiro `.desktop`:
+    * Alguns navegadores (Brave, Edge, Vivaldi, Opera) podem exigir a edição da linha `Exec=` no seu ficheiro `.desktop` (copie primeiro de `/usr/share/applications/` para `~/.local/share/applications/`).
+
+Conteúdo das Flags (para o ficheiro `.conf` ou linha `Exec=`):
+
+```bash
+# Cole as suas flags aqui.
+# Para ficheiros .desktop, as flags são separadas por espaços após o executável.
+```
+
+**Notas (Opcionais):**
+
+* Controladores necessários (ex: `nvidia-dkms`, `intel-media-driver`).
+
+* Considerações específicas de configuração ou instruções de modificação do ficheiro `.desktop`.
+
+
+### Passos de Configuração
 
 <Steps>
 
@@ -138,10 +174,10 @@ Este guia é extensível. Se tiver uma configuração de aceleração de hardwar
 --use-gl=angle
 --use-angle=vulkan
 --enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
---ozone-platform-hint=x11
 ```
 
-**Notas:** Tira partido do Vulkan (através do ANGLE) e VA-API. `--ozone-platform-hint=x11` pode ser útil mesmo em Wayland para certos caminhos de aceleração.
+**Notas:** Tira partido do Vulkan (via ANGLE) e VA-API. `--ozone-platform=x11` pode ser útil em Wayland para certos caminhos de aceleração.
+
 
 ### Nvidia RTX 4090 (Vivaldi)
 
@@ -175,7 +211,8 @@ Alternativamente, pode fazer o seguinte no KDE:
 ```
 --enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL
 ```
-5. Inicie o Vivaldi e fixe o processo no seu Gestor de Tarefas / barra de tarefas.
+5. Inicie o Vivaldi e fixe o processo no seu Gestor de Tarefas / barra de tarefas
+
 
 ### AMD Radeon RX 550 (UnGoogled Chromium)
 
@@ -187,17 +224,9 @@ Alternativamente, pode fazer o seguinte no KDE:
 
 ```bash
 --enable-wayland-ime
---ozone-platform=wayland
 --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,WaylandSessionManagement,WaylandTextInputV3,WaylandUiScale,WaylandWindowDecorations
 ```
 
-**Notas:**
-
-Se estiver a utilizar X11, utilize isto:
-```bash
---ozone-platform=x11
---enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder
-```
 
 ### Nvidia RTX 5070 TI (Brave)
 
@@ -215,6 +244,7 @@ Se estiver a utilizar X11, utilize isto:
 - Descodificação **e** codificação de vídeo aparecem como `Hardware accelerated` em `brave://gpu`.
 - Por vezes, a inspeção do separador `media` num vídeo do YouTube mostra aceleração de hardware, outras vezes não.
 
+
 ### Brave - 7700xt (Contribuído por DaJRJesus)
 
 * **Navegador:** Brave
@@ -228,43 +258,131 @@ Se estiver a utilizar X11, utilize isto:
 --enable-gpu-rasterization
 --enable-zero-copy
 --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,CanvasOopRasterization,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
---ozone-platform-hint=auto
 ```
 
 **Notas:**
-Funciona em Wayland. É necessário desativar o "Modo Ambiente" nas definições do YouTube para evitar lentidão (lag) na interface.
+Desativar o "Modo Ambiente" (Ambient Mode) nas definições do YouTube é necessário para evitar lentidão (lag) na interface.
 
----
 
-### Modelo para contribuir
+### Vivaldi - AMD Radeon RX 9070 XT (Contribuído por tTrmc)
 
-### [O Seu Navegador] - [O Seu Modelo de GPU] (Contribuído por [O Seu Nome/Alcunha])
+* **Navegador:** Vivaldi
 
-* **Navegador:** [ex: Brave, Ungoogled Chromium, Microsoft Edge, Vivaldi, Opera, Chromium]
+* **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
 
-* **GPU:** [ex: NVIDIA GeForce RTX 3080, Intel Iris Xe]
-
-* **Caminho do Ficheiro de Flags:** (Crucial, varia consoante o navegador!)
-
-  * Caminhos `.conf` comuns:
-
-    * Chromium: `~/.config/chromium-flags.conf`
-
-    * Brave Browser: `~/.config/brave-flags.conf`
-
-    * Ungoogled Chromium: `~/.config/ungoogled-chromium-flags.conf`
-
-  * Modificação do ficheiro `.desktop`: Alguns navegadores (Brave, Edge, Vivaldi, Opera) podem exigir a edição da linha `Exec=` no seu ficheiro `.desktop` (copie primeiro de `/usr/share/applications/` para `~/.local/share/applications/`).
-
-Conteúdo das Flags (para o ficheiro `.conf` ou linha `Exec=`):
+* **Caminho do Ficheiro de Flags:** `~/.config/vivaldi-stable.conf`
 
 ```bash
-# Cole as suas flags aqui.
-# Para ficheiros .desktop, as flags são separadas por espaços após o executável.
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
 ```
 
-**Notas (Opcionais):**
+**Notas:**
+- Testado no CachyOS com kernel 6.19.11-1-cachyos, Mesa 26.0.3, GNOME (Wayland), monitor 2560x1440.
+- Confirmado funcional: `vivaldi://gpu` mostra Video Decode e Video Encode como "Hardware accelerated". Suporte completo de codecs para descodificação H264, VP9, HEVC, AV1 e codificação H264, AV1. O separador Media do DevTools mostra `VaapiVideoDecoder` como o descodificador ativo.
+- O RX 9070 XT (RDNA 4) pode estar na lista de bloqueio de GPU do Chromium, pelo que `--ignore-gpu-blocklist` é necessário.
+- O log pode mostrar um aviso: `'--ozone-platform=wayland' is not compatible with Vulkan` — isto não impede a aceleração de hardware de funcionar.
 
-* Controladores necessários (ex: `nvidia-dkms`, `intel-media-driver`).
 
-* Considerações específicas de configuração ou instruções de modificação do ficheiro `.desktop`.
+### Google Chrome - AMD Radeon RX 9070 XT (Contribuído por naknak)
+
+* **Navegador:** Google Chrome
+
+* **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
+
+* **Caminho do Ficheiro de Flags:** `~/.config/chrome-flags.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--use-gl=angle
+--use-angle=vulkan
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo,Vulkan,VulkanFromANGLE,DefaultANGLEVulkan
+```
+
+**Notas:**
+- Descodificação **e** codificação de vídeo aparecem como `Hardware accelerated` em `chrome://gpu`.
+- Por vezes, a inspeção do separador `media` num vídeo do YouTube mostra aceleração de hardware, outras vezes não.
+
+### Vivaldi - AMD Ryzen AI Max+ 395 (Contribuído por woutervanelten)
+
+* **Navegador:** Vivaldi (8.0.4033.35)
+
+* **APU:** AMD Radeon 8060S (GFX1151/Strix Halo)
+
+* **Caminho do Ficheiro de Flags:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--ozone-platform=wayland
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```
+
+**Notas:**
+- Testado no CachyOS com kernel 7.0.10-2-cachyos, Mesa 26.1.1, GNOME (Wayland), monitor 5120x1440.
+- Confirmado funcional: `vivaldi://gpu` mostra Canvas, Compositing, Rasterization, Video Decode, Video Encode, WebGL, WebGPU e WebGPU interop como "Hardware accelerated". Suporte completo de codecs para descodificação H264, H265, VP9, AV1 e codificação H264, H265 e AV1.
+
+### Vivaldi - NVIDIA RTX 5090 (Contribuído por icetea)
+
+* **Navegador:** Vivaldi (8.1)
+
+* **GPU:** NVIDIA GeForce RTX 5090 (Blackwell)
+
+* **Caminho do Ficheiro de Flags:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks
+--use-gl=angle
+--use-angle=gl
+--disable-features=Vulkan
+--ignore-gpu-blocklist
+--ozone-platform=wayland
+```
+
+**Notas:**
+- Requer `libva-nvidia-driver`. Testado em julho de 2026: driver 610.43.03, KDE Plasma (Wayland), Vivaldi 8.1.
+- `VaapiIgnoreDriverChecks` é a flag chave na NVIDIA — sem ela, a descodificação inicializa e `vivaldi://gpu` indica "Hardware accelerated", mas a descodificação em tempo de execução falha (`vaEndPicture failed, VA error: internal decoding error`) e recorre silenciosamente ao software.
+- Verifique com DevTools → separador Media (`VaapiVideoDecoder` como nome do descodificador) e `nvidia-smi dmon -s u` (coluna DEC > 0 durante a reprodução). Não confie apenas em `vivaldi://gpu`.
+- A descodificação AV1 está com defeito no `libva-nvidia-driver` 0.0.17 (correção no upstream master, não lançada — veja [elFarto/nvidia-vaapi-driver#419](https://github.com/elFarto/nvidia-vaapi-driver/issues/419)). Bloqueie o AV1 (ex: enhanced-h264ify) para que o YouTube sirva VP9.
+
+### Google Chrome - NVIDIA RTX 5070 (Contribuído por pisyukaev)
+
+* **Navegador:** Google Chrome
+
+* **GPU:** NVIDIA GeForce RTX 5070 (Blackwell / GB205)
+
+* **Caminho do Ficheiro de Flags:** `~/.config/chrome-flags.conf`
+
+```bash
+--enable-features=AcceleratedVideoDecodeLinuxGL,VaapiVideoDecoder,VaapiIgnoreDriverChecks,VaapiOnNvidiaGPUs
+--ignore-gpu-blocklist
+```
+
+**Notas:**
+- Requer `libva-nvidia-driver` e `nvidia-utils` (testado com driver 610.43.03).
+- **Flag crítica:** `VaapiOnNvidiaGPUs` — esta é a flag chave que ativa o VA-API em GPUs NVIDIA no Chrome/Chromium. Sem ela, o Chrome bloqueia hardcoded dispositivos NVIDIA em `vaapi_wrapper.cc` e recorre silenciosamente à descodificação por software.
+- `VaapiIgnoreDriverChecks` também é recomendado para evitar falhas de descodificação em tempo de execução.
+- `AcceleratedVideoDecodeLinuxGL` ativa a descodificação de vídeo acelerada por hardware através do backend OpenGL do ANGLE.
+- Confirmado funcional: `chrome://gpu` → Video Acceleration Information mostra suporte de descodificação para H264 (baseline, main, high), VP8, VP9 (profile0, profile2), HEVC (main, main 10, main still-picture) e AV1.
+- Para verificar: Abra `chrome://gpu` e confirme que "Video Acceleration Information" lista os codecs de descodificação. Reproduza um vídeo HEVC e verifique o separador Media do DevTools para `VaapiVideoDecoder` como o descodificador ativo.
+- A flag `--ozone-platform=wayland` não é necessária — o Chrome deteta automaticamente o Wayland no CachyOS. Se tiver problemas, pode adicionar `--ozone-platform=wayland` explicitamente.
+
+### Brave Origin - AMD Radeon RX 7600 (Contribuído por RyuuPendragon)
+
+* **Navegador:** Brave Origin
+
+* **GPU:** AMD Radeon RX 7600
+
+* **Caminho do Ficheiro de Flags:** `~/.config/brave-origin-flags.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,CanvasOopRasterization,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```

--- a/src/content/docs/pt/configuration/gaming.mdx
+++ b/src/content/docs/pt/configuration/gaming.mdx
@@ -4,191 +4,131 @@ description: 'Abrange a instalação de pacotes essenciais, jogos na Steam com P
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
 import MultipleImageComponent from '~/components/multiple-images-component.astro';
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
 
-Bem-vindo ao guia de Jogos no CachyOS. Este guia orientará você nos aspectos essenciais de como configurar tudo para jogar.
+Bem-vindo ao guia de jogos no CachyOS! Este irá orientá-lo através de tudo o que precisa de saber para configurar o seu sistema para jogos.
 
-Antes de mais nada.
+*Primeiro de tudo, compreenda que obter uma melhoria de dois dígitos no FPS nem sempre é possível. Às vezes, as otimizações podem levar a melhorias mínimas ou até nenhuma, dependendo do jogo e da configuração do hardware.*
 
-*Lembre-se: obter uma melhoria de dois dígitos no FPS nem sempre é possível (ou sequer alcançável). Às vezes, as otimizações podem levar a melhorias mínimas ou até nenhuma, dependendo do jogo e da configuração do hardware.*
-
-*Não se pode esperar que otimizações de software funcionem como um upgrade de hardware gratuito.*
+*Não pode esperar que otimizações de software atuem como uma atualização de hardware gratuita.*
 
 <ImageComponent imgsrc={import('~/assets/images/gaming-meme.jpeg')} />
 
 ## Pré-requisitos
 
 :::caution
-Antes de prosseguir, certifique-se de que os drivers da sua placa de vídeo estejam instalados e funcionando corretamente; caso contrário, você poderá enfrentar problemas ao jogar.
+Antes de prosseguir, certifique-se de que os controladores da sua placa gráfica estão instalados e a funcionar corretamente, caso contrário poderá encontrar problemas ao jogar.
 :::
 
 ### Pacotes Essenciais
 
-Para facilitar a configuração do CachyOS para jogos, todos os pacotes necessários foram agrupados em um meta-pacote que inclui todas as dependências e bibliotecas essenciais para jogar no Linux, além de um meta-pacote separado para ferramentas e launchers/lojas.
+Para tornar a configuração do CachyOS para jogos mais fácil, todos os pacotes de jogos necessários estão agrupados num único meta-pacote que inclui todas as dependências e bibliotecas necessárias para jogos em Linux, juntamente com um meta-pacote separado para ferramentas e lojas/launchers populares.
 
-*Se você notar a falta de algum pacote, sinta-se à vontade para informar a equipe do CachyOS.*
+*Se verificar que faltam alguns pacotes, não hesite em informar a equipa do CachyOS.*
 
-Siga as etapas abaixo para iniciar a configuração de jogos.
-
+Siga os passos abaixo para começar com a configuração de jogos.
 <Tabs>
-    <TabItem label='Meta-pacote'>
-        O meta-pacote `cachyos-gaming-meta` inclui diversas bibliotecas relacionadas a jogos.
-        ```sh
-        sudo pacman -S cachyos-gaming-meta
-        ```
-    </TabItem>
-    <TabItem label='Ferramentas e Lojas'>
-        O meta-pacote `cachyos-gaming-applications` inclui o seguinte:
-          - Ferramentas
-            - Gamescope, Goverlay, MangoHud
-          - Launchers (Iniciadores)
-            - Steam, Heroic Games Launcher, Lutris
-        ```sh
-        sudo pacman -S cachyos-gaming-applications
-        ```
-    </TabItem>
-    <TabItem label= 'CachyOS Hello'>
-    - Vá em **Apps/Tweaks** e clique em `Install Gaming packages`.
-
-    *O CachyOS Hello instala tanto o `cachyos-gaming-meta` quanto o `cachyos-gaming-applications`.*
-    </TabItem>
+  <TabItem label='CachyOS Hello'>
+    - Abra o CachyOS Hello. Vá a **Apps/Tweaks** e clique em `Install Gaming packages`.
+    <ImageComponent imgsrc={import('~/assets/images/cachyos_hello-gaming.png')} />
+    *O CachyOS Hello instala tanto o `cachyos-gaming-meta` como o `cachyos-gaming-applications`.*
+  </TabItem>
+  <TabItem label='Meta Package'>
+    O meta-pacote `cachyos-gaming-meta` inclui muitas bibliotecas relacionadas com jogos.
+    ```sh
+    sudo pacman -S cachyos-gaming-meta
+    ```
+  </TabItem>
+  <TabItem label='Tools & Stores'>
+    O meta-pacote `cachyos-gaming-applications` inclui o seguinte:
+    - Tools
+      - Gamescope, GOverlay, MangoHud
+    - Launchers
+      - Steam, Heroic Games Launcher, Lutris, Faugus Launcher
+    ```sh
+    sudo pacman -S cachyos-gaming-applications
+    ```
+  </TabItem>
 </Tabs>
 
 ## Proton-CachyOS
 
-O Proton-CachyOS é baseado no branch `bleeding-edge` do Proton e aplica uma série de modificações sobre ele.
+O Proton-CachyOS é baseado no ramo `bleeding-edge` do Proton e aplica uma série de modificações sobre ele.
 - **Patches do Wine-staging**
 - **Wine Fullscreen FSR**
 - **Inclui codecs de vídeo e áudio para cutscenes de jogos**
-- **Suporte para umu-launcher, incluindo UMU-Protonfixes**
-- **Adiciona correções rápidas (hotfixes) e contornos antecipados para jogos**
+- **Suporte para umu-launcher incluindo UMU-Protonfixes**
+- **Adiciona correções rápidas (hotfixes)/contornos antecipados para jogos**
 
-:::note[O NTSync está habilitado por padrão]
-Você pode desativá-lo configurando a variável de ambiente`PROTON_NO_NTSYNC=1`
+:::note[O NTSync está ativado por padrão]
+Pode desativá-lo definindo a variável de ambiente `PROTON_NO_NTSYNC=1`
 :::
 
-### Como configurar corretamente múltiplas opções de inicialização
+### Como Definir Corretamente Múltiplas Opções de Inicialização
 
-As opções de inicialização na Steam são construídas seguindo o seguinte padrão:
+As opções de inicialização na Steam são construídas utilizando o seguinte padrão.
 
 ```bash
-<env variables> <wrappers> %command% <application arguments>
+[env variables] [wrappers] %command% [application arguments]
 ```
 
-- **`<env variables>`**: Estas são opções no formato `VARIÁVEL=valor`
+- **`[env variables]`**: Estas são opções no formato `VARIÁVEL=valor`
   ```bash title="Examples"
   PROTON_DXVK_D3D8=1
   # Ou
   DXVK_HUD="fps,memory,version,api"
   ```
 
-- **`<wrappers>`**: Estas são aplicações e scripts que modificam a forma como a aplicação real é executada. Os argumentos para o "wrapper" geralmente vêm após o executável do mesmo.
+- **`[wrappers]`**: Estas são aplicações e scripts que modificam como a aplicação real é executada. Argumentos para o wrapper geralmente vão após o executável do wrapper.
   ```bash title="Examples"
   mangohud --dlsym
   # Ou
   gamescope -W 1680 -H 1050 -w 1280 -h 720 -S fit -F fsr --mangoapp --
   ```
 
-- **`%command%`**: Esta é a aplicação real. Isto deve ser especificado exatamente como está, e a Steam irá substituí-lo pelo comando adequado quando a aplicação for executada.
+- **`%command%`**: Esta é a aplicação real. Isto deve ser especificado exatamente como está e a Steam irá substituí-lo pelo comando adequado quando a aplicação for executada.
 
-- **`<application arguments>`**: Estes são diversos argumentos para a aplicação real e dependem da própria aplicação.
+- **`[application arguments]`**: Estes são vários argumentos para a aplicação real, e dependem da aplicação.
   ```bash title="Example"
   %command% -dx11
   ```
 
 **Exemplo de uma opção de inicialização completa combinando todos os elementos:**
-
-  ```bash
-  __GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1 prime-run game-performance %command% -dx11
-  ```
+```bash
+__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1 prime-run game-performance %command% -dx11
+```
 
 :::caution
-Não adicione múltiplos `%command%` utilizando-os como separadores para várias opções de inicialização.
+Não adicione múltiplos `%command%` usando-os como separadores para múltiplas opções de inicialização.
 
 Exemplo: `__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1 %command% game-performance %command% prime-run %command%`
 
-Neste caso, tudo após o primeiro `%command%` será ignorado porque está a ser tratado como argumentos do jogo; portanto, apenas `__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1` será reconhecido como uma opção de inicialização.
+Neste caso, tudo após o primeiro `%command%` vai ser ignorado porque está a ser tratado como argumentos do jogo, portanto apenas `__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1` é reconhecido como uma opção de inicialização.
 :::
 
 #### Variáveis de Ambiente
+:::note
+Versões personalizadas do Proton têm opções de configuração instáveis por padrão. Para as informações mais recentes sobre as respetivas opções de configuração, consulte a documentação delas.
 
-<Tabs>
-<TabItem label="Gráficos e Upscaling">
+Links para documentos do Proton-CachyOS:
 
-- Funcionalidades DLSS & Nvidia
-    - `PROTON_DLSS_UPGRADE=1`: Atualiza automaticamente o DLSS para a versão mais recente.
-    - `PROTON_DLSS_INDICATOR=1`: Exibe o indicador de estado do DLSS dentro do jogo.
-    - `PROTON_NVIDIA_LIBS=1`: Ativa as bibliotecas Nvidia (PhysX, CUDA) - não é necessário para DLSS/ray tracing.
+<LinkButton icon="external" href="https://github.com/CachyOS/proton-cachyos/blob/cachyos_main/README.md#proton-cachyos-config-options">Readme</LinkButton>
+<LinkButton icon="external" href="https://github.com/CachyOS/proton-cachyos/blob/cachyos_main/CHANGELOG.md">Changelog</LinkButton>
 
-<details>
-<summary>Controlos Avançados Nvidia</summary>
+Links para documentos do Proton-EM:
 
-- `PROTON_NVIDIA_NVCUDA=1`: Ativa apenas o suporte CUDA.
-- `PROTON_NVIDIA_NVENC=1`: Ativa apenas a codificação NVENC.
-- `PROTON_NVIDIA_NVML=1`: Ativa a monitorização NVML.
-- `PROTON_NVIDIA_NVOPTIX=1`: Ativa o ray tracing OptiX.
-- `PROTON_NVIDIA_LIBS_NO_32BIT=1`: Restringe as bibliotecas apenas a 64 bits (corrige problemas de desempenho na série RTX 4000+).
-</details>
-
-- Upscaling AMD & Intel
-    - `PROTON_FSR4_UPGRADE=1`: Atualiza automaticamente o FSR para a versão mais recente.
-    - `PROTON_FSR4_RDNA3_UPGRADE=1`: Utiliza uma DLL de FSR4 otimizada para RDNA3.
-    - `PROTON_XESS_UPGRADE=1`: Atualiza automaticamente o XeSS para a versão mais recente.
-
-</TabItem>
-
-<TabItem label="Ecrã e HDR">
-
-- Wayland e Ecrã
-    - `PROTON_ENABLE_WAYLAND=1`: Ativa o suporte nativo ao Wayland.
-      - **Benefícios**: Permite HDR sem o Gamescope; melhora a latência/frame pacing.
-      - **Avisos**: Interrompe o Steam Overlay; atualmente experimental.
-    - `PROTON_NO_WM_DECORATION=1`: Desativa as decorações do gestor de janelas.
-      - **Correções**: Problemas de ecrã inteiro sem bordas, cliques do rato passando através das janelas.
-
-- Suporte HDR
-    - `PROTON_ENABLE_HDR=1`: Ativa o suporte de saída HDR.
-      - **Requisitos**: Gamescope com `--hdr-enabled` OU `PROTON_ENABLE_WAYLAND=1`. Se o teu GPU for **NVIDIA**, adiciona `ENABLE_HDR_WSI=1` e instala o pacote `vk-hdr-layer-kwin6-git`.
-      - **Configuração**: [Configuração adicional necessária](https://wiki.archlinux.org/title/HDR_monitor_support).
-
-</TabItem>
-
-<TabItem label="Desempenho e Cache">
-
-- Desempenho de CPU e Sincronização
-    - `PROTON_NO_NTSYNC=1`: Usa FSync em vez de NTSync.
-        - **Benefício**: Possibilidade de corrigir problemas em certos jogos que não rodam bem com o NTSync.
-
-- Gestão de Shaders e Cache
-    - `PROTON_LOCAL_SHADER_CACHE=1`: Ativa a cache de shaders por jogo, semelhante ao "Shader Pre-Caching" da Steam.
-        - **Nota**: Isto NÃO compila shaders antecipadamente, APENAS isola a cache de shaders de cada jogo. Os shaders continuarão a ser compilados durante o jogo.
-    - `PROTON_ENABLE_MEDIACONV=1`: Ativa o Proton Media Converter.
-        - **Nota**: Apenas para fins de teste.
-
-- AMD Anti-Lag
-    - `ENABLE_LAYER_MESA_ANTI_LAG=1`: Ativa o AMD Anti-Lag para reduzir a latência de entrada (input lag).
-
-</TabItem>
-
-<TabItem label="Entrada e Compatibilidade">
-
-- Comando e Entrada
-    - `PROTON_PREFER_SDL=1`: Solução alternativa para problemas de deteção de comandos.
-    - `PROTON_NO_STEAMINPUT=1`: Desativa o suporte ao Steam Input.
-        - **Correções**: Problemas de comando/gamepad em Wayland.
-
-</TabItem>
-</Tabs>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-11-hdr/README.md">Readme</LinkButton>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/EM-ADDITIONS.md">EM-ADDITIONS</LinkButton>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/FSR4.md">FSR4</LinkButton>
+<LinkButton icon="external" href="https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/CHANGES.md">Winewayland</LinkButton>
+:::
 
 ### Configurar o Proton-CachyOS com Lutris e Heroic
-
-:::note
-A seguinte configuração aplica-se apenas ao proton-cachyos. Se estiver a utilizar o proton-cachyos-slr, -GE ou -EM, pode ignorar esta secção.
-:::
 
 Certifique-se de que tem o umu-launcher do CachyOS instalado no seu sistema. Instale-o com o seguinte comando.
 ```sh
@@ -196,214 +136,255 @@ sudo pacman -S cachyos/umu-launcher
 ```
 
 <Tabs>
-    <TabItem label='Lutris Global'>
+  <TabItem label='Lutris Global'>
     <Steps>
-    1. No ecrã principal do Lutris, clique no ícone da engrenagem ao lado de Wine.
-    2. Vá ao separador **Runner Options** e confirme que as suas definições correspondem ao seguinte:
-        - **Wine version** = `proton-cachyos`
-        - **Use System winetricks** = *Disabled* (Desativado)
-        - **Graphics**
-            - **Enable DXVK** = `Enabled` (Ativado)
-              - Nota: Versões de **DXVK**, **VKD3D** e **DXVK-NVAPI** definidas pelo utilizador não são aplicadas ao usar o `umu-launcher`.
-    3. Navegue até ao separador **System Options**.
-        - **Lutris**
-            - **Disable Lutris Runtime** = `Enabled` (Ativado)
-            - **Prefer system libraries** = `Enabled` (Ativado)
-    4. Continue a descer até à secção **Game execution** e localize a tabela **Environment variables**.
-    5. Adicione as seguintes variáveis de ambiente:
-        - **Key**: `UMU_RUNTIME_UPDATE` *opcional*
-            - **Value**: `0`
-            - *Isto irá saltar as atualizações do Steam Linux Runtime para o proton-cachyos. Não use isto com qualquer Proton que utilize o Steam Linux Runtime, como o proton-cachyos-slr, -GE ou -EM.*
-        - **Key**: `PROTON_VERB` *opcional*
-            - **Value**: `waitforexitandrun`
-            - *Isto permite que os protonfixes funcionem com um GAMEID correspondente.*
-    6. Clique em **Save** para aplicar as alterações.
+      1. No ecrã principal do Lutris, clique no ícone da engrenagem ao lado de Wine.
+      2. Vá ao separador **Runner Options** e confirme que as suas definições correspondem ao seguinte:
+          - **Wine version** = `proton-cachyos-slr` ou `proton-cachyos-native`
+          - **Use System winetricks** = *Disabled*
+          - **Graphics**
+          - **Enable DXVK** = `Enabled`
+            - Nota: Versões definidas pelo utilizador de **DXVK**, **VKD3D** e **DXVK-NVAPI** não são aplicadas ao usar `umu-launcher`.
+      3. Navegue até ao separador **System Options**.
+          - **Lutris**
+          - **Disable Lutris Runtime** = `Enabled`
+          - **Prefer system libraries** = `Enabled`
+      4. Continue a descer até à secção **Game execution** e localize a tabela **Environment variables**.
+      5. Adicione as seguintes variáveis de ambiente:
+          - **Key**: `PROTON_VERB` *opcional*
+          - **Value**: `waitforexitandrun`
+            - *Isto permite que protonfixes funcionem com um GAMEID correspondente.*
+      6. Clique em **Save** para aplicar as alterações.
     </Steps>
-    </TabItem>
-    <TabItem label='Lutris por Jogo'>
+  </TabItem>
+  <TabItem label='Lutris Per Game'>
     <Steps>
-    1. Clique com o botão direito no jogo que deseja configurar e, em seguida, clique em **Configure**.
-    2. Vá ao separador **Runner Options** e confirme que as suas definições correspondem ao seguinte:
-        - **Wine version** = `proton-cachyos`
-        - **Use System winetricks** = *Disabled* (Desativado)
-        - **Graphics**
-            - **Enable DXVK** = `Enabled` (Ativado)
-              - Nota: Versões de **DXVK**, **VKD3D** e **DXVK-NVAPI** definidas pelo utilizador não são aplicadas ao usar o `umu-launcher`.
-    3. Navegue até ao separador **System Options**.
-        - **Lutris**
-            - **Disable Lutris Runtime** = `Enabled` (Ativado)
-            - **Prefer system libraries** = `Enabled` (Ativado)
-    4. Continue a descer até à secção **Game execution** e localize a tabela **Environment variables**.
-    5. Adicione as seguintes variáveis de ambiente:
-        - **Key**: `UMU_RUNTIME_UPDATE` *opcional*
-            - **Value**: `0`
-            - *Isto irá saltar as atualizações do Steam Linux Runtime para o proton-cachyos. Não use isto com qualquer Proton que utilize o Steam Linux Runtime, como o proton-cachyos-slr, -GE ou -EM.*
-        - **Key**: `PROTON_VERB` *opcional*
-            - **Value**: `waitforexitandrun`
-            - *Isto permite que os protonfixes funcionem com um GAMEID correspondente.*
-    6. Clique em **Save** para aplicar as alterações.
+      1. Clique com o botão direito no jogo que deseja configurar, depois clique em **Configure**.
+      2. Vá ao separador **Runner Options** e confirme que as suas definições correspondem ao seguinte:
+          - **Wine version** = `proton-cachyos-slr` ou `proton-cachyos-native`
+          - **Use System winetricks** = *Disabled*
+          - **Graphics**
+          - **Enable DXVK** = `Enabled`
+            - Nota: Versões definidas pelo utilizador de **DXVK**, **VKD3D** e **DXVK-NVAPI** não são aplicadas ao usar `umu-launcher`.
+      3. Navegue até ao separador **System Options**.
+          - **Lutris**
+          - **Disable Lutris Runtime** = `Enabled`
+          - **Prefer system libraries** = `Enabled`
+      4. Continue a descer até à secção **Game execution** e localize a tabela **Environment variables**.
+      5. Adicione as seguintes variáveis de ambiente:
+          - **Key**: `PROTON_VERB` *opcional*
+          - **Value**: `waitforexitandrun`
+            - *Isto permite que protonfixes funcionem com um GAMEID correspondente.*
+      6. Clique em **Save** para aplicar as alterações.
     </Steps>
-    </TabItem>
-    <TabItem label='Heroic Games Launcher'>
-        <Steps>
-            1. Clique no botão `Configure` ao lado do botão `Play Now` no jogo que deseja executar.
-            2. No separador `WINE`, defina a Wine Version para `Proton - proton-cachyos`.
-        </Steps>
-    </TabItem>
+  </TabItem>
+  <TabItem label='Heroic Games Launcher'>
+    <Steps>
+      1. Clique no botão `Configure` ao lado do botão `Play Now` no jogo que deseja executar.
+      2. No separador `WINE`. Defina a Wine Version para `Proton - proton-cachyos-slr`.
+    </Steps>
+  </TabItem>
 </Tabs>
 
 ### Suporte Anti-Cheat
 
 :::caution[Importante]
-Se encontrar problemas com jogos que utilizam **Easy Anti-Cheat** (EAC) ou **BattlEye** (BE), como a recusa de login em servidores de jogo, pode utilizar a versão do [Proton-CachyOS compilada usando o Steam Linux Runtime](https://github.com/CachyOS/proton-cachyos/releases), também conhecida como **proton-cachyos-slr**.
+Se encontrar problemas com jogos que usam **Easy Anti-Cheat** (EAC) ou **BattlEye** (BE), como recusa de login em servidores de jogo, pode usar a versão do [Proton-CachyOS construída usando Steam Linux Runtime](https://github.com/CachyOS/proton-cachyos/releases), também conhecida como **proton-cachyos-slr**.
 :::
 
-### Como Instalar o proton-cachyos-slr
+### Como Instalar proton-cachyos-slr
+
+:::note[Este passo é apenas necessário se o pacote cachyos-gaming-meta não foi instalado. Se foi instalado, ignore esta parte.]
+:::
 
 <Tabs>
 
-<TabItem label='protonup'>
-
-<Steps>
-1. Abra um terminal e instale o `protonup`.
-    ```sh
-    sudo pacman -S protonup-qt
+  <TabItem label='pacman'>
+    ```sh title='Run the following command'
+    sudo pacman -S proton-cachyos-slr
     ```
-2. Abra o **protonup-qt** e siga a captura de ecrã:
-    <ImageComponent imgsrc={import('~/assets/images/steam-protonup.png')} />
-    :::note
-    Escolha a versão `x86-64_v3` se o seu CPU suportar **[AVX2](/installation/installation_prepare#x86_64-microarchitecture-level-support)**.
+  </TabItem>
 
-    Caso contrário, descarregue a versão que termina em `x86-64`.
-    :::
-3. Reinicie a Steam se a tiver aberta.
+  <TabItem label='protonup'>
 
-</Steps>
-
-</TabItem>
-
-<TabItem label='pacman'>
-```sh title='Run the following command'
-sudo pacman -S proton-cachyos-slr
-```
-</TabItem>
+    <Steps>
+      1. Abra um terminal e instale `protonup`.
+          ```sh
+          sudo pacman -S protonup-qt
+          ```
+      2. Abra **protonup-qt** e siga a captura de ecrã:
+          <ImageComponent imgsrc={import('~/assets/images/steam-protonup.png')} />
+          :::note
+          Escolha a versão `x86-64_v3` se o seu CPU suportar **[AVX2](/pt/installation/installation_prepare#x86_64-microarchitecture-level-support)**.
+          Caso contrário, descarregue a que termina em `x86-64`.
+          :::
+      3. Reinicie a Steam se a tivesse aberta.
+    </Steps>
+  </TabItem>
 
 </Tabs>
 
 <details>
-<summary>Instalação Manual (Avançado)</summary>
+  <summary>Instalação Manual (Avançado)</summary>
 
-<Steps>
-1. Descarregue a versão mais recente [aqui](https://github.com/CachyOS/proton-cachyos/releases) (desça até **Assets**).
-    :::note
-    Escolha a que termina em `x86-64_v3` se o seu CPU suportar **[AVX2](/installation/installation_prepare#x86_64-microarchitecture-level-support)**.
-    Caso contrário, descarregue a que termina em `x86-64`.
-    :::
-2. Descompacte o ficheiro e mova a pasta para `~/.steam/steam/compatibilitytools.d/`
-3. Reinicie a Steam se a tiver aberta.
-</Steps>
+  <Steps>
+    1. Descarregue a versão mais recente [aqui](https://github.com/CachyOS/proton-cachyos/releases) (desça até **Assets**).
+        :::note
+        Escolha descarregar a que termina em `x86-64`. Esta é a versão que a maioria dos utilizadores deve preferir.
+        Escolha a que termina em `x86-64_v3` apenas se o seu CPU suportar **[AVX2](/pt/installation/installation_prepare#x86_64-microarchitecture-level-support)** e quiser experimentar.
+        :::
+    2. Descompacte o ficheiro e mova a pasta para `~/.steam/steam/compatibilitytools.d/`
+    3. Reinicie a Steam se a tivesse aberta.
+  </Steps>
 
 </details>
 
 ## Wine-CachyOS
 
-Este é o mesmo `wine` que está na base do `proton-cachyos`, mas como um pacote independente. Pode ser utilizado no Lutris, Heroic, Bottles e outros.
+Este é o mesmo `Wine` que está no cerne do `Proton-CachyOS`, mas como um pacote independente. Pode ser usado no Lutris, Heroic, Bottles e outros. **Tenha em mente que não está destinado a ser usado para Steam.**
 
-- **Todas as modificações do Wine incluídas no Proton-CachyOS**
-- **Adiciona correções rápidas (hotfixes) e contornos antecipados para jogos**
+- **Todas as modificações do Wine incluídas com Proton-CachyOS**
+- **Adiciona correções rápidas (hotfixes)/contornos antecipados para jogos**
 
 :::note
-Nos repositórios do CachyOS, o **Wine-CachyOS** é oferecido por dois pacotes diferentes. O `wine-cachyos` instala-o como o Wine predefinido do sistema e substitui o `wine` ou `wine-staging`. O `wine-cachyos-opt` instala-o num local diferente, o que permite a coexistência de múltiplas versões do Wine no sistema.
+Nos repositórios do CachyOS, o **Wine-CachyOS** é oferecido por dois pacotes diferentes. `wine-cachyos` instala-o como o Wine padrão do sistema e substitui `wine` ou `wine-staging`. `wine-cachyos-opt` instala-o num local diferente, o que permite que múltiplas versões do wine coexistam no sistema.
 :::
 
 :::caution
-O uso principal pretendido para o **Wine-CachyOS** são os **jogos**. Embora possa ser utilizado como o Wine do sistema com aplicações de desktop, esteja ciente de que pode levar a comportamentos inesperados e problemas devido às modificações focadas em jogos.
+O uso pretendido principal do **Wine-CachyOS** é para **jogos**. Embora possa ser usado como Wine do sistema com aplicações de desktop, esteja ciente de que pode levar a comportamento inesperado e problemas devido às modificações focadas em jogos.
 
-Se deseja utilizar aplicações de desktop, sugerimos que utilize o `wine` ou `wine-staging` como o Wine do seu sistema e instale o `wine-cachyos-opt` para jogar.
+Se quiser usar aplicações de desktop, sugerimos usar `wine` ou `wine-staging` como o Wine do seu sistema e instalar `wine-cachyos-opt` para jogos.
 :::
 
 **Opções de configuração adicionais**
 
-- `WINE_WMCLASS="<nome>"`: Define o `WM_CLASS` de todas as janelas do Wine, permitindo que o gestor de janelas controle as mesmas através de regras.
-- `WINEUSERSANDBOX=1`: Desativa a criação de links simbólicos (symlinks) das pastas de utilizador do Wine (como Documentos e Imagens) para as pastas equivalentes no diretório `HOME` do utilizador.
-- `WINE_NO_WM_DECORATION=1`: Desativa as decorações das janelas. Pode corrigir problemas com o modo **ecrã inteiro sem bordas** e cliques do rato que atravessam a janela.
-- `WINE_PREFER_SDL_INPUT=1`: Solução alternativa para problemas de deteção de comandos.
+- `WINE_WMCLASS="[name]"`: Define o `WM_CLASS` de todas as janelas do Wine, permitindo que o gestor de janelas controle as janelas do Wine através de regras.
+- `WINEUSERSANDBOX=1`: Desativa a criação de symlinks das pastas de utilizador do Wine (como Documentos e Imagens) para as pastas equivalentes no diretório `HOME` do utilizador.
+- `WINE_NO_WM_DECORATION=1`: Desativa decorações de janela. Pode corrigir problemas com **ecrã inteiro sem bordas** e o rato a clicar através da janela.
+- `WINE_PREFER_SDL_INPUT=1`: Contorno para problemas de deteção de controlador
 
-### Como Utilizar o wine-cachyos-opt
+### Como Usar wine-cachyos-opt
 
 <Tabs>
-    <TabItem label='Independente'>
-    Normalmente, executar `/opt/wine-cachyos/bin/wine` em vez de apenas `wine` deve ser suficiente para que uma aplicação corra utilizando o `wine-cachyos-opt`.
+  <TabItem label='Standalone'>
+    Normalmente, executar `/opt/wine-cachyos/bin/wine` em vez de apenas `wine` deve ser suficiente para uma aplicação correr usando `wine-cachyos-opt`.
 
-    Se for necessária uma configuração mais restrita, poderá ser algo como isto:
-    ```shell
+    Se for necessária uma configuração mais estrita, poderia parecer-se com isto:
+    ```sh
     export PATH="/opt/wine-cachyos/bin/:$PATH"
     export WINEDLLPATH="/opt/wine-cachyos/lib/wine:/opt/wine-cachyos/lib32/wine:$WINEDLLPATH"
     export LD_LIBRARY_PATH="/opt/wine-cachyos/lib/:/opt/wine-cachyos/lib32/:$LD_LIBRARY_PATH"
     ```
 
-    Se quiser utilizar o `winetricks` com o `wine-cachyos-opt`, pode invocá-lo desta forma:
-    ```shell
-    WINE=/opt/wine-cachyos/bin/wine WINEPREFIX=<your prefix> winetricks <verb>
+    Se quiser usar `winetricks` com `wine-cachyos-opt`, pode invocá-lo assim:
+    ```sh
+    WINE=/opt/wine-cachyos/bin/wine WINEPREFIX=[your prefix] winetricks [verb]
     ```
-</TabItem>
-    <TabItem label='Lutris'>
-      :::note
-      A segunda imagem também se aplica à configuração por jogo.
-      :::
-      <MultipleImageComponent
-      images={[
-      import('~/assets/images/lutris-guide-1.png'),
-      import('~/assets/images/lutris-guide-2.png')]}
-      />
-    </TabItem>
-    <TabItem label='Heroic Games Launcher'>
-      <MultipleImageComponent
-      images={[
-      import('~/assets/images/heroic-wine.png'),
-      import('~/assets/images/heroic-wine-2.png'),
-      import('~/assets/images/heroic-wine-3.png')]}
-      />
-    </TabItem>
+  </TabItem>
+  <TabItem label='Lutris'>
+    :::note
+    A segunda imagem também se aplica para configurar por jogo.
+    :::
+    <MultipleImageComponent
+      images={[import('~/assets/images/lutris-guide-1.png'), import('~/assets/images/lutris-guide-2.png')]}
+    />
+  </TabItem>
+  <TabItem label='Heroic Games Launcher'>
+    <MultipleImageComponent
+      images={[import('~/assets/images/heroic-wine.png'), import('~/assets/images/heroic-wine-2.png'), import('~/assets/images/heroic-wine-3.png')]}
+    />
+  </TabItem>
 </Tabs>
 
 ## FAQ e Dicas da Steam
 
 :::note
-Utilizadores de portáteis com GPUs Nvidia dedicadas devem consultar o [guia de GPUs Híbridas (Dual GPU)](/configuration/dual_gpu/).
+Utilizadores de portáteis com GPUs Nvidia dedicadas devem consultar o [guia de Dual GPU Laptops](/pt/configuration/dual_gpu/).
 :::
 
 :::tip
-O CachyOS fornece várias versões do Proton que são compiladas e mantidas para melhorias adicionais de desempenho:
-- `proton-cachyos` (incluído no pacote `cachyos-gaming-meta`) é desenvolvido com mudanças de QoL (qualidade de vida) adicionais e patches selecionados.
+O CachyOS fornece várias versões do Proton que são construídas e mantidas para melhorias de desempenho adicionais:
+- `proton-cachyos` (incluído no pacote `cachyos-gaming-meta`) é desenvolvido com alterações de QoL adicionais, patches cherry-picked, etc.
 :::
 
 :::tip
-Para verificar se um jogo é compatível com Linux, ou como ele corre no Linux, visite o **[ProtonDB](https://www.protondb.com/)** ou o **[Are We Anti-Cheat Yet?](https://areweanticheatyet.com/)**.
+Para verificar se um jogo é compatível com Linux, ou como corre em Linux, visite
+**[ProtonDB](https://www.protondb.com/)** ,
+**[Are We Anti-Cheat Yet?](https://areweanticheatyet.com/)**
+ou **[Gaming On Linux Anti Cheat Section](https://www.gamingonlinux.com/anticheat/)**
 :::
 
-### Qual versão do Proton deve ser utilizada na Steam?
+### Como definir versões personalizadas do Proton na Steam
 
-:::note
-Visto que tem havido alguma confusão no **Reddit**, a versão nativa do `Proton-CachyOS` não será descontinuada em consequência da descontinuação do `steam-native-runtime`.
-
-Eles não estão relacionados e são irrelevantes entre si. A nossa sugestão recente tem sido o SLR, **que também instalamos por padrão**, para reduzir a confusão e problemas para recém-chegados ao CachyOS e ao Linux em geral. Se gosta da versão nativa e ela funciona para si, continue a utilizá-la.
+:::caution[É FORTEMENTE RECOMENDADO manter o Proton da Valve como padrão global.]
 :::
 
-- `Proton 10.0` é a versão estável da `Valve`. Utilize esta se o jogo que pretende jogar for conhecido por funcionar bem com ela.
-- `Proton Experimental` é a versão de desenvolvimento (bleeding edge) da `Valve`. Utilize esta se o jogo que pretende jogar for relativamente novo, não funcionar bem com a versão estável atual do Proton, ou se for recomendado no **[ProtonDB](https://www.protondb.com/)**.
-- `proton-cachyos-slr` é a versão compilada e mantida pelos mantenedores do CachyOS. O seu uso é altamente recomendado devido às suas diversas funcionalidades de QoL, correções e otimizações. Para jogos que utilizam anti-cheat, como **BattlEye** ou **Easy Anti-Cheat**, ou launchers personalizados, o `proton-cachyos-slr` é o preferido.
-- `proton-cachyos` é a mesma versão que o `proton-cachyos-slr`, mas compilada sem depender do Steam Linux Runtime. Utilize-a apenas se compreender o significado desta diferença, e mude para o `proton-cachyos-slr` se ocorrerem problemas.
-- `Proton-GE` é uma versão personalizada feita por [GloriousEggroll](https://github.com/GloriousEggroll/proton-ge-custom). Inclui várias correções e pode ser útil em certas situações.
-- `Proton 9.0.4 ou inferior` são as versões estáveis da `Valve`. Utilize estas se o jogo que pretende jogar apenas funcionar com uma versão anterior do Proton.
+- Para definir um Proton personalizado para um jogo específico, navegue à Biblioteca, clique com o botão direito no jogo
+vá a **Properties** > **Compatibility**
 
-### Corrigir Stuttering causado pela funcionalidade de Gravação de Jogo da Steam
+marque a caixa `Force the use of a specific Steam Play compatibility tool`
+e selecione a versão do proton desejada.
+
+- Para definir o Proton da Valve como padrão global, navegue a **Settings** > **Compatibility** > **Default Compatibility tool**
+e defina a versão estável mais recente do proton da Valve ou Proton Experimental.
+
+### Qual Versão do Proton Devo Usar na Steam?
+
+:::tip
+Para novos utilizadores, sugerimos usar o Proton da Valve ou Proton Experimental.
+:::
+
+Versões oficiais do Proton:
+
+**Proton Experimental:** é a versão bleeding edge da **Valve**. Use esta se o jogo que quer jogar for relativamente novo, não funcionar bem com a versão estável atual do Proton, ou se as pessoas o recomendarem no **[ProtonDB](https://www.protondb.com/)**.
+
+**Proton 11.0:** é a versão estável da **Valve**. Use esta se o jogo que quer jogar for conhecido por funcionar bem com ela.
+
+**Proton 10.0 ou inferior:** são as versões estáveis da **Valve**. *Use esta se o jogo que quer jogar apenas funcionar com uma versão anterior do Proton.*
+
+:::tip
+Para utilizadores mais experientes, que querem experimentar funcionalidades extras, usar Proton fora da Steam, ou precisam de correções não presentes no Proton da Valve, existem mais do que algumas variantes personalizadas do Proton que podem usar. Tenha em mente que elas não são suportadas pela Valve, são esforços da comunidade e são experimentais por natureza.
+:::
+
+Forks do Proton de terceiros:
+
+**Proton-CachyOS:**
+Construído e mantido por [CachyOS](https://github.com/CachyOS/proton-cachyos), contém funcionalidades extras de qualidade de vida, correções e alterações experimentais.
+
+Pode encontrar duas variantes nos repositórios do CachyOS: [`proton-cachyos-native`](https://packages.cachyos.org/package/cachyos/x86_64/proton-cachyos-native) e [`proton-cachyos-slr`](https://packages.cachyos.org/package/cachyos/x86_64/proton-cachyos-slr).
+
+Sugerimos usar o pacote `proton-cachyos-slr` em vez do `proton-cachyos-native`.
+
+**Proton-EM:**
+Uma construção personalizada orientada para desenvolvimento feita por [Etaash-mathamsetty](https://github.com/Etaash-mathamsetty/Proton). É uma opção muito boa se quiser usar **winewayland** e **FSR4** sem nenhuma das extras que o Proton-CachyOS oferece. Também é a fonte de várias melhorias que o Proton-CachyOS inclui.
+
+*Se está interessado no mais recente e melhor em desenvolvimento **winewayland**, isto é para si.*
+
+**dwproton:**
+Uma construção personalizada feita por [Dawn Winery](https://dawn.wine/dawn-winery/dwproton), é um fork do Proton-CachyOS com **correções e patches extras para certos jogos anime**.
+
+Se encontrar problemas com tais jogos com outras variantes do Proton, **dwproton** é a sua melhor opção.
+
+**Proton-GE**:
+Uma construção personalizada feita por [GloriousEggroll](https://github.com/GloriousEggroll/proton-ge-custom). Inclui várias correções, e pode ser útil ter em certas situações.
+
+### Corrigir vídeos H264 que não reproduzem ou exibem barras de cor em jogos com o Proton da Valve
+:::caution
+Isto é opcional. Use apenas se estiver a ter o problema.
+:::
+Inicie a Steam com o seguinte comando. Aguarde que carregue, depois saia da Steam e inicie-a normalmente.
+
+```sh
+ steam steam://unlockh264/
+```
+
+### Corrigir Stuttering Causado pela Funcionalidade de Gravação de Jogos da Steam
 
 :::caution
-Adicionar esta variável de ambiente faz com que o **Steam Overlay** deixe de funcionar.
+Adicionar esta variável de ambiente faz com que o **Overlay da Steam** deixe de funcionar.
 :::
 
-Adicione a seguinte opção de inicialização ao seu jogo:
+Adicione a seguinte opção de inicialização ao seu jogo.
 
 ```sh
 LD_PRELOAD="" %command%
@@ -412,67 +393,75 @@ LD_PRELOAD="" %command%
 ### Capturar e Partilhar Logs do Proton
 
 :::note
-Ao partilhar logs com o CachyOS, por favor carregue-os para o **[paste-cachyos](https://paste.cachyos.org/)** em vez de os publicar diretamente.
+Ao partilhar logs com o CachyOS, por favor carregue-os para o **[paste-cachyos](https://paste.cachyos.org/)** em vez de publicar diretamente.
 
-Pode simplesmente arrastar e largar o ficheiro de log no site e depois partilhar o link gerado.
+Pode simplesmente arrastar e largar o ficheiro de log para o site, depois partilhar o link gerado.
 :::
 
-Para ativar o registo (logging) do Proton num jogo:
+Para ativar o logging do Proton para um jogo:
 
 <Steps>
-    1. Clique com o botão direito no seu jogo na Steam e selecione **Propriedades**.
-    2. Em **Opções de Inicialização**, defina a variável de ambiente `PROTON_LOG`:
-        ```sh
-        PROTON_LOG=1 %command%
-        ```
-        Isto criará um ficheiro de log no seu diretório pessoal (home) chamado `steam-<AppID>.log` (por exemplo, o Counter Strike 2 utiliza o AppID **730**, logo o ficheiro seria `steam-730.log`).
+  1. Clique com o botão direito no seu jogo na Steam e selecione **Properties**.
+  2. Em **Launch Options**, defina a variável de ambiente `PROTON_LOG`:
+      ```sh
+      PROTON_LOG=1 %command%
+      ```
+      Isto criará um ficheiro de log no seu diretório pessoal chamado `steam-[AppID].log` (por exemplo, Counter Strike 2 usa AppID **730**, pelo que o ficheiro seria `steam-730.log`).
 </Steps>
 
 <details>
-<summary>Diretório de Log Personalizado</summary>
+  <summary>Diretório de Log Personalizado</summary>
 
-Para definir um diretório de log personalizado, utilize `PROTON_LOG_DIR`:
+  Para definir um diretório de log personalizado, use `PROTON_LOG_DIR`:
 
-```bash title='Example'
-PROTON_LOG=1 PROTON_LOG_DIR=/home/cachyos/steam-logs %command%
-```
+  ```sh title='Example'
+  PROTON_LOG=1 PROTON_LOG_DIR=/home/cachyos/steam-logs %command%
+  ```
 </details>
 
-### Pré-compilação de Shaders com Proton-CachyOS, -GE e -EM
+### Pré-cache de Shaders com Proton-CachyOS, -GE, e -EM
 
 :::note
-É aconselhável desativar a funcionalidade de pré-compilação de shaders da Steam ao utilizar o Proton-CachyOS, Proton-GE ou Proton-EM. Estes já contêm todos os codecs necessários para reproduzir vídeos dentro dos jogos e, hoje em dia, um combo GPU-CPU relativamente moderno deve ser mais do que capaz de lidar com a compilação de shaders durante o jogo.
+É aconselhado desativar a funcionalidade de pré-cache de shaders da Steam ao utilizar Proton-CachyOS, Proton-GE, ou Proton-EM. Eles já contêm todos os codecs necessários para reproduzir vídeos dentro dos jogos, e hoje em dia, um combo GPU-CPU relativamente moderno deve ser mais do que capaz de lidar com compilar shaders em jogo.
 
-Se, no entanto, tiver tempo de sobra, pode ignorar esta dica e deixar a Steam pré-compilar alguns shaders para o seu jogo.
+Se tiver tempo sobrando, então pode ignorar esta dica e deixar a Steam pré-compilar alguns shaders para o seu jogo.
 
-**Tenha em mente que nem tudo é guardado em cache durante este processo, e atualizações na versão do Proton utilizada para compilar os shaders podem exigir uma recompilação total.**
+**Tenha em mente que nem tudo é cacheado durante este processo, e atualizações à versão do Proton usada para compilar os shaders podem exigir recompilação completa de shaders.**
 :::
 
 #### Para desativar esta funcionalidade na Steam
 
-Na Steam, clique em `Steam` -> `Definições`, vá a `Downloads` e desmarque estas opções:
-- **Permitir o processamento em segundo plano de shaders Vulkan**
-- **Ativar Pré-compilação de Shaders**
+Na Steam, clique em `Steam`->`Settings`, vá a `Downloads`, e desmarque estas definições:
+- **Allow background processing of Vulkan shaders**
+- **Enable Shader Pre-caching**
 
 :::note
-É altamente recomendado [aumentar o tamanho máximo da cache de shaders](#increase-maximum-shader-cache-size) após desativar a pré-compilação de shaders na Steam.
+É altamente recomendado [aumentar o tamanho máximo do cache de shaders](#aumentar-tamanho-máximo-do-cache-de-shaders) após desativar o pré-cache de shaders na Steam.
 :::
 
-### Reutilizar uma Partição de Jogos Windows em NTFS
+### Reutilizar uma Partição de Jogos Windows NTFS
 
 :::caution
-Evite utilizar o Proton em unidades NTFS. A Valve não suporta esta configuração, o que pode causar comportamentos imprevisíveis nos jogos.
+Evite usar Proton em unidades NTFS. A Valve não suporta esta configuração, e pode causar jogos a comportarem-se de forma imprevisível.
 
-Se desejar prosseguir, siga o **[guia não oficial](https://github.com/ValveSoftware/Proton/wiki/Using-a-NTFS-disk-with-Linux-and-Windows)** deles.
+Se estiver disposto a prosseguir. Siga o seu **[guia não oficial](https://github.com/ValveSoftware/Proton/wiki/Using-a-NTFS-disk-with-Linux-and-Windows)**.
 :::
+
+### Iniciar sessão no gamescope
+
+A Sessão Gamescope inicia o seu desktop dentro do gamescope, fornecendo um ambiente de jogo em ecrã inteiro dedicado com manuseamento de ecrã melhorado, gestão de entrada e otimizações de desempenho.
+
+É ideal para sistemas focados em jogos ou dispositivos portáteis, oferecendo uma experiência semelhante a uma consola enquanto ainda permite acesso à sua sessão de desktop quando necessário.
+
+Para o usar instale o pacote `gamescope-session-cachyos` (`pacman -S gamescope-session-cachyos`) e defina a sessão padrão para gamescope.
 
 ## [Lutris](https://lutris.net/)
 
-O Lutris é um gestor de jogos no CachyOS. Com o Lutris, pode gerir facilmente os seus "runners" de jogos, incluindo Wine, Proton e emuladores.
+O Lutris é um launcher de jogos no CachyOS. Com o Lutris, pode gerir facilmente os seus runners de jogos, incluindo Wine, Proton, e emuladores.
 
-- Inicie jogos através do Lutris simplesmente clicando no botão **Jogar**.
-- Adicione qualquer jogo que desejar clicando no **+** no canto superior esquerdo.
-- Configure uma loja nas "Fontes" (Sources) no painel esquerdo e ligue a sua conta. O Lutris procederá à instalação da referida loja e, a partir daí, poderá correr jogos dentro da loja, tal como faz no Windows.
+- Inicie jogos através do Lutris simplesmente clicando no botão **Play**.
+- Adicione qualquer jogo que quiser clicando no **+** no canto superior esquerdo.
+- Configure uma loja nas Sources no painel esquerdo e conecte a sua conta. Irá então proceder a instalar a dita loja, e então poderá executar jogos de dentro da loja, tal como faz no Windows.
 - E muito mais!
 
 *Lojas de jogos suportadas no Lutris:*
@@ -483,21 +472,24 @@ O Lutris é um gestor de jogos no CachyOS. Com o Lutris, pode gerir facilmente o
 - [Steam](https://lutris.net/games/steam/)
 - [Ubisoft Connect](https://lutris.net/games/ubisoft-connect/)
 
-### Como configurar corretamente múltiplas opções de inicialização e variáveis de ambiente no Lutris
+### Como Definir Corretamente Múltiplas Opções de Inicialização e Variáveis de Ambiente no Lutris
 
-- Opções de inicialização como `-dx11` ou `-fullscreen` devem ser adicionadas no campo **Arguments** (Argumentos) no separador **Game options**, utilizando um espaço como separador.
-- Wrappers de comando, por exemplo `mangohud --dlsym` ou `game-performance`, devem ser adicionados no campo **Command prefix** no separador **System options**, utilizando um espaço como separador.
-- Variáveis de ambiente como `PROTON_ENABLE_HDR=1` devem ser adicionadas na tabela **Environment variables** no separador **System options**, utilizando o botão `+` para adicionar uma nova entrada.
-
+- Opções de inicialização como `-dx11` ou `-fullscreen` devem ser adicionadas no campo **Arguments** sob o separador **Game options** usando um espaço como separador.
+- Wrappers de comando, por exemplo `mangohud --dlsym` ou `game-performance`, devem ser adicionados no campo **Command prefix** sob o separador **System options** usando um espaço como separador.
+- Variáveis de ambiente como `DXVK_HDR=1` devem ser adicionadas na tabela **Environment variables** sob o separador **System options** usando o botão `+` para adicionar uma nova entrada.
 :::note
-Não inclua o símbolo `=` no campo "Key". Este deve conter apenas o nome da variável.
+Não inclua `=` no campo Key. Este deve conter apenas o nome da variável.
 :::
+
+### Como Gerar Corretamente Logs no Lutris
+- Defina Output debugging info para `Inherit from environment`.
+- Em Environment variables adicione `PROTON_LOG` com o valor `1`.
 
 ## Desempenho e Dicas Diversas
 
-### Não combine o gamemode e o ananicy-cpp
+### Não Combine gamemode e ananicy-cpp
 
-Como tanto o `gamemode` quanto o `ananicy-cpp` tentam modificar a prioridade (niceness) de um processo ao mesmo tempo, isso pode levar a conflitos e comportamentos inesperados. Recomenda-se utilizar o gamemode sem o ananicy-cpp.
+Devido ao `gamemode` e ao `ananicy-cpp` ambos tentarem modificar a niceness de um processo ao mesmo tempo, pode levar a conflitos e comportamento inesperado. Se quiser usar gamemode, é recomendado desativar ou parar o ananicy-cpp primeiro.
 
 Para parar o ananicy-cpp, execute o seguinte comando:
 
@@ -508,186 +500,183 @@ systemctl stop ananicy-cpp
 ### Alternância de Perfil de Energia On-Demand
 
 :::note
-Este comportamento difere ligeiramente com o `intel_pstate`. Em sistemas Intel, o "governor" mantém-se em "powersave", mas os valores EPP/EPB são ajustados para "performance".
+Este comportamento difere ligeiramente com `intel_pstate`. Em Intel, o governor mantém-se em powersave, mas os valores EPP/EPB são ajustados para performance.
 :::
 
-:::caution
-O `game-performance` pode não fornecer qualquer benefício em CPUs antigos.
+:::caution[game-performance pode não fornecer qualquer benefício em CPUs antigos.]
 :::
 
-O CachyOS inclui um script "wrapper" chamado [game-performance](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/game-performance), que utiliza o `power-profiles-daemon` para alternar temporariamente o perfil de energia para `performance`.
-Este perfil aumenta os níveis de energia do sistema, define o "governor" do CPU para `performance` e também altera qualquer agendador (scheduler) scx ativo para o seu perfil de jogo (se disponível).
+O CachyOS inclui um script wrapper [game-performance](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/game-performance)
+que usa `power-profiles-daemon` para alternar temporariamente o perfil de energia para `performance`.
+O perfil aumenta os níveis de energia do sistema e define o CPU governor para `performance`, e também altera qualquer scheduler scx ativo para o seu perfil de jogo (se disponível).
 
-Quando utilizado para iniciar um jogo, o sistema permanece em **modo de desempenho** até que o jogo seja encerrado, momento em que o perfil anterior é restaurado.
+Quando usado para iniciar um jogo, o sistema permanece em **modo de desempenho** até o jogo sair, momento em que o perfil anterior é restaurado.
 
-O [Feral's GameMode](https://github.com/FeralInteractive/gamemode) oferece uma funcionalidade semelhante.
+O [Feral's GameMode](https://github.com/FeralInteractive/gamemode)
+oferece funcionalidade semelhante.
 
-### Como adicionar o game-performance à Steam, Lutris e Heroic Games Launcher
+### Como Adicionar game-performance à Steam, Lutris, e Heroic Games Launcher
 
 <Tabs>
 
-<TabItem label='Steam'>
+  <TabItem label='Steam'>
 
-<Steps>
-1. Abra a sua `Biblioteca Steam`.
-2. Clique com o botão direito no título do jogo e selecione `Propriedades`.
-3. No separador `Geral`, encontrará a secção `Opções de Inicialização`.
-4. Adicione a seguinte opção de inicialização:
-    ```sh
-    game-performance %command%
-    ```
-</Steps>
+    <Steps>
+        1. Abra a sua `Steam Library`.
+        2. Clique com o botão direito no título do jogo e selecione `Properties`.
+        3. No separador `General` encontrará a secção `Launch Options`.
+        4. Adicione a seguinte opção de inicialização:
+            ```sh
+            game-performance %command%
+            ```
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Heroic Games Launcher'>
+  <TabItem label='Heroic Games Launcher'>
 
-<Steps>
-1. No painel esquerdo, abra as `Definições` (Settings).
-2. Vá a `Game defaults` e depois clique em `Advanced`.
-3. Na secção do comando `wrapper`, adicione a seguinte linha sem qualquer argumento:
-   ```sh
-   game-performance
-   ```
-4. Clique no sinal `+` para guardar as alterações.
-</Steps>
+    <Steps>
+        1. No painel esquerdo abra `Settings`.
+        2. Vá a `Game defaults` depois clique em `Advanced`.
+        3. Na secção `wrapper` command. Adicione a seguinte linha sem qualquer argumento:
+            ```sh
+            game-performance
+            ```
+        4. Clique no sinal `+` para guardar alterações.
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Lutris'>
+  <TabItem label='Lutris'>
 
-<Steps>
-1. No canto superior direito, abra o `menu hambúrguer`.
-2. Vá a `Preferences/Global options`.
-3. Ative o `Advanced Mode` no canto superior direito.
-4. Desça até `Command prefix` e adicione a seguinte linha:
-   ```sh
-   game-performance
-   ```
-5. Guarde as alterações.
+    <Steps>
+      1. No canto superior direito abra o `hamburger menu`.
+      2. Vá a `Preferences/Global options`.
+      3. Ative `Advanced Mode` no canto superior direito.
+      4. Desça até `Command prefix` e adicione a seguinte linha:
+          ```sh
+          game-performance
+          ```
+      5. Guarde alterações.
+    </Steps>
 
-</Steps>
-
-</TabItem>
+  </TabItem>
 
 </Tabs>
 
-### Aumentar o tamanho máximo da cache de shaders
+### Aumentar Tamanho Máximo do Cache de Shaders
 
-Os shaders dos jogos são compilados automaticamente enquanto joga, o que pode causar tempos de carregamento longos e "stuttering" na primeira vez que os encontra. Estes shaders são armazenados no seu sistema para serem reutilizados quando necessário.
+Shaders de jogos são compilados automaticamente enquanto joga, o que pode causar tempos de carregamento longos e stuttering na primeira vez que os encontra. Estes shaders são armazenados no seu sistema para serem reutilizados quando necessário.
 
-No entanto, existe um limite máximo para o tamanho do ficheiro da cache de shaders, fazendo com que os shaders antigos sejam descartados ao exceder o tamanho predefinido. Isto pode ser um problema, já que jogos grandes podem ter shaders com mais de 1GB, forçando a recompilação a cada inicialização.
+No entanto, existe um limite máximo para o tamanho do ficheiro do cache de shaders, fazendo com que shaders antigos sejam esquecidos ao exceder o tamanho padrão. Isto pode ser um problema já que jogos grandes podem ter shaders com mais de 1GB, fazendo-os recompilar shaders a cada lançamento.
 
-Para evitar tempos de carregamento longos e problemas de fluidez, podemos aumentar o tamanho global da cache de shaders:
+Para evitar tempos de carregamento longos e stuttering, podemos aumentar o tamanho global do cache de shaders:
 
 <Steps>
 
-1. Abra um terminal.
-2. Crie um diretório `environment.d` na sua pasta de configuração, caso ainda não exista:
-	```sh
-	mkdir -p ~/.config/environment.d
-    ```
-3. Crie um novo ficheiro de configuração:
-    ```sh
-    touch ~/.config/environment.d/gaming.conf
-    ```
-4. Abra o ficheiro com o **Micro** (um editor de texto).
-    ```sh
-    micro ~/.config/environment.d/gaming.conf
-    ```
-    E cole o seguinte, dependendo do fabricante do seu GPU:
-    <details>
+  1. Abra um terminal.
+  2. Crie um diretório `environment.d` na sua pasta de configuração se não existir:
+      ```sh
+      mkdir -p ~/.config/environment.d
+      ```
+  3. Crie um novo ficheiro de configuração:
+      ```sh
+      touch ~/.config/environment.d/gaming.conf
+      ```
+  4. Abra o ficheiro com **Micro** (um editor de texto).
+      ```sh
+      micro ~/.config/environment.d/gaming.conf
+      ```
+      E cole o seguinte dependendo do seu fornecedor de GPU:
+      <details>
         <summary>AMD</summary>
-            ```sh
-            # Força a implementação Vulkan RADV
-            AMD_VULKAN_ICD=RADV
-
-            # Aumenta o tamanho da cache de shaders da AMD para 12GB
-            MESA_SHADER_CACHE_MAX_SIZE=12G
-            ```
-   </details>
-   <details>
-       <summary>NVIDIA</summary>
-           ```sh
-           # Aumenta o tamanho da cache de shaders da Nvidia para 12GB
-           __GL_SHADER_DISK_CACHE_SIZE=12000000000
-           ```
-   </details>
-5. Guarde o ficheiro pressionando `CTRL+S` e depois `CTRL+Q` para sair do Micro. Reinicie o seu sistema.
+        ```sh
+        # Increase AMD's shader cache size to 12GB
+        MESA_SHADER_CACHE_MAX_SIZE=12G
+        ```
+      </details>
+      <details>
+        <summary>NVIDIA</summary>
+        ```sh
+        # Increase Nvidia's shader cache size to 12GB
+        __GL_SHADER_DISK_CACHE_SIZE=12000000000
+        ```
+      </details>
+  5. Guarde o ficheiro pressionando `CTRL+S` e `CTRL+Q` para sair do Micro. Reinicie o seu sistema.
 
 </Steps>
 
-Após reiniciar, o tamanho máximo da cache de shaders deverá estar permanentemente aumentado. Agradecimentos ao [shader-booster do psygreg](https://github.com/psygreg/shader-booster/) por ajudar neste guia.
+Após reiniciar, o tamanho máximo do cache de shaders deve ser permanentemente aumentado. Obrigado ao [shader booster do psygreg](https://github.com/psygreg/shader-booster/) por ajudar este guia.
 
-### Forçar o Preset de DLSS mais recente
+### Forçar o Preset de DLSS Mais Recente
 
-#### Como adicionar o dlss-swapper à Steam, Lutris e Heroic Games Launcher
+#### Como adicionar dlss-swapper à Steam, Lutris, e Heroic Games Launcher
 
 <Tabs>
 
-<TabItem label='Steam'>
+  <TabItem label='Steam'>
 
-<Steps>
-1. Abra a sua `Biblioteca Steam`.
-2. Clique com o botão direito no título do jogo e selecione `Propriedades`.
-3. No separador `Geral`, encontrará a secção `Opções de Inicialização`.
-4. Adicione a seguinte Opção de Inicialização:
-    ```sh
-    dlss-swapper %command%
-    ```
-</Steps>
+    <Steps>
+      1. Abra a sua `Steam Library`.
+      2. Clique com o botão direito no título do jogo e selecione `Properties`.
+      3. No separador `General` encontrará a secção `Launch Options`.
+      4. Adicione a seguinte Launch Option:
+          ```sh
+          dlss-swapper %command%
+          ```
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Heroic Games Launcher'>
+  <TabItem label='Heroic Games Launcher'>
 
-<Steps>
-1. No painel esquerdo, abra as `Definições` (Settings).
-2. Vá a `Game defaults` e depois clique em `Advanced`.
-3. Na secção do comando `wrapper`, adicione a seguinte linha sem qualquer argumento:
-   ```sh
-   dlss-swapper
-   ```
-4. Clique no sinal `+` para guardar as alterações.
-</Steps>
+    <Steps>
+      1. No painel esquerdo abra `Settings`.
+      2. Vá a `Game defaults` depois clique em `Advanced`.
+      3. Na secção `wrapper` command. Adicione a seguinte linha sem qualquer argumento:
+          ```sh
+          dlss-swapper
+          ```
+      4. Clique no sinal `+` para guardar alterações.
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
-<TabItem label='Lutris'>
+  <TabItem label='Lutris'>
 
-<Steps>
-1. No canto superior direito, abra o `menu hambúrguer`.
-2. Vá a `Preferences/Global options`.
-3. Ative o `Advanced Mode` no canto superior direito.
-4. Desça até `Command prefix` e adicione a seguinte linha:
-   ```sh
-   dlss-swapper
-   ```
-5. Guarde as alterações.
-</Steps>
+    <Steps>
+      1. No canto superior direito abra o `hamburger menu`.
+      2. Vá a `Preferences/Global options`.
+      3. Ative `Advanced Mode` no canto superior direito.
+      4. Desça até `Command prefix` e adicione a seguinte linha:
+          ```sh
+          dlss-swapper
+          ```
+      5. Guarde alterações.
+    </Steps>
 
-</TabItem>
+  </TabItem>
 
 </Tabs>
 
 <details>
-<summary>Método de Substituição Manual de DLL</summary>
+  <summary>Método de Substituição Manual de DLL</summary>
 
-Se o `dlss-swapper` não estiver a funcionar ou estiver a causar problemas, tente atualizar a implementação de DLSS do jogo manualmente, substituindo o ficheiro `nvngx_dlss.dll` por uma versão atualizada e utilizando o script wrapper `dlss-swapper-dll` em vez do anterior.
+  Se `dlss-swapper` não estiver a funcionar ou estiver a causar problemas, tente atualizar a implementação DLSS do jogo manualmente substituindo `nvngx_dlss.dll` por uma versão atualizada e usando o script wrapper `dlss-swapper-dll` em vez disso.
 </details>
 
 ### Suporte a Ray Tracing
-A Arch Wiki já fornece instruções abrangentes sobre como ativar o [ray tracing](https://wiki.archlinux.org/title/Hardware_raytracing) para várias plataformas de hardware.
+A Arch Wiki já fornece instruções abrangentes sobre como ativar [ray tracing](https://wiki.archlinux.org/title/Hardware_raytracing) para várias plataformas de hardware.
 - [Ray tracing na Nvidia](https://wiki.archlinux.org/title/Hardware_raytracing#NVIDIA)
 - [Ray tracing na AMD](https://wiki.archlinux.org/title/Hardware_raytracing#AMD)
 - [Ray tracing na Intel](https://wiki.archlinux.org/title/Hardware_raytracing#Intel)
 
 ### Queda de Desempenho na Nvidia em Jogos DirectX12
 
-Alguns utilizadores relatam que o problema está relacionado com a forma como os controladores de Linux da Nvidia gerem o agendamento (scheduling) do GPU — ao contrário do Windows, onde o agendamento adequado é imposto. Ainda não houve qualquer declaração oficial da Nvidia sobre este assunto. Atualmente, não existe nenhuma solução alternativa conhecida para este problema. Supostamente, a Nvidia está a trabalhar numa correção, mas não é claro quando será lançada.
+Alguns utilizadores relatam que o problema está relacionado com como os controladores Linux da Nvidia lidam com o scheduling do GPU — ao contrário do Windows, onde o scheduling adequado é imposto. Ainda não houve nenhum comunicado oficial da Nvidia sobre este assunto. Atualmente não existe contorno conhecido para este problema. Supostamente a Nvidia está a trabalhar numa correção, mas não está claro quando será lançada.
 
-**Isto não tem qualquer relação com o CachyOS.**
+**Isto não tem nada a ver com o CachyOS.**
 
-Em alguns títulos, a queda de desempenho é menos percetível do que em outros. Consulte este [vídeo de comparação de benchmark](https://www.youtube.com/watch?v=SU2mFqCOh5A) para referência.
+Em alguns títulos, a queda de desempenho é menos notável do que em outros. Consulte este [vídeo de comparação de benchmark](https://www.youtube.com/watch?v=SU2mFqCOh5A) para referência.
 
-Acompanhe o [tópico oficial da Nvidia](https://forums.developer.nvidia.com/t/directx12-performance-is-terrible-on-linux/303207/488) para saber mais sobre este problema.
+Siga o [fórum da Nvidia](https://forums.developer.nvidia.com/t/directx12-performance-is-terrible-on-linux/303207/488) para saber mais sobre este problema.

--- a/src/content/docs/pt/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/pt/configuration/general_system_tweaks.mdx
@@ -4,6 +4,7 @@ description: Coisas que pode ajustar após a instalação
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
@@ -235,8 +236,43 @@ FAQ:
   - Não. O limitador interno do jogo (in-game cap) deverá funcionar corretamente.
 - O Smooth Motion pode ser combinado com o DLSS Frame Generation?
   - Não. Apenas um método de geração de frames pode estar ativo de cada vez.
+- O Smooth Motion pode ser utilizado com aplicações OpenGL?
+  - Não diretamente, uma vez que é implementado como uma camada Vulkan, mas é possível utilizando o [Zink](https://docs.mesa3d.org/drivers/zink.html) para traduzir chamadas OpenGL para Vulkan:
+    ```text
+    NVPRESENT_ENABLE_SMOOTH_MOTION=1 zink-run <command>
+    ```
+    :::note
+    Utilizar o Zink provavelmente terá um impacto no desempenho e pode introduzir falhas gráficas em alguns jogos.
+
+    Utilizadores de Dual GPU precisam de definir `DRI_PRIME=1` para utilizar a dGPU Nvidia em vez de métodos mais típicos de seleção de GPU.
+    :::
 
 ## Ajustes de Poupança de Energia
+
+### thermald
+
+O `thermald` é um daemon de gestão térmica para sistemas Intel. Monitoriza sensores térmicos e aplica ações de arrefecimento, como limites de energia da CPU ou alterações de estado de desempenho, antes que o firmware precise de utilizar throttling mais agressivo.
+
+É principalmente útil em computadores portáteis Intel, conversíveis, tablets, dispositivos portáteis (handhelds) e PCs de formato reduzido que expõem controlos térmicos Intel através de `/sys/class/thermal`. Sistemas suportados utilizam frequentemente sensores de temperatura de CPU Intel, Intel P-state, Intel power clamp, RAPL, `INT340X` ou tabelas térmicas ACPI DPTF/adaptive. CPUs AMD não são suportadas pelo `thermald`.
+
+Instale e ative com:
+
+```sh
+sudo pacman -S thermald
+sudo systemctl enable --now thermald.service
+```
+
+Verifique se foi iniciado corretamente:
+
+```sh
+systemctl status thermald.service
+journalctl -u thermald.service -b
+```
+
+Para mais informações:
+
+<LinkButton icon="external" href="https://github.com/intel/thermal_daemon">Repositório upstream do thermald</LinkButton>
+<LinkButton icon="external" href="https://man.archlinux.org/man/thermald.8">Página de manual do thermald</LinkButton>
 
 ### Ativar RCU Lazy
 
@@ -244,25 +280,12 @@ O RCU Lazy ajuda a reduzir o consumo de energia em sistemas em repouso (idle) ou
 A melhoria situa-se entre 5-10% em termos de poupança de energia. No entanto, é importante notar que esta funcionalidade de poupança de energia pode vir acompanhada de uma ligeira redução no desempenho, dependendo do cenário.
 O kernel `linux-cachyos-deckify` terá esta opção ativada por defeito, uma vez que a poupança de energia é fundamental e necessária para estes dispositivos.
 
-Para ativar o RCU Lazy, adicione o seguinte parâmetro à sua lista de parâmetros da [linha de comandos do kernel (cmdline)](/configuration/boot_manager_configuration/):
+Para ativar o RCU Lazy, adicione o seguinte parâmetro à sua lista de parâmetros da [linha de comandos do kernel (cmdline)](/pt/configuration/boot_manager_configuration/):
 ```text
 rcutree.enable_rcu_lazy=1
 ```
 
 ## Resolução de Problemas NVIDIA
-
-### Desativar o Backend Wayland do SDDM
-
-:::note
-A partir do cachyos-kde-settings 4.3, o SDDM utiliza o KWin como o seu compositor Wayland por defeito.
-:::
-
-Embora este seja um passo em frente positivo, pode introduzir alguns inconvenientes, como quebrar o suporte para overclocking através do nvidia-settings ou causar incompatibilidade com GPUs mais antigos que tenham dificuldades sob Wayland.
-
-Para reverter esta alteração, remova o pacote cachyos-kde-settings:
-```sh
-sudo pacman -R cachyos-kde-settings
-```
 
 ### Firmware NVIDIA GSP
 
@@ -362,7 +385,7 @@ Como alternativa, pode tentar utilizar o [JDSP4Linux](https://github.com/Audio4L
 
 Disponibilizamos no nosso repositório um pacote `obs-studio-browser` personalizado que é recomendado em vez do pacote `obs-studio` padrão. Este contém correções (patches) para resolver alguns dos problemas comuns, como erros de CUDA e problemas com a câmara virtual.
 
-```sh title='Open a terminal and run the following command'
+```sh title='Abra um terminal e execute o seguinte comando'
 sudo pacman -S obs-studio-browser
 # Se já tinha o obs-studio instalado anteriormente, o pacman irá perguntar-lhe se
 # deseja substituí-lo; se for o caso, introduza "Y" (Sim).
@@ -379,7 +402,7 @@ Este guia assume que tem a configuração padrão do CachyOS com ZRam ativado e 
 :::
 
 <Steps>
-    1. Desative o ZRam adicionando um parâmetro ao kernel. [Edite a configuração do seu gestor de arranque](/configuration/boot_manager_configuration) e adicione a seguinte linha:
+    1. Desative o ZRam adicionando um parâmetro ao kernel. [Edite a configuração do seu gestor de arranque](/pt/configuration/boot_manager_configuration) e adicione a seguinte linha:
         ```text
         systemd.zram=0
         ```

--- a/src/content/docs/pt/configuration/post_install_setup.mdx
+++ b/src/content/docs/pt/configuration/post_install_setup.mdx
@@ -4,19 +4,81 @@ description: Passos para configurar após a instalação do CachyOS
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
+import ImageComponent from '~/components/image-component.astro';
 
 ## Passos Recomendados Após a Instalação
 
 ### Atualizar o Sistema
 
 :::tip
-Certifique-se de consultar as nossas [Práticas Recomendadas e de Segurança](/cachyos_basic/faq#security--best-practices) para evitar erros comuns e manter o seu sistema seguro.
+Certifique-se de consultar as nossas [Práticas Recomendadas e de Segurança](/pt/cachyos_basic/faq#security--best-practices) para evitar erros comuns e manter o seu sistema seguro.
 :::
 
 <Tabs>
+
+<TabItem label="Shelly (GUI & CLI)">
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/overview/">Wiki do Shelly</LinkButton>
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/docs/cli-reference/">CLI do Shelly</LinkButton>
+
+    O [Shelly](https://github.com/Seafoam-Labs/Shelly-ALPM) é uma reimaginação moderna do gestor de pacotes do Arch Linux, concebido para ser uma alternativa mais intuitiva e amigável ao pacman e ao octopi.
+
+    Desenvolvido por: [Seafoam-Labs](https://github.com/Seafoam-Labs)
+
+    Permitindo aos utilizadores gerir os seus pacotes sem necessidade de utilizar o terminal.
+
+    Algumas das funcionalidades do Shelly incluem:
+
+    Instalar/desinstalar pacotes do AUR, repositórios oficiais, AppImages, Flatpaks e pacotes locais, ver detalhes dos pacotes, gerir grupos de pacotes e muito mais.
+
+    Porquê escolher o Shelly em vez do Octopi?
+    - Tem uma interface mais moderna e amigável.
+    - Desenvolvimento e atualizações contínuas com novas funcionalidades e melhorias.
+    - Suporta mais formatos de pacotes (AUR, AppImages, Flatpaks, etc.)
+    - Funcionalidades de segurança como verificação de PKGBUILDs, consulte as [Verificações de Segurança](https://www.seafoam-labs.org/shelly-alpm/docs/security/) para mais informações.
+
+    <details>
+        <summary>Captura de ecrã da página inicial do Shelly</summary>
+        <ImageComponent imgsrc={import('~/assets/images/shelly-homepage.png')} />
+    </details>
+    <details>
+        <summary>Separador de Gestão de Pacotes</summary>
+        <ImageComponent imgsrc={import('~/assets/images/shelly-package-management.png')} />
+    </details>
+    Aqui estão alguns comandos úteis para começar com a CLI do Shelly:
+
+    <details>
+    <summary>Atualizar todos os pacotes (AUR, repositórios oficiais, Flatpak, etc.):</summary>
+    ```sh
+    shelly
+    ```
+    </details>
+    <details>
+    <summary>Atualizar pacotes padrão (derivados Arch) + instalar pacote:</summary>
+    ```sh
+    shelly install --upgrade {pkg}
+    # Exemplo:
+    shelly install --upgrade discord
+    ```
+    </details>
+    <details>
+    <summary>Remover pacote e dependências:</summary>
+    ```sh
+    shelly remove {pkg}
+    # Exemplo:
+    shelly remove discord
+    ```
+    </details>
+    <details>
+    <summary>Pesquisar pacote no AUR:</summary>
+    ```sh
+    shelly aur search {pkg}
+    ```
+    </details>
+</TabItem>
 
 <TabItem label="Usar o Octopi (Interface Gráfica)">
 
@@ -77,7 +139,7 @@ O ficheiro `/etc/pacman.d/offline.conf` é crucial para gerir quais os pacotes q
    :::note[Adicione a linha após a secção [options]. Consulte o exemplo abaixo como referência.]
    :::
 
-   ```bash title='Add the following line to the /etc/pacman.conf file'
+   ```bash title='Adicione a seguinte linha ao ficheiro /etc/pacman.conf'
    Include = /etc/pacman.d/offline.conf
    ```
    *Exemplo*
@@ -138,7 +200,7 @@ O ficheiro `/etc/pacman.d/offline.conf` é crucial para gerir quais os pacotes q
 
 3. **Inicie a preparação para a atualização offline apenas uma vez**
 
-   ```bash title='Run the following command'
+   ```bash title='Execute o seguinte comando'
    sudo systemctl start pacman-offline-prepare.service
    ```
    Este comando fará com que o pacman-offline seja executado uma vez e sincronize as bases de dados dos pacotes, procedendo ao descarregamento das atualizações sem as instalar.
@@ -184,7 +246,25 @@ Fork do [Arch-Update](https://github.com/Antiz96/arch-update)
 Um notificador e aplicador de atualizações para Arch Linux que o auxilia com tarefas importantes de pré e pós-atualização.
 Inclui uma applet de systray dinâmica e clicável para uma integração fácil com qualquer Ambiente de Trabalho / Gestor de Janelas.
 
-Ative o Cachy-Update no CachyOS Hello > Apps/Tweaks > Cachy Update enabled
+<details>
+    <summary>Como ativar o Cachy-Update</summary>
+    Ative o Cachy-Update em `CachyOS Hello > Apps/Tweaks > Cachy Update enabled`
+</details>
+<details>
+    <summary>Como desativar o Cachy-Update</summary>
+        Desative o Cachy-Update em `CachyOS Hello > Apps/Tweaks > Cachy Update disabled`
+            :::tip
+            Se pretende manter o Cachy-Update e apenas desativar a applet de systray, abra um terminal e execute os seguintes comandos:
+            ```bash
+            mkdir -p ~/.config/autostart
+            echo -e "[Desktop Entry]\nHidden=true" > ~/.config/autostart/arch-update-tray.desktop"
+            ```
+            Se pretende manter a applet de systray ativada e simplesmente desativar a verificação automática de atualizações, execute o seguinte comando:
+            ```bash
+            sudo systemctl --global disable --now arch-update.timer
+            ```
+            :::
+</details>
 
 - Funcionalidades:
   - Verificação e listagem automática de atualizações disponíveis.
@@ -195,7 +275,7 @@ Ative o Cachy-Update no CachyOS Hello > Apps/Tweaks > Cachy Update enabled
   - Verificação de serviços que exijam reinício pós-atualização (e oferta para o fazer, se existirem).
   - Suporte para `sudo`, `sudo-rs`, `doas` e `run0`.
 
-**Intervalo de verificação de atualizações:** `Uma vez 15 segundos após o arranque e depois a cada hora.`
+**Intervalo de verificação de atualizações:** `Uma vez dois minutos após o arranque e depois uma vez por dia com um atraso aleatório de uma hora.`
 
 - Como alterar o intervalo de verificação de atualizações:
 
@@ -204,13 +284,16 @@ systemctl --user edit --full arch-update.timer
 # Dica: Também pode usar qualquer editor de texto à sua escolha em vez do `nano`
 # ex: EDITOR=micro systemctl --user edit --full arch-update.timer
 ```
-Conteúdo predefinido do ficheiro:
-```systemd
-[Timer]
-OnStartupSec=15 # Verificar atualizações 15 segundos após o arranque
-OnUnitActiveSec=1h # Verificar atualizações a cada hora
-```
 
+<details>
+<summary>Conteúdo predefinido do ficheiro:</summary>
+    ```systemd
+    [Timer]
+    OnStartupSec=2min # Verificar atualizações dois minutos após o arranque
+    RandomizedDelaySec=1h # Atraso aleatório de uma hora
+    OnUnitActiveSec=1d # Verificar atualizações uma vez por dia
+    ```
+</details>
 Basicamente, pode alterar o valor de `OnUnitActiveSec` para o que desejar. Por exemplo, se quiser verificar se há atualizações a cada 30 minutos, mude para `30m`. Ou a cada 6 horas, mude para `6h`. Consulte este [documento](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans) para mais detalhes sobre como configurar o intervalo de tempo.
 
 Caso pretenda que o Cachy-Update verifique se existem novas atualizações apenas uma vez ao iniciar, pode simplesmente apagar a linha `OnUnitActiveSec` por completo.
@@ -250,17 +333,27 @@ sudo ufw disable
 Por predefinição, o ufw ignora o tráfego de entrada e permite o tráfego de saída; pode adicionar regras específicas à firewall para bloquear ou permitir ligações específicas.
 
 ```bash
-# Por exemplo:
+# Exemplo 1, permitir tráfego ssh:
 sudo ufw allow ssh
+# Exemplo 2, abrir a porta 12345 para tráfego TCP & UDP:
+sudo ufw allow 12345
+
+# O texto ou número da porta pode ser ajustado conforme necessário, como 12345/udp para permitir apenas tráfego UDP ou substituindo ssh pelo nome de um programa
 ```
 
 </TabItem>
 
 <TabItem label="Recusar">
 
+Por predefinição, o ufw ignora o tráfego de entrada e permite o tráfego de saída; pode adicionar regras específicas à firewall para bloquear ou permitir ligações específicas.
+
 ```bash
-# Para recusar uma porta específica, consulte o seguinte exemplo:
-sudo ufw deny 80
+# Exemplo 1, recusar tráfego ssh:
+sudo ufw deny ssh
+# Exemplo 2, fechar a porta 12345 para tráfego TCP & UDP:
+sudo ufw deny 12345
+
+# O texto ou número da porta pode ser ajustado conforme necessário, como 12345/udp para recusar apenas tráfego UDP ou substituindo ssh pelo nome de um programa
 ```
 
 </TabItem>
@@ -270,7 +363,15 @@ sudo ufw deny 80
 ```bash
 sudo ufw status verbose
 ```
-
+:::tip
+Se não quer esquecer porquê abriu/fechou uma porta, adicione um comentário à regra.
+```bash
+# Exemplo 1, abrir a porta 12345 para tráfego TCP & UDP com um comentário:
+sudo ufw allow 12345 comment 'Exemplo'
+# Exemplo 2, fechar a porta 6789 para TCP com um comentário:
+sudo ufw deny 6789/tcp comment 'Comentários podem ter espaços'
+```
+:::
 </TabItem>
 
 </Tabs>
@@ -283,6 +384,10 @@ Tenha cuidado ao configurar as regras da firewall, pois regras mal configuradas 
 Também pode configurar graficamente através da secção "Firewall" nas definições do KDE Plasma.
 :::
 
+:::note
+As alterações em permitir/recusar entram em efeito após o ufw ter sido reiniciado. Desative e depois ative o ufw novamente para resultado imediato.
+:::
+
 ### Ativar o Menu Global
 Para algumas aplicações como o Visual Studio Code, o menu global pode não funcionar ou pode ficar anexado à aplicação principal em vez de aparecer no painel.
 
@@ -290,6 +395,7 @@ Para algumas aplicações como o Visual Studio Code, o menu global pode não fun
 # Para ativar o suporte ao menu global, execute o comando e reinicie a aplicação.
 sudo pacman -S appmenu-gtk-module libdbusmenu-glib
 ```
+
 ## Configurações Opcionais
 
 ### Alterar a Shell Predefinida
@@ -312,7 +418,7 @@ Atualmente, o CachyOS utiliza a [fish](https://fishshell.com/) como a shell de i
 
       Disponibilizamos uma [configuração zsh](https://github.com/CachyOS/cachyos-zsh-config) com plugins e configurações comummente utilizados. O objetivo é ter uma funcionalidade 1:1 com a nossa [configuração fish](https://github.com/CachyOS/cachyos-fish-config). Esta é também a shell predefinida utilizada no MacOS.
 
-      ```sh title='Changing the default shell to zsh'
+      ```sh title='Alterar a shell predefinida para zsh'
       chsh -s /usr/bin/zsh
       ```
 
@@ -348,7 +454,7 @@ Esta ferramenta é extremamente útil para quem não quer ler muito ou perder te
 
 Appimages são aplicações portáteis que correm na maioria das distribuições Linux sem necessidade de instalação ou permissões de root.
 
-:::note[Nota: Todas as AppImages requerem permissões de execução para correr.]
+:::note[Todas as AppImages requerem permissões de execução para correr.]
 Pode definir a permissão de execução utilizando o seguinte comando:
 ```sh
 chmod +x /path/to/your/appimage
@@ -356,29 +462,29 @@ chmod +x /path/to/your/appimage
 Ou clique com o botão direito no ficheiro AppImage, vá a `Propriedades` > `Permissões` e marque a caixa que diz `Permitir executar o ficheiro como um programa.`
 :::
 
-:::note[Nota: Antes de executar AppImages, certifique-se de que o FUSE (Filesystem in Userspace) está instalado no seu sistema.]
+:::note[Antes de executar Appimages, certifique-se de que o FUSE (Filesystem in Userspace) está instalado no seu sistema.]
 ```sh
 sudo pacman -S fuse2
 ```
 :::
 
-Para gerir AppImages, podes utilizar o [gearlever](https://github.com/mijorus/gearlever), que oferece uma forma simples de integrar AppImages no teu sistema.
+Para gerir Appimages, pode utilizar o [gearlever](https://github.com/mijorus/gearlever), que oferece uma forma simples de integrar Appimages no seu sistema.
 
-O `gearlever` é uma ferramenta gráfica que simplifica a gestão de AppImages no teu sistema. Integra-se com o teu ambiente de trabalho, facilitando a execução e gestão de AppImages.
+O `gearlever` é uma ferramenta gráfica que simplifica a gestão de Appimages no seu sistema. Integra-se com o seu ambiente de trabalho, facilitando a execução e gestão de Appimages.
 
-Para instalar o gearlever, segue estes passos:
+Para instalar o gearlever, siga estes passos:
 
 <Steps>
-    1. Instala o flatpak, caso ainda não o tenhas feito:
+    1. Instale o flatpak, caso ainda não o tenha feito:
         ```sh
         sudo pacman -S flatpak
         ```
-	2. Reinicia o teu sistema.
-    3. Instala o gearlever via flatpak:
+    2. Reinicie o seu sistema.
+    3. Instale o gearlever via flatpak:
         ```sh
         flatpak install flathub it.mijorus.gearlever
         ```
-	4. Após a instalação, encerra a sessão e volta a entrar para veres o gearlever no teu menu de aplicações.
+    4. Após a instalação, encerre a sessão e volte a entrar para ver o gearlever no seu menu de aplicações.
 </Steps>
 
 ### Configurar o Acesso a Partilhas Samba
@@ -389,7 +495,7 @@ O Samba é uma implementação de software livre do protocolo de rede SMB. Para 
 
 Para utilizar o prático ficheiro `smb.conf`, instale primeiro o pacote específico que fornece o ficheiro necessário. Em seguida, substitua o `smb.conf` existente no seu servidor por este ficheiro e reconfigure os seus volumes partilhados.
 
-:::note[Nota: Este guia assume que já possui um servidor Samba funcional]
+:::note[Este guia assume que já possui um servidor Samba funcional]
 :::
 
 <Steps>
@@ -404,7 +510,7 @@ Para utilizar o prático ficheiro `smb.conf`, instale primeiro o pacote específ
         ```sh
         sudo systemctl restart --now samba
         ```
-6. Na máquina cliente, aceda aos seus recursos partilhados através do seu gestor de ficheiros (ex: `smb://<ip_do_seu_servidor>/<nome_da_partilha>`).
+    6. Na máquina cliente, aceda aos seus recursos partilhados através do seu gestor de ficheiros (ex: `smb://<ip_do_seu_servidor>/<nome_da_partilha>`).
 
         Se estiver configurado corretamente, ser-lhe-ão pedidas as credenciais de acesso. Lembre-se de selecionar a opção para guardar as suas informações de início de sessão, se assim o desejar.
 </Steps>
@@ -415,42 +521,42 @@ Citação da Wikipédia:
 
 *AppArmor ("Application Armor") é um módulo de segurança do kernel Linux que permite ao administrador do sistema restringir as capacidades dos programas através de perfis individuais. Os perfis podem permitir capacidades como acesso à rede, acesso a raw sockets e permissão para ler, escrever ou executar ficheiros em caminhos correspondentes.*
 
-Isto é apenas uma introdução sobre como instalar uma configuração básica do AppArmor, caso não estejas familiarizado com o mesmo. Por favor, não avances sem compreender as implicações.
+Isto é apenas uma introdução sobre como instalar uma configuração básica do AppArmor, caso não esteja familiarizado com o mesmo. Por favor, não avance sem compreender as implicações.
 
-Para informações mais detalhadas sobre o AppArmor.d e como criar os teus próprios perfis, consulta a [documentação do AppArmor.d](https://github.com/roddhjav/apparmor.d?tab=readme-ov-file#configuration).
+Para informações mais detalhadas sobre o AppArmor.d e como criar os seus próprios perfis, consulte a [documentação do AppArmor.d](https://github.com/roddhjav/apparmor.d?tab=readme-ov-file#configuration).
 
-:::caution[Procede com cautela. Uma configuração deficiente do AppArmor pode causar problemas.]
+:::caution[Proceda com cautela. Uma configuração deficiente do AppArmor pode causar problemas.]
 :::
 
 <Steps>
 
-1. Adiciona os seguintes parâmetros de kernel ao teu Gestor de Arranque; consulta a [Configuração do Gestor de Arranque](/configuration/boot_manager_configuration) para referência:
+1. Adicione os seguintes parâmetros de kernel ao seu Gestor de Arranque; consulte a [Configuração do Gestor de Arranque](/pt/configuration/boot_manager_configuration) para referência:
 
    ```text
    lsm=landlock,lockdown,yama,integrity,apparmor,bpf
    ```
 
-2. Instala o apparmor e os pacotes apparmord **(conjunto de mais de 1500 perfis)**:
+2. Instale o apparmor e os pacotes apparmord **(conjunto de mais de 1500 perfis)**:
 
    ```bash
    sudo pacman -S apparmor apparmor.d
    ```
 
-3. Ativa/Inicia o serviço AppArmor:
+3. Ative/Inicie o serviço AppArmor:
 
    ```bash
    systemctl enable --now apparmor.service
    ```
 
-4. Ativa o caching (armazenamento em cache) para os perfis AppArmor:
+4. Ative o caching (armazenamento em cache) para os perfis AppArmor:
 
    ```shell
    # /etc/apparmor/parser.conf
-   ## Adiciona as seguintes linhas:
+   ## Adicione as seguintes linhas:
    write-cache
    Optimize=compress-fast
    cache-loc /etc/apparmor/earlypolicy/
    ```
-   Guarda o ficheiro e reinicia o sistema.
+   Guarde o ficheiro e reinicie o sistema.
 
 </Steps>

--- a/src/content/docs/pt/configuration/sched-ext.mdx
+++ b/src/content/docs/pt/configuration/sched-ext.mdx
@@ -4,13 +4,19 @@ description: Tutorial sobre como usar a framework e informações diversas
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 5
+ai_translated: true
 ---
 
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Icon } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem, Icon } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
 A Extensible Scheduler Class (mais conhecida como `sched-ext`) é uma funcionalidade do kernel Linux que permite a implementação de escalonadores de threads do kernel em BPF (Berkeley Package Filter) e o seu carregamento dinâmico. Essencialmente, isto permite que os utilizadores finais alterem os seus escalonadores em userspace sem a necessidade de compilar outro kernel apenas para ter um escalonador diferente.
+
+:::note
+O uso de qualquer um dos escalonadores sched-ext irá desligar temporariamente o escalonador padrão do kernel. Quando um escalonador sched-ext é parado, o escalonador padrão do kernel retomará o controlo novamente.
+
+Exemplo: EEVDF ou BORE.
+:::
 
 :::tip[Entre em contacto com os desenvolvedores no seu [servidor de Discord](https://discord.gg/b2J8DrWa7t)]
 :::
@@ -47,9 +53,9 @@ Sem `sudo`, o scxctl/scx_loader solicitará autenticação através de um agente
   sudo scx_rusty
   ```
 
-*Isto irá iniciar o escalonador rusty e desativar o escalonador predefinido.*
+*Isto irá iniciar o escalonador rusty e desativar o escalonador padrão.*
 
-Para parar o escalonador. Prima `CTRL + C` e o escalonador será então interrompido e o escalonador predefinido do kernel assumirá o controlo novamente.
+Para parar o escalonador, prima `CTRL + C` e o escalonador será então interrompido e o escalonador padrão do kernel assumirá o controlo novamente.
 
 </TabItem>
 
@@ -83,8 +89,8 @@ O `scxctl` é um cliente CLI DBUS para interagir com o `scx_loader`.
           scxctl stop
           ```
     </TabItem>
-    <TabItem label='Restaurar o escalonador predefinido'>
-          ```sh title='Restaura o escalonador predefinido definido no ficheiro de configuração do scx_loader'
+    <TabItem label='Restaurar o escalonador padrão'>
+          ```sh title='Restaura o escalonador padrão definido no ficheiro de configuração do scx_loader'
           scxctl restore
           ```
     </TabItem>
@@ -117,7 +123,7 @@ Comandos:
   switch   Alternar entre escalonadores ou modos, opcionalmente com argumentos
   stop     Parar o escalonador atual
   restart  Reiniciar o escalonador atual com a configuração original
-  restore  Restaurar o escalonador predefinido a partir da configuração
+  restore  Restaurar o escalonador padrão a partir da configuração
   help     Imprimir esta mensagem ou a ajuda do(s) subcomando(s) indicado(s)
 
 Opções:
@@ -135,12 +141,12 @@ Consulte a seguinte **[página da Arch Wiki para referência.](https://wiki.arch
 
 *Como o nome indica, é um utilitário que funciona como um carregador e gestor para a framework sched-ext utilizando a interface D-Bus.*
 
-*Embora não requeira o systemd, este pode ainda assim ser utilizado em conjunto com ele.* [Consulte o guia de transição para referência](/configuration/sched-ext#transitioning-from-scxservice-to-scx_loader-a-comprehensive-guide).
+*Embora não requeira o systemd, este pode ainda assim ser utilizado em conjunto com ele.* [Consulte o guia de transição para referência](/pt/configuration/sched-ext#transitioning-from-scxservice-to-scx_loader-a-comprehensive-guide).
 
 - Tem a capacidade de parar, iniciar, reiniciar, ler informações sobre um escalonador scx e muito mais.
   - *Pode utilizar ferramentas como o `dbus-send` ou o `gdbus` para comunicar com ele.*
 - Este guia explica como utilizar o scx_loader com o comando dbus-send.
-  - ```sh title='Iniciar o scx_rusty com os seus argumentos predefinidos'
+  - ```sh title='Iniciar o scx_rusty com os seus argumentos padrão'
     dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.StartScheduler string:scx_rusty uint32:0
     ```
   - ```sh title='Iniciar um escalonador com argumentos'
@@ -150,8 +156,8 @@ Consulte a seguinte **[página da Arch Wiki para referência.](https://wiki.arch
   - ```sh title='Parar o escalonador atualmente em execução'
     dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.StopScheduler
     ```
-  - ```sh title='Alternar para o escalonador predefinido'
-    # O scx_loader irá alternar para o escalonador predefinido definido no ficheiro de configuração do scx_loader
+  - ```sh title='Alternar para o escalonador padrão'
+    # O scx_loader irá alternar para o escalonador padrão definido no ficheiro de configuração do scx_loader
     dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.RestoreDefault
     ```
   - ```sh title='Alternar para outro escalonador no Modo 2'
@@ -170,11 +176,11 @@ Consulte a seguinte **[página da Arch Wiki para referência.](https://wiki.arch
 :::tip
 Aqui está uma explicação do que cada modo significa no scx_loader:
 
-- Modo 0 = `Flags predefinidas do escalonador`
-- Modo 1 = `Gaming (Jogos)`
-- Modo 2 = `Power Saving (Poupança de Energia)`
-- Modo 3 = `Low Latency (Baixa Latência)`
-- Modo 4 = `Server (Servidor)`
+- Modo 0 = `Flags padrão do escalonador`
+- Modo 1 = `Gaming`
+- Modo 2 = `Power Saving`
+- Modo 3 = `Low Latency`
+- Modo 4 = `Server`
 
 Exemplo: O LAVD a correr no Modo 1 é o equivalente a `scx_lavd --performance`
 
@@ -201,11 +207,11 @@ Pode aceder e configurá-los através do botão `sched-ext scheduler config`.
 Consulte a seguinte **[página da Arch Wiki para referência.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
 :::
 
-O SCX Manager é uma ferramenta GUI (interface gráfica) independente derivada do CachyOS Kernel Manager. Permite aos utilizadores gerir a framework sched-ext e os seus escalonadores através do `scx_loader`.
+O SCX Manager é uma ferramenta GUI independente derivada do CachyOS Kernel Manager. Permite aos utilizadores gerir a framework sched-ext e os seus escalonadores através do `scx_loader`.
 
 Funcionalidades:
 - Verificar qual o escalonador atualmente ativo
-- Selecionar um escalonador ou perfil: (Auto, Gaming, Poupança de energia, Baixa Latência ou Servidor)
+- Selecionar um escalonador ou perfil: (Auto, Gaming, Power save, Low Latency ou Server)
 - Definir flags adicionais
 - Desativar o escalonador atual
 
@@ -238,7 +244,7 @@ scx_rusty --help
 
 ### [scx_beerland](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_beerland)
 
-**Desenvolvido por: Andrea Righi (arighi [GitHub](https://github.com/arighi))**
+**Desenvolvido por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
 
 Pronto para Produção? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
 
@@ -246,27 +252,28 @@ O scx_beerland é um escalonador desenhado para priorizar a localidade e a escal
 
 Prioriza manter as tarefas no mesmo CPU para preservar a localidade da cache, garantindo ao mesmo tempo uma boa escalabilidade em sistemas com muitos CPUs através do uso de DSQs locais (filas de execução por CPU) quando o sistema não está saturado.
 
-- **Casos de uso:**
+- Casos de uso:
   - Cargas de trabalho intensivas em cache
   - Sistemas com um grande número de CPUs
-  - Gaming: Conhecido por funcionar surpreendentemente bem em certos jogos, embora os resultados possam variar
+  - Gaming: Funciona surpreendentemente bem em certos jogos, embora os resultados possam variar.
   - Servidor: Bom para cargas gerais devido às otimizações de escalabilidade e localidade.
-  - Também pode ser usado para uso diário em desktop.
+  - Também pode ser usado para uso em desktop.
 
 #### Modos do Escalonador
+
 Nenhum de momento.
 
-### [scx_bpfland](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_bpfland)
+### [scx_bpfland](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_bpfland>)
 
-**Desenvolvido por: Andrea Righi (arighi [GitHub](https://github.com/arighi))**
+**Desenvolvido por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
 
 Pronto para Produção? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
 
-Um escalonador sched_ext baseado em `vruntime` que prioriza cargas de trabalho interativas. Altamente flexível e fácil de adaptar.
+Um escalonador sched_ext baseado em vruntime que prioriza cargas de trabalho interativas. Altamente flexível e fácil de adaptar.
 
-Ao decidir quais núcleos usar, o **Bpfland** leva em consideração o layout da cache e quais núcleos partilham a mesma cache L2/L3, resultando em menos falhas de cache (*cache misses*) e, consequentemente, mais desempenho.
+Ao decidir quais núcleos usar, o Bpfland leva em consideração o layout da cache e quais núcleos partilham a mesma cache L2/L3, resultando em menos falhas de cache (*cache misses*) = mais desempenho.
 
-- **Casos de uso:**
+- Casos de uso:
   - Gaming
   - Uso de desktop
   - Produção multimédia/áudio
@@ -276,15 +283,18 @@ Ao decidir quais núcleos usar, o **Bpfland** leva em consideração o layout da
 
 #### Modos do Escalonador
 
-##### Baixa Latência (Low Latency)
+##### Baixa Latência
+
 * **Flags de Linha de Comando:** `-m performance -w`
 * **Descrição:** Destinado a reduzir a latência à custa do rendimento (*throughput*). Adequado para aplicações de tempo real suave (*soft real-time*), como processamento de áudio e multimédia.
 
-##### Poupança de Energia (Power Save)
+##### Poupança de Energia
+
 * **Flags de Linha de Comando:** `-s 20000 -m powersave -I 100 -t 100`
 * **Descrição:** Prioriza a eficiência energética. Favorece núcleos menos potentes (ex: E-cores em Intel).
 
-##### Servidor (Server)
+##### Servidor
+
 * **Flags de Linha de Comando:** `-s 20000 -S`
 * **Descrição:** Prioriza tarefas com afinidade estrita. Esta opção pode aumentar o rendimento à custa da latência, sendo mais adequada para cargas de trabalho de servidor.
 
@@ -319,8 +329,9 @@ O `scx_cake` classifica cada tarefa num de quatro níveis com base no seu runtim
 | **T2** | Frame      | < 8ms       | Threads de renderização de jogos, codificação de vídeo    | 4.0ms   | 40ms                 |
 | **T3** | Bulk       | ≥ 8ms       | Compilação, indexação em fundo, trabalhos em lote        | 8.0ms   | 100ms                |
 
-> [!TIP]
-> **Nenhuma tarefa de jogo deve estar em T3**. As threads de renderização de jogos correm 2-8ms por frame → T2. Física/IA correm 0.5-2ms → T1. Handlers de input correm < 100µs → T0. Apenas tarefas a realizar 8ms+ de trabalho contínuo de CPU (compilação de shaders, ecrãs de carregamento) vão para T3.
+:::tip
+**Nenhuma tarefa de jogo deve estar em T3**. As threads de renderização de jogos correm 2-8ms por frame → T2. Física/IA correm 0.5-2ms → T1. Handlers de input correm < 100µs → T0. Apenas tarefas a realizar 8ms+ de trabalho contínuo de CPU (compilação de shaders, ecrãs de carregamento) vão para T3.
+:::
 
 ##### Como funciona a Classificação
 
@@ -353,15 +364,15 @@ Em CPUs híbridos Intel (`has_hybrid = true`), os alvos são ajustados pela `cpu
 
 | Perfil      | Quantum | Inanição | Caso de Uso                                            |
 | :---------- | :------ | :------- | :------------------------------------                  |
-| **gaming**  | 2ms     | 100ms    | **(Predefinido)** Equilibrado para a maioria dos jogos |
+| **gaming**  | 2ms     | 100ms    | **(Padrão)** Equilibrado para a maioria dos jogos |
 | **esports** | 1ms     | 50ms     | FPS competitivo, latência ultra-baixa                  |
 | **legacy**  | 4ms     | 200ms    | CPUs antigos, poupança de bateria                      |
 | **default** | 2ms     | 100ms    | Alias para gaming                                      |
 
 #### Argumentos CLI
 
-| Argumento                 | Predef.  | Descrição                             |
-| :------------------------ | :------- | :------------------------------------ |
+| Argumento                 | Padrão  | Descrição                             |
+| :------------------------ | :------ | :------------------------------------ |
 | `--profile, -p <PERFIL>`  | `gaming` | Selecionar perfil predefinido         |
 | `--quantum <µs>`          | perfil   | Fatia de tempo base em microssegundos |
 | `--new-flow-bonus <µs>`   | perfil   | Défice extra para tarefas recém-acordadas |
@@ -380,218 +391,362 @@ Em CPUs híbridos Intel (`has_hybrid = true`), os alvos são ajustados pela `cpu
 
 ### [scx_cosmos](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_cosmos)
 
-**Desenvolvido por: Andrea Righi (arighi [GitHub](https://github.com/arighi))**
+**Desenvolvido por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
 
-Pronto para Produção? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
+- Pronto para Produção? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
 
 Escalonador leve otimizado para preservar a localidade tarefa-para-CPU.
 
-Quando o sistema não está saturado, o escalonador prioriza manter as tarefas no mesmo CPU. Isto reduz a contenção de bloqueios (*locking*) em comparação com filas partilhadas, permitindo uma escalabilidade excelente em muitos CPUs.
+Quando o sistema não está saturado, o escalonador prioriza manter as tarefas no mesmo CPU usando DSQs locais. Isto não só mantém a localidade como também reduz a contenção de bloqueios em comparação com DSQs partilhados, permitindo uma boa escalabilidade em muitos CPUs.
 
-- **Casos de uso:**
-  - Escalonador de propósito geral: adapta-se tanto a cargas de servidor como de desktop.
+- Casos de uso:
+  - Escalonador de propósito geral: o escalonador deve adaptar-se tanto a cargas de servidor como de desktop.
 
 #### Modos do Escalonador
 
 ##### Auto
-* **Flags:** `-s 20000 -d -c 0 -p 0`
-* **Descrição:** Sacrifica a localidade e eficiência para uma distribuição uniforme entre todos os CPUs. Inclina-se para interatividade.
+
+* **Flags de Linha de Comando:** Nenhuma.
+* **Descrição:**
 
 ##### Gaming
-* **Flags:** `-c 0 -p 0`
-* **Descrição:** Desativa a monitorização de carga do CPU e força o escalonamento baseado em prazos (*deadlines*) para melhorar a resposta.
 
-##### Poupança de Energia (Power Save)
-* **Flags:** `-m powersave -d -p 5000`
-* **Descrição:** Favorece a eficiência e núcleos E-cores. Desativa despertares diferidos.
+* **Flags de Linha de Comando:** `-s 700 -S`
+* **Descrição:** Sacrifica o rendimento para melhor consistência no desempenho de Gaming, reduzindo a contenção em núcleos SMT partilhados.
 
-##### Baixa Latência (Low Latency)
-* **Flags:** `-m performance -c 0 -p 0 -w`
-* **Descrição:** Foca na previsibilidade de desempenho através de otimizações de despertar síncrono.
+##### Poupança de Energia
 
-##### Servidor (Server)
-* **Flags:** `-s 20000`
-* **Descrição:** Ativa a afinidade de espaço de endereçamento para melhorar o desempenho em cargas sensíveis à cache.
+* **Flags de Linha de Comando:** `-m powersave`
+* **Descrição:** Prioriza a eficiência energética. Favorece núcleos menos potentes (ex: E-cores em Intel).
 
-### [scx_flash](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_flash)
+##### Baixa Latência
 
-**Desenvolvido por: Andrea Righi (arighi [GitHub](https://github.com/arighi))**
+* **Flags de Linha de Comando:** `-s 700 -S -m performance -w`
+* **Descrição:** Destinado a reduzir a latência à custa do rendimento. Adequado para aplicações de tempo real suave como processamento de áudio e multimédia. Concede uma distribuição de carga mais uniforme entre núcleos disponíveis, sacrificando eficiência.
+
+##### Servidor
+
+* **Flags de Linha de Comando:** `-s 20000 -c 75 -p 250`
+* **Descrição:** Ativa a afinidade de espaço de endereçamento para melhorar a localidade e o desempenho em certas cargas sensíveis à cache. A duração da fatia é definida para 20ms e o polling que monitoriza com que frequência o escalonador compara a utilização da CPU com o limiar de ocupação da CPU para decidir quando o sistema está ocupado.
+
+### [scx_flash](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_flash>)
+
+**Desenvolvido por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
 
 Pronto para Produção? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
 
 Um escalonador que se foca em garantir a justiça (*fairness*) entre tarefas e a previsibilidade de desempenho.
 
-Opera utilizando uma política [Earliest Deadline First (EDF)](https://www.geeksforgeeks.org/operating-systems/earliest-deadline-first-edf-cpu-scheduling-algorithm/), onde a cada tarefa é atribuído um peso de "latência". Este peso é ajustado dinamicamente com base na frequência com que uma tarefa liberta o CPU antes de esgotar a sua fatia de tempo (*time slice*).
+Opera utilizando uma política [earliest deadline first (EDF)](https://www.geeksforgeeks.org/operating-systems/earliest-deadline-first-edf-cpu-scheduling-algorithm/), onde a cada tarefa é atribuído um peso de "latência". Este peso é ajustado dinamicamente com base na frequência com que uma tarefa liberta o CPU antes de esgotar a sua fatia de tempo completa.
 
-Tarefas que libertam o CPU cedo recebem um peso de latência maior, sendo priorizadas sobre tarefas que consomem totalmente o seu tempo de execução.
+Tarefas que libertam o CPU cedo recebem um peso de latência maior, sendo priorizadas sobre tarefas que consomem totalmente a sua fatia de tempo.
 
-- **Casos de uso:**
+- Casos de uso:
   - Gaming
-  - Cargas sensíveis à latência (multimédia ou áudio em tempo real)
+  - Cargas sensíveis à latência como multimédia ou processamento de áudio em tempo real
   - Necessidade de responsividade em situações de sobrecarga
   - Consistência de desempenho
   - Servidor
 
 #### Modos do Escalonador
 
-##### Baixa Latência (Low Latency)
-* **Flags:** `-m performance -w -C 0`
-* **Descrição:** Reduz a latência à custa do rendimento. Ideal para áudio e multimédia.
+##### Baixa Latência
+
+* **Flags de Linha de Comando:** `-m performance -w -C 0`
+* **Descrição:** Destinado a reduzir a latência à custa do rendimento. Adequado para aplicações de tempo real suave como processamento de áudio e multimédia.
 
 ##### Gaming
-* **Flags:** `-m all`
+
+* **Flags de Linha de Comando:** `-m all`
 * **Descrição:** Otimiza para alto desempenho em jogos.
 
-##### Poupança de Energia (Power Save)
-* **Flags:** `-m powersave -I 10000 -t 10000 -s 10000 -S 1000`
-* **Descrição:** Prioriza a eficiência. Favorece núcleos menos potentes e introduz um ciclo de repouso forçado a cada 10ms.
+##### Poupança de Energia
 
-##### Servidor (Server)
-* **Flags:** `-m all -s 20000 -S 1000 -I -1 -D -L`
-* **Descrição:** Ajustado para servidores. Troca responsividade por rendimento bruto.
+* **Flags de Linha de Comando:** `-m powersave -I 10000 -t 10000 -s 10000 -S 1000`
+* **Descrição:** Prioriza a eficiência energética. Favorece núcleos menos potentes (ex: E-cores em Intel) e introduz um ciclo de repouso forçado a cada 10ms para aumentar a poupança de energia.
 
-### [scx_lavd](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_lavd)
+##### Servidor
 
-**Desenvolvido por: Changwoo Min (multics69 [GitHub](https://github.com/multics69))**
+* **Flags de Linha de Comando:** `-m all -s 20000 -S 1000 -I -1 -D -L`
+* **Descrição:** Ajustado para cargas de trabalho de servidor. Troca responsividade por rendimento.
+
+### [scx_flow](https://github.com/sched-ext/scx/tree/main/scheds/experimental/scx_flow)
+
+**Desenvolvido por: Galih Tama (galpt [GitHub](https://github.com/galpt))**
 
 Pronto para Produção? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
 
-*LAVD é um novo algoritmo motivado por cargas de gaming, que são críticas em latência e pesadas em comunicação. Visa minimizar picos de latência mantendo um bom rendimento global.*
+O scx_flow é um escalonador baseado em orçamento que classifica tarefas num de quatro níveis FIFO O(1) com base no orçamento que lhes resta. Sem heurísticas, sem algoritmos de pontuação, sem afinação adaptativa — cada decisão vem de um número: *orçamento restante*.
 
-- **Casos de uso:**
-  - Gaming e Produção de Áudio
-  - Cargas sensíveis à latência e uso de desktop
-  - Excelente interatividade sob carga intensa
+- Casos de uso:
+  - Multitarefa geral em desktop e workstation
+  - Gaming com aplicações de fundo abertas
+  - Trabalho de desenvolvimento com compilações, testes ou contentores a correr
+  - Qualquer cenário onde a responsividade interativa sob carga mista importa
+  - Sistemas que necessitam de escalonamento determinístico e explicável (controlo embutido, robótica, aviónica)
 
-Uma das capacidades principais é a **Core Compaction (Compactação de Núcleos):** Quando o uso de CPU é < 50%, os núcleos ativos correm por mais tempo e a maior frequência, enquanto os núcleos inativos permanecem em C-State (Sleep) por mais tempo, poupando energia.
+#### Como funciona — o orçamento
 
-#### Modos do Escalonador
+Pense em cada tarefa como tendo um "orçamento de responsividade". Enquanto uma tarefa está a dormir (à espera de algo para fazer), acumula orçamento. Quando acorda e corre, gasta-o. Tarefas que acordam ainda com orçamento são sinal de interatividade — são despachadas imediatamente para o CPU onde correu pela última vez, contornando o sistema de níveis completamente. Tarefas que esgotam o orçamento são reencaminhadas para um dos quatro níveis FIFO.
+
+##### Os quatro níveis de despacho
+
+Quando uma tarefa é reencaminhada (não um despertar), o seu orçamento restante decide em que nível vai parar:
+
+| Nível | Limiar de Orçamento | Que tipo de tarefas acabam aqui |
+|---|---|---|
+| **Priority** | ≥ 1.5ms | Tarefas interativas que dormem frequentemente e correm brevemente |
+| **Normal** | ≥ 1ms | Tarefas típicas com orçamento decente restante |
+| **Low** | ≥ 0.5ms | Tarefas com pouco orçamento |
+| **Deficit** | < 0.5ms | Workers bulk, consumidores de CPU, trabalhos de fundo |
+
+Cada nível é uma fila FIFO simples — O(1) enqueue, O(1) dequeue. Sem percorrer árvores, sem recalculação de prioridades.
+
+##### Sem inanição, sem inversão de prioridade
+
+A função de despacho não apenas drena Priority primeiro cada vez. Rota o nível inicial em cada chamada — `gen & 3` decide onde começar. Assim, o nível Deficit nunca espera mais de 3 ciclos de despacho antes de ser servido primeiro. Isto significa que workers bulk fazem progresso mesmo sob carga interativa pesada, e não há inversão de prioridade porque nenhum nível único pode monopolizar o CPU.
+
+##### Despertares pulam a fila completamente
+
+Quando uma tarefa acorda (estava a dormir e agora tem algo para fazer), não espera em nenhuma fila de nível. Vai direto para o CPU onde correu pela última vez via `SCX_DSQ_LOCAL_ON` — cache quente e imediato. É isto que mantém as tarefas interativas ágeis: um Discord ou separador do navegador adormecido acorda com orçamento e é despachado em microssegundos, não milissegundos.
+
+##### Tarefas fixas sempre primeiro
+
+Tarefas que não podem migrar entre CPUs (setaffinity) têm a sua própria fila FIFO por CPU que tem prioridade absoluta sobre qualquer nível. São despachadas antes de qualquer coisa do sistema de níveis correr nessa CPU.
+
+##### O resultado
+
+Tarefas interativas (input de teclado, atualizações de UI, threads de áudio, polling de rede) quase sempre acordam com orçamento e têm a via expressa. Trabalho batch pesado em CPU (compilação, downloads, indexação de fundo) drena o orçamento e assenta no nível Deficit, onde ainda faz progresso graças ao despacho rotativo. Sem afinação necessária.
+
+##### Sem perfis, sem autotuning, sem modos
+
+O scx_flow **não** tem modos Gaming, Power Save ou Low Latency — e ao contrário de versões anteriores, também não tem um ciclo de controlo adaptativo. O despacho rotativo de níveis e os limiares de orçamento são constantes em tempo de compilação. O que obtém é o que corre: determinístico, explicável e idêntico em cada sistema. Se uma tarefa tem orçamento, tem prioridade. Se não, partilha o nível Deficit de forma justa. Essa é toda a política.
+
+#### Interface Web (Web UI)
+
+Quando o scx_flow inicia, serve automaticamente um painel de métricas ao vivo em **[http://localhost:50005](http://localhost:50005)**. Abra-o em qualquer navegador — sem flags extras necessárias.
+
+O painel mostra:
+- Quantos despachos passaram por cada nível (Priority / Normal / Low / Deficit)
+- Informações do sistema: tarefas em execução, uptime, contagem total de despachos
+- Uma barra de distribuição de níveis para ver de relance se trabalho interativo ou bulk domina
+- Cada cartão de métrica é clicável — abre um modal histórico com sparklines e um gráfico de barras
+- Todos os valores atualizam a cada segundo via polling — sem necessidade de atualizar a página
+
+Se a página não carregar, o escalonador pode ter parado de correr (o kernel recorre ao EEVDF embutido).
+
+```sh
+# Desativar a interface web se não a precisar:
+sudo scx_flow --no-webui
+```
+
+Quando o `scx_loader` está a correr com endurecimento systemd que restringe famílias de soquetes (`RestrictAddressFamilies`, `SocketBindDeny`), a ligação TCP é bloqueada e o scx_flow recorre a um soquete Unix em `/tmp/scx_flow.sock`. Nesse caso, o navegador não pode alcançar o painel diretamente — execute temporariamente `sudo scx_flow --no-webui` para silenciar erros se não precisar da interface.
+
+#### Argumentos CLI
+
+| Argumento | Descrição |
+|---|---|
+| `--no-webui` | Desativar a interface web embutida |
+| `-d, --debug` | Ativar registo de nível de depuração |
+| `-V, --version` | Imprimir versão do escalonador e sair |
+
+:::note
+O scx_flow **não** tem modos de perfil scx_loader (Gaming, Power Save, Low Latency, Server). Cada decisão de escalonamento é derivada diretamente do orçamento da tarefa — sem perfis necessários.
+:::
+
+### [scx_forge](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_forge>)
+
+**Desenvolvido por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
+
+- Pronto para Produção? <Icon name="close" color="var(--sl-color-text-accent)" size="2rem" />
+
+O scx_forge contém duas partes:
+
+1. Um escalonador base orientado para IA que é desenhado para ser usado em conjunto com a segunda parte.
+2. Um agente destinado a ser usado com o escalonador base para proporcionar uma experiência de escalonamento mais orientada para IA, mais otimização no local pelo próprio agente.
+
+O agente permite definir o seu modelo de IA, a carga de trabalho que quer otimizar e o objetivo geral que quer alcançar. O agente irá então tentar otimizar o escalonador para a sua carga de trabalho e objetivo específicos.
+
+Como? através do [ficheiro spec.toml](https://github.com/sched-ext/scx/blob/main/tools/scx_forge_agent/spec.toml) que é usado para iniciar o ciclo de otimização.
+
+Basicamente, este escalonador é perfeito para quem quer otimizar uma carga de trabalho específica por um agente de IA.
+
+Para saber mais sobre ele, consulte o [README do scx_forge_agent](https://github.com/sched-ext/scx/tree/main/tools/scx_forge_agent).
+
+### [scx_lavd](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_lavd>)
+
+**Desenvolvido por: Changwoo Min (multics69 [GitHub](<https://github.com/multics69>)).**
+
+- Pronto para Produção? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
+
+Breve introdução ao LAVD por Changwoo:
+
+*LAVD é um novo algoritmo de escalonamento que ainda está em desenvolvimento. É motivado por cargas de trabalho de gaming, que são críticas em latência e pesadas em comunicação. Visa minimizar picos de latência mantendo um bom rendimento global e uso justo de tempo de CPU entre tarefas.*
+
+- Casos de uso:
+  - Gaming
+  - Produção de Áudio
+  - Cargas sensíveis à latência
+  - Uso de desktop
+  - Excelente interatividade sob cargas de trabalho intensivas
+  - Poupança de energia
+
+Uma das capacidades principais e impressionantes que o LAVD inclui é a **Core Compaction.** Sem entrar em detalhes técnicos: Quando a utilização de CPU < 50%, os núcleos atualmente ativos correm por mais tempo e a uma frequência mais elevada. Enquanto isso, os núcleos ociosos permanecem em C-State (Sleep) por uma duração muito maior, alcançando menos utilização de energia global.
+
+##### Modos do Escalonador
 
 ##### Gaming & Baixa Latência
-* **Flags:** `--performance`
+
+* **Flags de Linha de Comando:** `--performance`
 * **Descrição:** Maximiza o desempenho usando todos os núcleos disponíveis, priorizando núcleos físicos.
 
-##### Poupança de Energia (Power Save)
-* **Flags:** `--powersave`
-* **Descrição:** Minimiza o consumo mantendo um desempenho razoável. Prioriza núcleos eficientes e threads sobre núcleos físicos.
+##### Poupança de Energia
+
+* **Flags de Linha de Comando:** `--powersave`
+* **Descrição:** Minimiza o consumo de energia mantendo um desempenho razoável. Prioriza núcleos e threads eficientes sobre núcleos físicos.
 
 ### [scx_pandemonium](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_pandemonium)
 
 **Desenvolvido por: Will Clingan (willclngn [GitHub](https://github.com/wllclngn/))**
 
-Um escalonador de classificação comportamental que utiliza pontuação baseada em EWMA (frequência de *wakeup*, taxa de mudança de contexto, variância de tempo de execução) para organizar as tarefas em três níveis de despacho — LAT_CRITICAL, INTERACTIVE e BATCH — cada um com o seu próprio *time slice*, regras de preempção e encaminhamento DSQ. Um mecanismo de resgate de permanência (*sojourn rescue*), inspirado no CoDel, monitoriza os tempos de espera da fila *batch* e resgata tarefas antigas antes que bloqueiem, com limiares que se adaptam à taxa de despacho e ao número de núcleos. A deteção de rajadas dual (detetor de ponto de mudança CUSUM + contador de taxa de *wakeup*) lida com tempestades de *forks*, e um ciclo de controlo adaptativo em Rust ajusta os parâmetros de escalonamento uma vez por segundo, com base na deteção do regime de carga de trabalho e na telemetria de histogramas BPF.
+*Um escalonador de classificação comportamental com colocação consciente da topologia. Pontuação baseada em EWMA (frequência de despertar, taxa de troca de contexto, variância de runtime) classifica tarefas em três níveis — LAT_CRITICAL, INTERACTIVE, BATCH — cada um com a sua própria fatia, regras de preempção e roteamento DSQ. A colocação é conduzida pela resistência efetiva (R_eff) no gráfico de topologia da CPU, derivada de uma pseudo-inversa Laplaciana; DSQs por CPU são roubados em ordem R_eff para manter o trabalho cache-hot cache-hot. Cada constante de temporização — resgate de permanência, alvo CoDel, teto vtime, limiar longrun — deriva de um único valor tau (o recíproco do autovalor de Fiedler), para que o escalonador se auto-calibre de laptops 2C a servidores 32C+ sem afinação. Um oscilador harmónico amortecido adapta o alvo de stalling CoDel da pressão de resgate a cada tick. Um ciclo de controlo adaptativo Rust 1Hz (atualização de pesos multiplicativos sobre seis perfis de especialista) afina parâmetros de escalonamento a partir de telemetria de histograma BPF, sincronizado com o estado do oscilador BPF para evitar correção dupla. Uma base de dados de processos persistente aprende classificações de tarefas entre reinícios. Consciente de NUMA, correto em hotplug.*
 
-Os compositores (KWin, GNOME Shell, Hyprland, Sway, entre outros) são automaticamente promovidos para LAT_CRITICAL. Uma base de dados de processos persistente memoriza as classificações das tarefas entre reinícios.
+- Casos de uso:
+    - Gaming
+    - Uso de desktop
+    - Produção multimédia/áudio
+    - Compilação de código
+    - Cargas ZFS / pesadas em armazenamento
+    - Cargas de trabalho mistas
+    - Interatividade sob saturação sustentada de CPU
 
-* **Casos de uso:**
-    * Jogos
-    * Uso de computador de secretária
-    * Produção multimédia/áudio
-    * Compilação de código
-    * Interatividade sob cargas de trabalho intensivas
-    * Cargas de trabalho mistas
+##### Modos do Escalonador
 
-#### Modos do Escalonador
+Padrão (Adaptativo)
+- **Flags de Linha de Comando:** (nenhuma — corre adaptativo por padrão)
+- **Descrição:** Modo totalmente adaptativo. O ciclo de controlo Rust deteta o regime de carga de trabalho (LIGHT / MIXED / HEAVY) e ajusta parâmetros de escalonamento em tempo real. Melhor para uso geral de desktop e jogos.
 
-##### Predefinido (Adaptativo)
+###### Apenas BPF
+- **Flags de Linha de Comando:** `--no-adaptive`
+- **Descrição:** Desativa o ciclo de controlo adaptativo Rust. O escalonador BPF corre com parâmetros estáticos. Menor overhead, útil para benchmarking ou se a camada adaptativa estiver a corrigir em excesso na sua carga de trabalho.
 
-* **Argumentos da linha de comandos:** *(nenhum — corre em modo adaptativo por defeito)*
-* **Descrição:** Modo totalmente adaptativo. O ciclo de controlo em Rust deteta o regime de carga de trabalho (LIGHT / MIXED / HEAVY) e ajusta os parâmetros de escalonamento em tempo real. Ideal para uso geral em computador e jogos.
+###### Detalhado / Depuração
+- **Flags de Linha de Comando:** `-v` ou `--verbose`
+- **Descrição:** Ativa saída de telemetria detalhada incluindo contagens de despacho por nível, tempos de permanência e estatísticas de classificação comportamental. Útil para diagnosticar comportamento de escalonamento.
 
-##### Apenas BPF
+### [scx_p2dq](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_p2dq>)
 
-* **Argumentos da linha de comandos:** `--no-adaptive`
-* **Descrição:** Desativa o ciclo de controlo adaptativo em Rust. O escalonador BPF funciona com parâmetros estáticos. Menor sobrecarga (*overhead*), útil para *benchmarking* ou caso a camada adaptativa esteja a corrigir excessivamente a sua carga de trabalho.
+- Pronto para Produção? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
+  - Sim. Se ajustado corretamente para a sua carga de trabalho e hardware específicos.
 
-##### Detalhado / Depuração
+**Desenvolvido por: Daniel Hodges (hodgesds [GitHub](<https://github.com/hodgesds>))**
 
-* **Argumentos da linha de comandos:** `-v` ou `--verbose`
-* **Descrição:** Ativa a saída de telemetria detalhada, incluindo contagens de despacho por nível, tempos de permanência e estatísticas de classificação comportamental. Útil para diagnosticar o comportamento do escalonamento.
+Um escalonador de propósito geral que se foca em escolher dois equilíbrios de carga entre LLCs. Mantém alta localidade de cache e conservação de trabalho enquanto fornece latência razoável.
 
-### [scx_p2dq](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_p2dq)
-
-Pronto para Produção? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
-- Sim, se ajustado ao seu hardware e carga de trabalho.
-
-**Desenvolvido por: Daniel Hodges (hodgesds [GitHub](https://github.com/hodgesds))**
-
-Escalonador de propósito geral que se foca no equilíbrio de carga "escolha dois" entre LLCs. Mantém alta localidade de cache enquanto providencia latência razoável.
+- Casos de uso:
+  - Servidor
+  - Ambientes de desktop
+  - Gaming (com alguma afinação manual)
 
 #### Modos do Escalonador
 
 ##### Gaming
-* **Flags:** `--task-slice true -f --sched-mode performance`
-* **Descrição:** Melhora a consistência em jogos e favorece núcleos de alto desempenho.
 
-##### Baixa Latência (Low Latency)
-* **Flags:** `-y -f --task-slice true`
-* **Descrição:** Faz com que tarefas interativas "prendam" mais ao CPU original.
+* **Flags de Linha de Comando:** `--task-slice true -f --sched-mode performance`
+* **Descrição:** Melhora a consistência no desempenho de jogos e aumenta o enviesamento para escalonamento em núcleos de maior desempenho.
 
-##### Poupança de Energia (Power Save)
-* **Flags:** `--sched-mode efficiency`
-* **Descrição:** Prioriza núcleos energeticamente eficientes.
+##### Baixa Latência
 
-##### Servidor (Server)
-* **Flags:** `--keep-running`
-* **Descrição:** Permite que tarefas corram além da sua fatia se o CPU estiver ocioso.
+* **Flags de Linha de Comando:** `-y -f --task-slice true`
+* **Descrição:** Reduz a latência fazendo com que tarefas interativas grudem mais ao CPU a que foram atribuídas e aumentando a estabilidade no tempo de fatia.
 
-### [scx_tickless](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_tickless)
+##### Poupança de Energia
 
-**Desenvolvido por: Andrea Righi (arighi [Github](https://github.com/arighi))**
+* **Flags de Linha de Comando:** `--sched-mode efficiency`
+* **Descrição:** Melhora a eficiência energética priorizando núcleos energeticamente eficientes.
 
-Pronto para Produção? <Icon name="close" color="var(--sl-color-text-accent)" size="2rem" />
-- Este escalonador ainda é experimental e não recomendado para uso em produção.
+##### Servidor
+
+* **Flags de Linha de Comando:** `--keep-running`
+* **Descrição:** Melhora cargas de trabalho de servidor permitindo que tarefas corram além da sua fatia se o CPU estiver ocioso.
+
+### [scx_tickless](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_tickless>)
+
+**Desenvolvido por: Andrea Righi (arighi [Github](<https://github.com/arighi>))**
+
+- Pronto para Produção? <Icon name="close" color="var(--sl-color-text-accent)" size="2rem" />
+  - Este escalonador ainda é experimental e não recomendado para uso em produção.
 
 :::note
-Para desativar eficazmente os "ticks" nos CPUs, o kernel deve ser iniciado com `nohz_full`. Tenha em conta que isto introduz overhead em chamadas de sistema (syscalls).
+Para desativar eficazmente os ticks nos CPUs "tickless", o kernel deve ser iniciado com `nohz_full`. Tenha em conta que `nohz_full` introduz overhead em chamadas de sistema (syscalls), por isso isto pode regressar cargas de trabalho sensíveis à latência.
 :::
 
-Orientado a servidores, cloud e virtualização. Funciona enviando eventos de escalonamento através de um grupo de CPUs primários, permitindo desativar o "tick" nos outros CPUs para reduzir o ruído do SO.
+O scx_tickless é um escalonador orientado a servidores desenhado para computação em cloud, virtualização e cargas de trabalho de computação de alto desempenho.
+
+O escalonador funciona roteando todos os eventos de escalonamento através de um grupo de CPUs primários designados para lidar com esses eventos. Isto permite desativar o tick do escalonador noutros CPUs, reduzindo o ruído do SO.
+
+- Casos de uso:
+  - Computação em cloud
+  - Virtualização
+  - Cargas de trabalho de computação de alto desempenho
+  - Servidor
 
 #### Modos do Escalonador
 
 ##### Gaming
-* **Flags:** `-f 5000 -s 5000`
-* **Descrição:** Aumenta a frequência de deteção de contenção.
 
-##### Poupança de Energia (Power Save)
-* **Flags:** `-f 50`
-* **Descrição:** Reduz as verificações de contenção.
+* **Flags de Linha de Comando:** `-f 5000 -s 5000`
+* **Descrição:** Aumenta o desempenho de jogos aumentando a frequência com que o escalonador deteta contenção de CPU e ativa trocas de contexto com uma fatia de tempo mais curta.
 
-### [scx_rustland](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rustland)
+##### Poupança de Energia
 
-**Desenvolvido por: Andrea Righi (arighi [GitHub](https://github.com/arighi))**
+* **Flags de Linha de Comando:** `-f 50`
+* **Descrição:** Melhora a eficiência energética reduzindo as verificações de contenção.
+
+##### Baixa Latência
+* **Flags de Linha de Comando:** `-f 5000 -s 1000`
+* **Descrição:** Semelhante ao perfil de jogos mas com uma fatia ainda reduzida.
+
+##### Servidor
+
+* **Flags de Linha de Comando:** `-f 100`
+* **Descrição:** Reduz a frequência com que o escalonador verifica contenção de CPU para melhorar o rendimento à custa da responsividade.
+
+### [scx_rustland](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rustland>)
+
+**Desenvolvido por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
 
 Pronto para Produção? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
 
-Para cenários de produção críticos em termos de desempenho, outros escalonadores provavelmente exibirão melhor performance, visto que delegar todas as decisões de escalonamento para o espaço de utilizador (*user-space*) tem um certo custo (mesmo que mínimo).
+Para cenários de produção críticos em termos de desempenho, outros escalonadores provavelmente exibirão melhor desempenho, visto que delegar todas as decisões de escalonamento para o espaço de utilizador (*user-space*) tem um certo custo (mesmo que mínimo).
 
-No entanto, um escalonador totalmente implementado no espaço de utilizador permite uma integração fluida com bibliotecas sofisticadas, ferramentas de rastreio, serviços externos (ex: IA), etc.
+No entanto, um escalonador totalmente implementado no espaço de utilizador tem o potencial de integração perfeita com bibliotecas sofisticadas, ferramentas de rastreio, serviços externos (ex: IA), etc.
 
-Por isso, podem existir situações onde os benefícios superam o *overhead*, justificando o seu uso em produção.
+Assim, podem existir situações onde os benefícios superam o overhead, justificando o uso deste escalonador num ambiente de produção.
 
-- Partilha semelhanças com o bpfland.
-- Criado para ser fácil de ler e compreender devido à implementação em *userspace*.
-- **Nota:** Existe uma ligeira desvantagem no rendimento ao usar um escalonador em *userspace*.
+Partilha semelhanças com bpfland, feito com a intenção de ser fácil de ler e compreender como funciona devido à sua implementação em userspace.
 
-- **Casos de uso:**
+Tenha em conta que há uma ligeira desvantagem de rendimento ao usar um escalonador userspace.
+
+- Casos de uso:
   - Cargas de trabalho de baixa latência (Gaming, videoconferências e live streaming)
   - Uso de desktop
 
-### [scx_rusty](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rusty)
+### [scx_rusty](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rusty>)
 
-**Desenvolvido por: David Vernet (Byte-Lab [GitHub](https://github.com/Byte-Lab))**
+**Desenvolvido por: David Vernet (Byte-Lab [GitHub](<https://github.com/Byte-Lab>))**
 
-Pronto para Produção? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
-- Sim, se for ajustado corretamente.
+- Pronto para Produção? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
+  - Sim. Se ajustado corretamente,
 
-O Rusty oferece uma vasta gama de funcionalidades e uma grande capacidade de ajuste (*tunability*), permitindo personalizar o escalonador para requisitos muito específicos.
+O Rusty oferece uma vasta gama de funcionalidades que melhoram as suas capacidades, proporcionando maior flexibilidade para vários casos de uso.
+Uma destas funcionalidades é a capacidade de afinação, permitindo personalizar o Rusty para se adequar às suas preferências e requisitos específicos.
 
-- Casos de utilização:
-  - Gaming / Jogos
-  - Cargas de trabalho sensíveis à latência
-  - Utilização em desktop
-  - Produção multimédia/áudio
+- Casos de uso:
+  - Gaming
+  - Cargas sensíveis à latência
+  - Uso de desktop
+  - Produção Multimédia/Áudio
   - Excelente interatividade sob cargas de trabalho intensivas
   - Poupança de energia
 
@@ -600,8 +755,9 @@ O Rusty oferece uma vasta gama de funcionalidades e uma grande capacidade de aju
 ### LAVD Autopilot & Autopower
 
 *Citações de Changwoo Min:*
-- No modo **Autopilot**, o escalonador ajusta o seu modo (Powersave, Balanced ou Performance) com base na carga do sistema (utilização de CPU).
-- **Autopower:** Decide automaticamente o modo com base no perfil de energia do sistema (EPP - Energy Performance Preference).
+- No modo autopilot, o escalonador ajusta o seu modo de energia `Powersave, Balanced, ou Performance` com base na carga do sistema, especificamente na utilização da CPU.
+
+- Autopower: Decide automaticamente o modo de energia do escalonador com base no perfil de energia do sistema, conhecido como EPP (Energy Performance Preference).
 
 ```sh
 # O Autopower pode ser ativado pela seguinte flag:
@@ -613,7 +769,7 @@ scx_lavd --autopower
 ### ananicy-cpp & sched-ext
 
 :::note[Atualização sobre ananicy-cpp e sched-ext]
-Após o desenvolvimento adicional dos escalonadores, o uso do ananicy-cpp em conjunto com os mesmos é, geralmente, seguro. No entanto, se experienciar quaisquer bloqueios ou instabilidade, considere desativá-lo como um passo de resolução de problemas.
+Após desenvolvimento adicional dos escalonadores, o ananicy-cpp geralmente pode ser usado juntamente com eles. No entanto, se experienciar quaisquer bloqueios ou instabilidade, considere desativá-lo como um passo de resolução de problemas.
 :::
 
 Para desativar/parar o ananicy-cpp, execute o seguinte comando:
@@ -622,63 +778,62 @@ Para desativar/parar o ananicy-cpp, execute o seguinte comando:
 systemctl disable --now ananicy-cpp
 ```
 
-### Mudança de Perfil de Energia no scx_loader
+### Alternância de Perfil de Energia no scx_loader
 
-Implementado no pacote `power-profiles-daemon` fornecido pelo CachyOS, que inclui um [patch personalizado](https://github.com/CachyOS/CachyOS-PKGBUILDS/blob/master/power-profiles-daemon/0001-Add-support-for-scx_loader-modes-switching.patch) para suportar a mudança de perfis de energia do `scx_loader`.
+Implementado no pacote `power-profiles-daemon` fornecido pelo CachyOS, que inclui um [patch personalizado](https://github.com/CachyOS/CachyOS-PKGBUILDS/blob/master/power-profiles-daemon/0001-Add-support-for-scx_loader-modes-switching.patch) para suportar a alternância de perfis de energia do `scx_loader`.
 
-- Se o `scx_loader` estiver a ser executado, quando o [game-performance](/configuration/gaming#power-profile-switching-on-demand) for utilizado, ele alternará automaticamente o escalonador ativo para o perfil `Gaming` ao iniciar um jogo, e voltará ao perfil predefinido quando o jogo for fechado.
-- Ao alternar entre perfis de energia (ex: no KDE Plasma ou GNOME utilizando o seletor de perfil de energia), o `scx_loader` mudará automaticamente para o perfil de escalonador correspondente:
+- Se o `scx_loader` estiver atualmente em execução, quando o [game-performance](/pt/configuration/gaming#power-profile-switching-on-demand) for usado, ele alternará automaticamente o escalonador ativo para o perfil `Gaming` quando um jogo for lançado, e voltará ao perfil padrão quando o jogo for fechado.
+- Ao alterar entre perfis de energia, ex: no KDE Plasma ou GNOME usando o alternador de perfil de energia, o `scx_loader` alternará automaticamente para o perfil de escalonador correspondente:
 
-| Perfil de Energia   | Perfil do Escalonador |
-| ------------------- | --------------------- |
-| Power Saver         | Power Save            |
-| Balanced            | Auto                  |
-| Performance         | Gaming                |
+| Perfil de Energia       | Perfil do Escalonador  |
+| ----------------------- | ---------------------- |
+| Power Saver             | Power Save             |
+| Balanced                | Auto                   |
+| Performance             | Gaming                 |
 
 ### Benchmarking e comparação de escalonadores com cachyos-benchmarker
 
-A ferramenta [cachyos-benchmarker](https://github.com/CachyOS/cachyos-benchmarker) oferece uma forma fácil de avaliar e comparar o desempenho de diferentes escalonadores de CPU.
+A ferramenta [cachyos-benchmarker](https://github.com/CachyOS/cachyos-benchmarker) fornece uma forma fácil de avaliar e comparar o desempenho de diferentes escalonadores de CPU.
 
-Esta ferramenta executa um conjunto abrangente de testes para medir o CPU, a memória e o desempenho geral do sistema sob várias cargas de trabalho.
+Executa um conjunto abrangente de benchmarks para medir o desempenho de CPU, memória e do sistema geral sob várias cargas de trabalho.
 
-Estão incluídos os seguintes benchmarks:
+Os seguintes benchmarks estão incluídos:
 
-| Teste                       | Mede                                     | Ferramenta   |
-| --------------------------- | ---------------------------------------- | ------------ |
-| **stress-ng cpu-cache-mem** | Desempenho de CPU, cache e memória       | `stress-ng`  |
-| **FFmpeg compilation**      | Desempenho de compilação paralela        | `make`       |
-| **x265 encoding**           | Rendimento de codificação de vídeo       | `x265`       |
-| **argon2 hashing**          | Hashing de passwords multithreaded       | `argon2`     |
-| **perf sched msg**          | Troca de contexto e desempenho de IPC    | `perf`       |
-| **perf memcpy**             | Rendimento de memória `memcpy()`         | `perf`       |
-| **prime calculation**       | Aritmética de inteiros e paralelismo     | `primesieve` |
-| **NAMD**                    | Dinâmica molecular (carga científica)    | `namd3`      |
-| **Blender render**          | Renderização 3D apenas por CPU           | `blender`    |
-| **xz compression**          | Rendimento de compressão                 | `xz`         |
-| **Kernel defconfig build**  | Desempenho de compilação do Kernel       | `make`       |
-| **y-cruncher**              | Precisão matemática e stress de memória  | `y-cruncher` |
+| Teste                         | Mede                                      | Ferramenta     |
+| ----------------------------- | ----------------------------------------- | -------------- |
+| **stress-ng cpu-cache-mem**   | Desempenho de CPU, cache e memória        | `stress-ng`    |
+| **FFmpeg compilation**        | Desempenho de compilação paralela         | `make`         |
+| **x265 encoding**             | Rendimento de codificação de vídeo        | `x265`         |
+| **argon2 hashing**            | Hashing de passwords multithreaded        | `argon2`       |
+| **perf sched msg**            | Troca de contexto e desempenho de IPC     | `perf`         |
+| **perf memcpy**               | Rendimento de memória `memcpy()`          | `perf`         |
+| **prime calculation**         | Aritmética de inteiros e paralelismo      | `primesieve`   |
+| **NAMD**                      | Dinâmica molecular (carga científica)     | `namd3`        |
+| **Blender render**            | Renderização 3D apenas por CPU            | `blender`      |
+| **xz compression**            | Rendimento de compressão                  | `xz`           |
+| **Kernel defconfig build**    | Desempenho de compilação do kernel        | `make`         |
+| **y-cruncher**                | Precisão matemática e stress de memória   | `y-cruncher`   |
 
-O `cachyos-benchmarker` pode ser utilizado para vários fins, incluindo:
+O `cachyos-benchmarker` pode ser usado para vários propósitos, incluindo:
 
-- **Testar a estabilidade do escalonador**
-  Execute o conjunto completo de benchmarks para detetar bloqueios (*stalls*), falhas (*crashes*) ou regressões introduzidas por alterações no escalonador.
-- **Recolher registos**
-  Se estiver a utilizar o `scx_loader`, pode recolher registos em caso de bloqueio ou falha com:
+- **Testar estabilidade do escalonador**
+  Execute o conjunto completo de benchmarks para detetar bloqueios, falhas ou regressões introduzidas por alterações no escalonador.
+  Se estiver a usar o `scx_loader`, pode recolher logs em caso de bloqueio ou falha com:
   ```bash
   journalctl --unit scx_loader.service --boot 0 > crash.log
   ```
   Isto criará um ficheiro chamado `crash.log` no seu diretório atual.
-- **Comparar o desempenho dos escalonadores**
-  - Avalie as diferenças de desempenho entre escalonadores. Ex: `BPFLAND vs LAVD`.
-- **Medir o efeito de atualizações do kernel ou do escalonador**
-  - Compare execuções antes e depois de aplicar patches ou alterações de versão para verificar regressões ou melhorias de desempenho.
+- **Comparar desempenho de escalonadores**
+  - Avaliar diferenças de desempenho entre escalonadores. Ex: `BPFLAND vs LAVD`
+- **Medir o efeito de atualizações de kernel ou escalonador**
+  - Comparar execuções antes e depois de aplicar patches ou alterações de versão para verificar regressões ou melhorias de desempenho.
 - **Testar ajustes de configuração**
-  - Avalie o impacto de alterações como as definições do regulador de CPU (governor), alternância de SMT ou flags modificadas do escalonador.
+  - Avaliar o impacto de alterações como definições de governor da CPU, alternância de SMT ou flags de escalonador modificadas.
 
 #### Requisitos
 - 4 GB de RAM ou mais
-- Pelo menos 8 GB de espaço livre em disco
-- Tempo e paciência – **o benchmark completo pode demorar mais de uma hora em sistemas mais lentos**
+- Pelo menos 8 GB de espaço de armazenamento livre
+- Tempo e paciência - **o benchmark completo pode levar mais de uma hora em sistemas mais lentos**
 
 #### Instalação
 
@@ -690,25 +845,25 @@ sudo pacman -S cachyos-benchmarker
 #### Executar o benchmark
 
 <Steps>
-    1. Execute o `cachyos-benchmarker`:
+    1. Execute o `cachyos-benchmarker:`
         ```bash
         cachyos-benchmarker ~/cachyos-benchmarker/
-        # Pode substituir ~/cachyos-benchmarker/ por qualquer diretório onde deseje que os registos sejam guardados.
+        # Pode substituir ~/cachyos-benchmarker/ por qualquer diretório onde quer que os logs sejam guardados.
         ```
     2. Aguarde até que os passos de preparação terminem.
-    3. Siga as instruções no terminal:
-        - `Do you want to drop page cache now? Root privileges needed! (y/N) y` (Deseja limpar a cache de páginas agora? Requer privilégios de root!)
-        - `Please enter a name for this run, or leave empty for default:` (Por favor, introduza um nome para esta execução ou deixe em branco para o predefinido:)
+    3. Siga os prompts:
+        - `Do you want to drop page cache now? Root privileges needed! (y/N) y`
+        - `Please enter a name for this run, or leave empty for default:`
     4. Aguarde que os testes terminem.
-    5. Assim que terminar, acontecerá o seguinte:
-        - Criação de um ficheiro de registo com um nome semelhante a `benchie_<nome>_<DATA>.log`, que contém informações detalhadas sobre a execução do benchmark.
+    5. Uma vez terminado, o seguinte acontecerá:
+        - Criação de um ficheiro de log com nome como `benchie_<name>_<DATE>.log` que contém informações detalhadas sobre a execução do benchmark.
           - Exemplo: `benchie_p2dq_2025-09-29-2115.log`
-          - O script `benchmark_scraper.py` será executado automaticamente para gerar um relatório de resumo em formato HTML.
+          - O script `benchmark_scraper.py` executará automaticamente para gerar um relatório de resumo em formato HTML.
           - O que faz o script?:
             - Lê todos os ficheiros `benchie_*.log` no diretório especificado.
             - Extrai os nomes dos benchmarks, tempos e pontuações.
-            - Ordena ou agrega os dados.
-            - Exibe um resumo limpo dos resultados no seu terminal e cria um ficheiro HTML que pode ser aberto num navegador.
+            - Ordena ou agrega-os.
+            - Imprime um resumo limpo dos resultados no seu terminal e cria um ficheiro HTML que pode ser aberto num navegador.
                 <details>
                 <summary>Exemplo de saída do terminal:</summary>
                 ```text
@@ -717,55 +872,55 @@ sudo pacman -S cachyos-benchmarker
                 perf sched msg fork thread: 8.892
                 perf memcpy: 13.53
                 namd 92K atoms: 53.54
-                cálculo de números primos: 11.126
-                hashing argon2: 6.62
-                compilação ffmpeg: 53.38
-                compressão xz: 61.13
+                calculating prime numbers: 11.126
+                argon2 hashing: 6.62
+                ffmpeg compilation: 53.38
+                xz compression: 61.13
                 kernel defconfig: 130.73
-                renderização blender: 96.29
-                codificação x265: 24.99
+                blender render: 96.29
+                x265 encoding: 24.99
 
-                Tempo total (s): 506.72
-                Pontuação total: 70.71
+                Total time (s): 506.72
+                Total score: 70.71
 
-                Nome: p2dq
-                Data: 2025-09-29-2115
+                Name: p2dq
+                Date: 2025-09-29-2115
 
-                Sistema:    Kernel: 6.17.0-1.1-cachyos-p2dq arch: x86_64 bits: 64
-                            Desktop: KDE Plasma v: 6.4.5 Distro: CachyOS
-                Memória:    RAM do Sistema: total: 32 GiB disponível: 30.61 GiB usada: 7.54 GiB (24.6%)
-                            Dispositivo-1: Channel-A DIMM 0 tipo: LPDDR5 tamanho: 8 GiB velocidade: 7500 MT/s
-                            Dispositivo-2: Channel-B DIMM 0 tipo: LPDDR5 tamanho: 8 GiB velocidade: 7500 MT/s
-                            Dispositivo-3: Channel-C DIMM 0 tipo: LPDDR5 tamanho: 8 GiB velocidade: 7500 MT/s
-                            Dispositivo-4: Channel-D DIMM 0 tipo: LPDDR5 tamanho: 8 GiB velocidade: 7500 MT/s
-                CPU:        Info: 8-core modelo: AMD Ryzen 7 8845HS w/ Radeon 780M Graphics bits: 64 tipo: MT MCP cache: L2: 8 MiB
-                            Velocidade (MHz): média: 3366 min/max: 419/5138 núcleos: 1: 3366 2: 3366 3: 3366 4: 3366 5: 3366 6: 3366 7: 3366 8: 3366 9: 3366 10: 3366 11: 3366 12: 3366 13: 3366 14: 3366 15: 3366 16: 3366
+                System:    Kernel: 6.17.0-1.1-cachyos-p2dq arch: x86_64 bits: 64
+                           Desktop: KDE Plasma v: 6.4.5 Distro: CachyOS
+                Memory:    System RAM: total: 32 GiB available: 30.61 GiB used: 7.54 GiB (24.6%)
+                           Device-1: Channel-A DIMM 0 type: LPDDR5 size: 8 GiB speed: 7500 MT/s
+                           Device-2: Channel-B DIMM 0 type: LPDDR5 size: 8 GiB speed: 7500 MT/s
+                           Device-3: Channel-C DIMM 0 type: LPDDR5 size: 8 GiB speed: 7500 MT/s
+                           Device-4: Channel-D DIMM 0 type: LPDDR5 size: 8 GiB speed: 7500 MT/s
+                CPU:       Info: 8-core model: AMD Ryzen 7 8845HS w/ Radeon 780M Graphics bits: 64 type: MT MCP cache: L2: 8 MiB
+                           Speed (MHz): avg: 3366 min/max: 419/5138 cores: 1: 3366 2: 3366 3: 3366 4: 3366 5: 3366 6: 3366 7: 3366 8: 3366 9: 3366 10: 3366 11: 3366 12: 3366 13: 3366 14: 3366 15: 3366 16: 3366
 
-                Escalonador SCX: p2dq_1.0.21_gf90c2aa1_dirty_x86_64_unknown_linux_gnu
+                SCX Scheduler: p2dq_1.0.21_gf90c2aa1_dirty_x86_64_unknown_linux_gnu
 
-                Versão SCX: p2dq_1.0.21_gf90c2aa1_dirty_x86_64_unknown_linux_gnu
+                SCX Version: p2dq_1.0.21_gf90c2aa1_dirty_x86_64_unknown_linux_gnu
 
-                Versão         : 0.5.1-1
+                 Version         : 0.5.1-1
                 ```
                 </details>
                 <details>
-                <summary>Exemplo em HTML de um resultado de teste comparando dois ramos diferentes do mesmo escalonador:</summary>
+                <summary>Exemplo HTML de um resultado de teste comparando dois ramos diferentes do mesmo escalonador:</summary>
                 <ImageComponent imgsrc={import('~/assets/images/cachyos-benchmarker-example.png')} />
                 </details>
-    6. Para comparar duas ou mais execuções, coloque os ficheiros `.log` no mesmo diretório antes de executar o `benchmark_scraper.py`. A ferramenta irá detetá-los e compará-los automaticamente no relatório HTML.
+    6. Para comparar duas ou mais execuções, coloque os ficheiros `.log` no mesmo diretório antes de executar o `benchmark_scraper.py`. A ferramenta irá detetar e compará-los automaticamente no relatório HTML.
 </Steps>
 
-### Testar a latência do escalonador com o schbench
+### Testar latência do escalonador com schbench
 
-O **schbench** é um benchmark de escalonador desenhado para medir a latência do escalonador sob uma carga de trabalho simulada de estilo servidor. Este cria um número configurável de threads "worker" (trabalhadoras) e "message" (mensagens), onde as mensagens acordam repetidamente os workers. Ao medir a distribuição da latência desde o despertar até à execução destas threads, o schbench fornece informações críticas sobre a capacidade do kernel em lidar com o despertar de threads, o equilíbrio de carga (*balancing*) e a contenção de CPU, especialmente sob carga.
+O schbench é um benchmark de escalonador desenhado para medir a latência do escalonador sob uma carga de trabalho simulada de estilo servidor. Cria um número configurável de threads "worker" e "message", onde as mensagens acordam repetidamente os workers. Ao medir a distribuição de latência do despertar à execução destas threads worker, fornece informações críticas sobre a capacidade de um kernel em lidar com despertares de threads, balancing e contenção de CPU, especialmente sob carga.
 
 #### Casos de uso
 
-Pode utilizar o `schbench` para:
+Pode usar o `schbench` para:
 
-- **Avaliar a latência do escalonador:** Identificar quão rapidamente as threads são escalonadas após acordarem.
-- **Comparar o desempenho de despertar (*wakeup*) entre escalonadores:** Detetar melhorias ou regressões na troca de contexto e na latência de despertar.
-- **Testar o efeito de patches no kernel ou no escalonador:** Avaliar se ajustes ou atualizações afetam a justiça (*fairness*) e a responsividade do escalonamento.
+- **Avaliar latência do escalonador:** Identificar quão rapidamente as threads são escalonadas após acordarem.
+- **Comparar desempenho de despertar entre escalonadores:** Detetar melhorias ou regressões na troca de contexto e latência de despertar.
+- **Testar o efeito de patches de kernel ou escalonador:** Avaliar se a afinação ou atualizações afetam a justiça e responsividade do escalonamento.
 
 #### Instalação
 
@@ -783,35 +938,35 @@ schbench -m 2 -t 8 -r 60
 
 Este exemplo executa:
 - 2 threads de mensagem (`-m 2`)
-- 8 threads trabalhadoras (*worker threads*) por thread de mensagem (`-t 8`)
-- durante um tempo total de 60 segundos (`-r 60`)
+- 8 threads worker por thread de mensagem (`-t 8`)
+- por 60 segundos de tempo total (`-r 60`)
 
-Podes ajustar estes valores dependendo do número de núcleos do teu CPU e do nível de carga desejado.
+Pode ajustar estes valores dependendo da contagem de núcleos da sua CPU e do nível de carga desejado.
 
-Aqui está uma tabela que explica algumas das principais opções:
+Aqui está uma tabela explicando algumas das opções principais:
 
-| Opção                        | Descrição                                                                    |
-| ---------------------------- | ---------------------------------------------------------------------------- |
-| `-C, --calibrate`            | Executa a calibração e reporta o tempo (sem benchmark).                      |
-| `-L, --no-locking`           | Desativa os *spinlocks* durante o trabalho de CPU (padrão: bloqueio ativado). |
-| `-m, --message-threads <n>`  | Número de threads de mensagem (padrão: 1).                                   |
-| `-t, --threads <n>`          | Threads trabalhadoras por thread de mensagem (padrão: número de CPUs).       |
-| `-r, --runtime <seg>`        | Duração do benchmark (padrão: 30).                                           |
-| `-F, --cache_footprint <KB>` | Tamanho da pegada (*footprint*) da cache (padrão: 256).                      |
-| `-n, --operations <count>`   | Número de operações de "tempo de reflexão" a realizar (padrão: 5).           |
-| `-A, --auto-rps`             | Aumenta automaticamente o RPS até atingir o alvo de utilização de CPU.       |
-| `-R, --rps <count>`          | Modo de requisições por segundo.                                             |
-| `-p, --pipe <bytes>`         | Simula um teste de transferência por *pipe*.                                 |
-| `-w, --warmuptime <seg>`     | Duração do aquecimento antes de recolher estatísticas (padrão: 0).           |
-| `-i, --intervaltime <seg>`   | Intervalo para exibir as latências (padrão: 10).                             |
-| `-z, --zerotime <seg>`       | Intervalo para reiniciar as estatísticas de latência (padrão: nunca).        |
+| Opção                        | Descrição                                                     |
+| ---------------------------- | ------------------------------------------------------------- |
+| `-C, --calibrate`            | Executar calibração e reportar tempo (sem benchmark).         |
+| `-L, --no-locking`           | Desativar spinlocks durante trabalho de CPU (padrão: locking ativado). |
+| `-m, --message-threads <n>`  | Número de threads de mensagem (padrão: 1).                    |
+| `-t, --threads <n>`          | Threads worker por thread de mensagem (padrão: número de CPUs). |
+| `-r, --runtime <sec>`        | Duração do benchmark (padrão: 30).                            |
+| `-F, --cache_footprint <KB>` | Tamanho da pegada de cache (padrão: 256).                     |
+| `-n, --operations <count>`   | Número de operações de "tempo de pensamento" a executar (padrão: 5). |
+| `-A, --auto-rps`             | Aumentar automaticamente RPS até atingir o alvo de utilização de CPU. |
+| `-R, --rps <count>`          | Modo de requisições por segundo.                              |
+| `-p, --pipe <bytes>`         | Simular um teste de transferência de pipe.                    |
+| `-w, --warmuptime <sec>`     | Duração de aquecimento antes de recolher estatísticas (padrão: 0). |
+| `-i, --intervaltime <sec>`   | Intervalo para imprimir latências (padrão: 10).               |
+| `-z, --zerotime <sec>`       | Intervalo para zerar estatísticas de latência (padrão: nunca). |
 
-#### Compreender os resultados
+#### Compreender a saída
 
-Após cada execução, o `schbench` exibe os percentis de latência como:
+Após cada execução, o `schbench` imprime percentis de latência como:
 
 <details>
-    <summary>Exemplo de saída (Output)</summary>
+    <summary>Exemplo de saída</summary>
     ```bash
     Wakeup Latencies percentiles (usec) runtime 10 (s) (2406 total samples)
 	  50.0th: 60         (648 samples)
@@ -854,78 +1009,127 @@ Após cada execução, o `schbench` exibe os percentis de latência como:
 
 ##### Como interpretar os resultados
 
-- **Wakeup Latencies (Latências de Despertar):**
-  - Mede a rapidez com que as threads acordam após serem sinalizadas.
-    - Valores mais baixos aqui (especialmente no **percentil 99**) significam que o escalonador é mais responsivo.
-- **Request Latencies (Latências de Requisição):**
-  - Representa o tempo necessário para completar requisições entre threads.
-    - Uma latência mais baixa indica melhor comunicação entre threads e maior eficiência de escalonamento.
-- **RPS (Requisições Por Segundo):**
-  - Mostra o rendimento (*throughput*) sustentado:
-    - Um **RPS médio** mais elevado indica que o escalonador consegue lidar com mais trabalho por segundo sob a configuração dada.
+- **Wakeup Latencies:**
+  - Mede quão rapidamente as threads acordam após serem sinalizadas.
+    - Valores mais baixos aqui (especialmente o **99th percentile**) significam que o escalonador é mais responsivo.
+- **Request Latencies:**
+  - Representa o tempo levado para completar requisições entre threads.
+    - Latência mais baixa indica melhor comunicação inter-thread e eficiência de escalonamento.
+- **RPS (Requests Per Second):**
+  - Mostra o throughput sustentado:
+    - Um **average RPS** mais alto indica que o escalonador pode lidar com mais trabalho por segundo sob a configuração dada.
 
 Em conclusão:
-- Um **bom escalonador** apresentará **latências de despertar e de requisição baixas** com um **RPS consistente**.
+- Um **bom escalonador** mostrará **latências de despertar e requisição baixas** com **RPS consistente**.
 - Um **escalonador menos eficiente** pode exibir **picos de latência altos** ou **valores de RPS instáveis** ao longo do tempo.
 
 :::note
-Estes resultados podem variar com base no CPU, contagem de núcleos, carga do sistema e se o escalonador é capaz de lidar com a arquitetura do seu CPU de forma eficiente.
+Estes resultados podem variar com base na CPU, contagem de núcleos, carga do sistema e se o escalonador é capaz de lidar com a sua arquitetura de CPU eficientemente.
 :::
 
 ### Recomendações para benchmarking de jogos
 
-Se o seu desejo é testar jogos para comparar o desempenho de diferentes escalonadores, aqui estão algumas dicas para obter os resultados mais precisos:
+Se o seu desejo é fazer benchmark de jogos para comparar como diferentes escalonadores performam, aqui estão algumas dicas para obter os resultados mais precisos:
 
-- **Utilize benchmarks integrados:** Muitos jogos modernos incluem ferramentas de benchmark internas. Estas são desenhadas para fornecer resultados consistentes ao correr a mesma sequência de eventos em cada execução.
+- **Usar benchmarks integrados:** Muitos jogos modernos vêm com ferramentas de benchmark integradas. Estas são desenhadas para fornecer resultados consistentes ao executar a mesma sequência de eventos cada vez.
   - Consulte este [website](https://www.pcgamingwiki.com/wiki/List_of_games_with_built-in_benchmarks) para uma lista de jogos que incluem benchmarks integrados.
-- **Configurações consistentes:** Certifique-se de que as definições do jogo (resolução, qualidade gráfica, etc.) são as mesmas em cada teste.
-- **Feche aplicações em segundo plano:** Outras aplicações a correr em fundo podem afetar o desempenho. Feche programas desnecessários para minimizar o seu impacto.
-- **Consistência manual:** Se não estiver a usar um benchmark integrado, tente realizar as mesmas ações no jogo em cada execução (seguir o mesmo caminho, combates semelhantes, etc.).
-  - Até o simples facto de não apontar para o mesmo local exato pode levar a variações nos resultados.
-- **Múltiplas execuções:** Realize o benchmark várias vezes e utilize a média para compensar a variabilidade.
-- **Ferramentas de monitorização:** Ferramentas como o **MangoHud** ou **GOverlay** podem fornecer métricas em tempo real, como FPS, *frame times* e utilização de CPU/GPU.
-- **Atalhos e Macros:**
-  - Pode criar um atalho de teclado para alternar entre diferentes escalonadores ou mudar os seus modos "na hora" enquanto joga.
-    - Isto pode ser feito usando uma ferramenta como o [scxctl](/configuration/sched-ext#how-to-launch-and-manage-the-scheduler) ou através de scripts personalizados.
+- **Configurações consistentes:** Certifique-se de que as definições do jogo (resolução, qualidade gráfica, etc.) são as mesmas para cada execução de teste.
+- **Fechar aplicações de fundo:** Outras aplicações a correr em fundo podem afetar o desempenho. Feche programas desnecessários para minimizar o seu impacto.
+- Se não estiver a usar um benchmark integrado, tente executar as mesmas ações no jogo para cada execução de teste. Isto pode incluir seguir o mesmo caminho, envolver-se em cenários de combate semelhantes ou executar as mesmas tarefas.
+  - Até nem mirar no mesmo local pode levar a resultados de desempenho diferentes.
+- **Múltiplas execuções:** Execute múltiplas execuções do benchmark e faça a média para ter em conta a variabilidade.
+- **Usar ferramentas de monitorização de desempenho:** Ferramentas como MangoHud ou GOverlay podem fornecer métricas de desempenho em tempo real como FPS, frame times e utilização de CPU/GPU.
+- **Aproveitar atalhos de teclado ou macros:**
+  - Um exemplo é criar um keybinding onde pode alternar entre diferentes escalonadores ou alterar os seus modos em tempo real durante o jogo.
+    - Isto pode ser feito usando uma ferramenta como [scxctl](/pt/configuration/sched-ext#how-to-launch-and-manage-the-scheduler) ou criando scripts personalizados que alteram o escalonador ativo e o seu modo.
 
-#### Upload e partilha de benchmarks
+#### Carregar e partilhar os seus benchmarks
 
-Este [website](https://flightlesssomething.ambrosia.one/benchmarks) contém uma lista de benchmarks feitos pela comunidade testando diferentes escalonadores e configurações.
+Este [website](https://flightlesssomething.ambrosia.one/benchmarks) contém uma lista de benchmarks feitos pela comunidade usando diferentes escalonadores ou testando várias definições.
 
-Para carregar os seus próprios benchmarks, deverá associar a sua conta do Discord ao site.
+Para carregar os seus próprios benchmarks, terá de ligar a sua conta Discord ao website e então poderá submeter os seus próprios benchmarks.
 
-Depois, clique no botão `New benchmark` e preencha a informação necessária:
-- Pode carregar múltiplos resultados para o mesmo jogo usando diferentes escalonadores.
-- Aceita registos (*logs*) do MangoHud e Afterburner.
-- Permite pesquisa por título ou descrição.
+Depois clique no botão `New benchmark` e preencha a informação necessária.
+
+- Pode carregar múltiplos resultados para o mesmo jogo usando diferentes escalonadores ou definições.
+- Aceita logs tanto do MangoHud como do Afterburner.
+- Permite pesquisar por título ou descrição.
+
+## Configuração do scx_loader
+
+### Definir um escalonador como padrão (no arranque)
+
+Para definir um escalonador para iniciar automaticamente quando o `scx_loader` inicia (ex: no arranque), siga estes passos:
+
+<Steps>
+1. **Copiar o ficheiro de configuração de exemplo** para o diretório de configuração:
+   ```sh
+   sudo mkdir -p /etc/scx_loader
+   sudo cp /usr/share/scx_loader/config.toml /etc/scx_loader/config.toml
+   ```
+
+2. **Editar o ficheiro de configuração** com o seu editor preferido:
+   ```sh
+   sudo nano /etc/scx_loader/config.toml
+   ```
+
+3. **Definir o escalonador padrão e o modo**. Por exemplo, para definir o `scx_pandemonium` no modo `Auto`:
+   ```toml
+   # Este campo especifica o escalonador que será iniciado automaticamente quando o scx_loader iniciar (ex: no arranque).
+   default_sched = "scx_pandemonium"
+
+   # Este campo especifica o modo que será usado quando o scx_loader iniciar (ex: no arranque).
+   default_mode = "Auto"
+   ```
+
+4. **Ativar e iniciar o serviço**:
+   ```sh
+   sudo systemctl enable --now scx_loader.service
+   ```
+</Steps>
+
+#### Ordem de Pesquisa de Configuração
+
+O `scx_loader` pesquisa o ficheiro de configuração na seguinte ordem:
+
+1. `/etc/scx_loader/config.toml` (Preferido)
+2. `/etc/scx_loader.toml`
+3. `/usr/share/scx_loader/config.toml` (Modelo padrão)
+4. `/usr/share/scx_loader.toml`
+
+### Personalizar Argumentos do Escalonador
+
+Pode personalizar os argumentos passados a cada escalonador para diferentes modos adicionando uma secção `[scheds.scx_name]` ao seu ficheiro de configuração.
+
+Para informações detalhadas e exemplos sobre como configurar argumentos por escalonador, consulte a [documentação de configuração do scx_loader](https://github.com/sched-ext/scx-loader/blob/main/crates/scx_loader/configuration.md).
 
 ## Transição do scx.service para o scx_loader: Um Guia Abrangente
 
 :::caution
-Não tente correr o `scx_loader.service` em conjunto com o `scx.service`. Caso contrário, o serviço do loader iniciará mas não fará nada.
+Não tente executar o scx_loader.service juntamente com o scx.service, caso contrário, o serviço loader irá iniciar mas não fará nada.
 
-Este conflito ocorre porque ambos os serviços não têm conhecimento um do outro, especialmente sobre qual deles deve gerir os escalonadores.
+Este conflito surge porque ambos os serviços são inconscientes um do outro, especialmente relativamente a qual deles gere os escalonadores.
 :::
 
 :::tip
-O CachyOS Kernel Manager já inclui uma [interface gráfica (GUI) para gerir o scx_loader.](/features/kernel_manager#sched-ext-framework-management)
+O CachyOS Kernel Manager já inclui uma [GUI para gerir o scx_loader.](/pt/features/kernel_manager#sched-ext-framework-management)
 :::
 
-Vamos começar com uma comparação direta entre a estrutura do ficheiro `scx.service` e a estrutura do ficheiro de configuração do `scx_loader`.
+Primeiro, vamos começar com uma comparação detalhada entre a estrutura do ficheiro scx.service contra a estrutura do ficheiro de configuração do scx_loader.
 
-*Se anteriormente tinha o LAVD a correr com o antigo scx.service, como no exemplo abaixo:*
+*Se anteriormente tinha o LAVD a correr com o antigo scx.service como neste exemplo abaixo:*
 
-```sh title='estrutura do ficheiro scx.service'
-# Lista de escalonadores scx: scx_bpfland scx_central scx_flash scx_lavd scx_layered scx_nest scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_userland
+```sh title='Estrutura do ficheiro scx.service'
+# Lista de scx_schedulers: scx_bpfland scx_central scx_flash scx_lavd scx_layered scx_nest scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_userland
 SCX_SCHEDULER=scx_lavd
 
 # Definir flags personalizadas para o escalonador
 SCX_FLAGS='--performance'
 ```
 
-Então, o equivalente no ficheiro de configuração do scx_loader será:
+Então o equivalente no ficheiro de configuração do scx_loader será:
 
-```sh title='estrutura do ficheiro scx_loader'
+```sh title='Estrutura do ficheiro scx_loader'
 default_sched = "scx_lavd"
 default_mode = "Auto"
 
@@ -935,29 +1139,29 @@ auto_mode = ["--performance"]
 
 [Para mais informações sobre como configurar o ficheiro scx_loader](https://github.com/sched-ext/scx-loader/blob/main/crates/scx_loader/configuration.md#scx_loader-configuration-file)
 
-Siga o guia abaixo para uma transição fácil do `scx systemd service` para o novo utilitário `scx_loader`.
+  Siga o guia abaixo para uma transição fácil do `scx systemd service` para o novo utilitário `scx_loader`.
   <Steps>
-  1. ```sh title='Desativar o scx.service em favor do scx_loader.service'
+  1. ```sh title='Desativar scx.service em favor do scx_loader.service'
       systemctl disable --now scx.service && systemctl enable --now scx_loader.service
-     ```
-  2. ```sh title='Criar o ficheiro de configuração para o scx_loader e adicionar a estrutura predefinida'
-      # O editor Micro irá criar um novo ficheiro.
-      sudo micro /etc/scx_loader.toml
+      ```
+  2. ```sh title='Criar o ficheiro de configuração para o scx_loader e adicionar a estrutura padrão'
+     # O editor Micro vai criar um novo ficheiro.
+     sudo micro /etc/scx_loader.toml
+     # Adicione as seguintes linhas:
 
-      # Adicione as seguintes linhas:
-      default_sched = "scx_bpfland" # Edite esta linha para o escalonador que deseja que o scx_loader inicie no arranque
-      default_mode = "Auto" # Valores possíveis: "Auto", "Gaming", "LowLatency", "PowerSave".
+     default_sched = "scx_bpfland" # Edite esta linha para o escalonador que quer que o scx_loader inicie no arranque
+     default_mode = "Auto" # Valores possíveis: "Auto", "Gaming", "LowLatency", "PowerSave".
 
-      # Pressione CTRL + S para guardar as alterações e CTRL + Q para sair do Micro.
+     # Prima CTRL + S para guardar alterações e CTRL + Q para sair do Micro.
      ```
-  3. ```sh title='Restarting the scx_loader'
+  3. ```sh title='Reiniciar o scx_loader'
      systemctl restart scx_loader.service
      ```
-     - Concluído, o scx_loader irá agora carregar e iniciar o escalonador pretendido.
+     - Está feito, o scx_loader irá agora carregar e iniciar o escalonador desejado.
 
   </Steps>
 
-### Depuração (Debugging) no scx_loader
+### Depuração no scx_loader
 
 <Tabs>
 <TabItem label='Registo simples'>
@@ -965,79 +1169,89 @@ Siga o guia abaixo para uma transição fácil do `scx systemd service` para o n
   - ```sh title='Verificar o estado do serviço'
     systemctl status scx_loader.service
     ```
-  - ```sh title='Visualizar todas as entradas de registo (logs) do serviço'
+  - ```sh title='Ver todas as entradas de log do serviço'
     journalctl -u scx_loader.service
     ```
-  - ```sh title='Visualizar apenas os registos (logs) da sessão atual.'
+  - ```sh title='Ver apenas os logs da sessão atual.'
     journalctl -u scx_loader.service -b 0
     ```
 </TabItem>
 <TabItem label='Registo estendido'>
 
-*Para obter um registo (log) mais detalhado, siga estes passos.*
-  - ```sh title='Editar o ficheiro de serviço'
+*Para obter um log mais detalhado, siga estes passos.*
+  - ```sh title='Editar o ficheiro do serviço'
      sudo systemctl edit scx_loader.service
-    ```
+     ```
   - ```sh title='Adicionar a seguinte linha sob a secção [Service]'
      Environment=RUST_LOG=trace
-    ```
+     ```
   - ```sh title='Reiniciar o serviço'
      sudo systemctl restart scx_loader.service
-    ```
-  - Verifique os registos (logs) novamente para obter informações de depuração mais detalhadas.
+     ```
+  - Verifique os logs novamente para informações de depuração mais detalhadas.
 </TabItem>
 
 </Tabs>
 
 ## FAQ
 
-### Por que razão o escalonador X tem um desempenho pior do que o outro?
+### Há tantas opções... por que não fazem apenas um escalonador que seja bom em tudo?
 
-- Existem muitas variáveis a considerar ao compará-los. Por exemplo, como medem o peso de uma tarefa? Priorizam tarefas interativas sobre as não interativas?
+A principal razão é que não existe uma solução única quando se trata de escalonamento de CPU. Diferentes cargas de trabalho têm diferentes requisitos e prioridades, e um escalonador otimizado para um tipo de carga de trabalho pode não performar bem para outro.
+
+Pode ver os escalonadores de CPU como diferentes pares de sapatos, cada um desenhado para uma atividade específica. Por exemplo, executar um jogo num escalonador otimizado para cargas de trabalho de servidor pode levar a desempenho subóptimo e latência aumentada, enquanto usar um escalonador desenhado para jogos num servidor pode resultar em utilização ineficiente de recursos e rendimento reduzido.
+
+Essa é a magia do sched-ext. As limitações já não são um problema.
+
+### Por que o escalonador X performa pior que o outro?
+
+- Há muitas variáveis a considerar ao compará-los. Por exemplo, como medem o peso de uma tarefa? Priorizam tarefas interativas sobre não interativas?
   Em última análise, depende das suas escolhas de design.
 
-### Por que é que todos dizem que o escalonador X é o melhor para o caso X, mas não funciona tão bem para mim?
+### Por que todos dizem que este escalonador X é o melhor para o caso X mas não performa tão bem para mim?
 
-- Tal como na resposta anterior, a escolha do CPU e o seu design, como o layout dos núcleos, a forma como partilham a cache entre os núcleos e outros fatores relacionados, podem levar o escalonador a operar de forma menos eficiente.
-- É por isso que ter escolhas é um dos destaques da framework sched-ext, por isso não tenha medo de experimentar um e ver qual funciona melhor para o seu caso de uso. `Exemplos: estabilidade de fps, desempenho máximo, capacidade de resposta sob cargas de trabalho intensivas, etc.`
+- Como na resposta anterior, a escolha da CPU e o seu design, como o layout dos núcleos, como partilham cache entre os núcleos e outros fatores relacionados podem levar o escalonador a operar menos eficientemente.
+- É por isso que ter escolhas é um dos destaques da framework sched-ext, então não tenha medo de tentar um e ver qual funciona melhor para o seu caso de uso. `Exemplos: estabilidade de fps, desempenho máximo, responsividade sob cargas de trabalho intensivas, etc.`
 
-### Os casos de uso destes escalonadores são bastante semelhantes... porquê?
+### Os casos de uso destes escalonadores são bastante semelhantes... por que é que isso acontece?
 
-Principalmente porque são escalonadores de uso geral (multipurpose), o que significa que podem acomodar uma variedade de cargas de trabalho, mesmo que possam não exceder-se em todas as áreas.
+Principalmente porque são escalonadores multi-propósito, o que significa que podem acomodar uma variedade de cargas de trabalho, mesmo que possam não destacar-se em todas as áreas.
 
-- Para determinar qual o escalonador que melhor se adapta a si, não há melhor conselho do que experimentá-lo por si próprio.
+- Para determinar qual escalonador o serve melhor, não há melhor conselho do que tentar por si próprio.
 
-### Por que me falta um escalonador que alguns utilizadores estão a mencionar ou a testar no servidor Discord da CachyOS?
-Certifique-se de que está a usar a versão de desenvolvimento (bleeding edge) do pacote scx-scheds, denominada `scx-scheds-git`.
+### Por que me falta um escalonador que alguns utilizadores mencionam ou testam no servidor Discord do CachyOS?
 
-- Uma das razões será que esse escalonador é muito recente e está atualmente a ser testado pelos utilizadores, portanto, ainda não foi adicionado ao pacote `scx-scheds-git`.
+Certifique-se de estar a usar a versão bleeding edge do pacote scx-scheds chamado `scx-scheds-git`.
 
-### Por que é que o escalonador crashou subitamente? É instável?
+- Uma das razões será que este escalonador é muito novo e está atualmente a ser testado pelos utilizadores, portanto ainda não foi adicionado ao pacote `scx-scheds-git`.
 
-- *Podem existir algumas razões para isto ter acontecido:*
-  - Uma das razões mais comuns é que estava a usar o ananicy-cpp juntamente com o escalonador. É por isso que adicionámos este [aviso](/configuration/sched-ext#ananicy-cpp--sched-ext)
-  - Outra razão pode ser que a carga de trabalho que estava a executar excedeu os limites e a capacidade do escalonador, fazendo-o bloquear (stall).
-    - Exemplo de uma carga de trabalho irracional: `hackbench`
-  - Ou a razão mais óbvia: encontrou um bug no escalonador. Se for o caso, por favor reporte-o como um problema (issue) no seu [GitHub](https://github.com/sched-ext/scx/issues) ou informe os desenvolvedores no canal `sched-ext` do Discord da CachyOS.
+### Por que o escalonador falhou subitamente? É instável?
 
-### Já utilizei anteriormente o scx_loader na interface gráfica do Kernel Manager. Ainda preciso de seguir os passos de transição?
+- *Pode haver algumas razões para isto ter acontecido:*
+  - Uma das razões mais comuns é que estava a usar ananicy-cpp juntamente com o escalonador. É por isso que adicionámos este [aviso](/pt/configuration/sched-ext#ananicy-cpp--sched-ext)
+  - Outra razão pode ser que a carga de trabalho que estava a executar excedeu os limites e capacidade do escalonador, fazendo-o bloquear.
+    - Exemplo de uma carga de trabalho irrazoável: `hackbench`
+  - Ou a razão mais óbvia, encontrou um bug no escalonador, se for o caso. Por favor reporte-o como uma issue no seu [GitHub](https://github.com/sched-ext/scx/issues) ou avise-os
+    sobre isso no canal do Discord do CachyOS `sched-ext`
 
-- Neste caso particular, não, não é necessário porque o Kernel Manager já lida com o processo de transição.
-  - *A menos que tenha adicionado anteriormente flags personalizadas em `/etc/default/scx` e ainda queira utilizá-las.*
+### Usei anteriormente o scx_loader na GUI Kernel Manager. Ainda preciso de seguir os passos de transição?
 
-## Saiba Mais
+- Neste caso particular, não, não é necessário porque o Kernel Manager já gere o processo de transição.
+  - *A menos que tenha adicionado flags personalizadas em `/etc/default/scx` anteriormente e ainda queira usá-las.*
+
+## Saber Mais
 
 :::note[Créditos]
-Alguns dos links abaixo foram originalmente referenciados do [repositório GitHub do sched-ext](https://github.com/sched-ext/scx?tab=readme-ov-file#sched_ext-schedulers-and-tools).
-Todo o mérito vai para os mantenedores e contribuidores do sched-ext por organizarem e partilharem estes excelentes recursos.
+Algumas das ligações abaixo foram originalmente referenciadas do [repositório GitHub do sched-ext](https://github.com/sched-ext/scx?tab=readme-ov-file#sched_ext-schedulers-and-tools).
+Todo o crédito vai para os mantenedores e contribuidores do sched-ext por curar e partilhar estes excelentes recursos.
 :::
 
-- [Playlist de YT do Sched_ext](https://youtube.com/playlist?list=PLLLT4NxU7U1TnhgFH6k57iKjRu6CXJ3yB&si=DETiqpfwMoj8Anvl)
-- [LWN: The extensible scheduler class (Fevereiro, 2023)](https://lwn.net/Articles/922405/)
-- [Blog de arighi: Implement your own kernel CPU scheduler in Ubuntu with sched_ext (Julho, 2023)](https://arighi.blogspot.com/2023/07/implement-your-own-cpu-scheduler-in.html)
-- [Palestra de David Vernet: Kernel Recipes 2023 - sched_ext: pluggable scheduling in the Linux kernel (Setembro, 2023)](https://youtu.be/8kAcnNVSAdI?si=F5Q-dkSS_sG9BTXA)
-- [Blog de Changwoo: sched_ext: a BPF-extensible scheduler class (Parte 1) (Dezembro, 2023)](https://blogs.igalia.com/changwoo/sched-ext-a-bpf-extensible-scheduler-class-part-1/)
-- [Blog de arighi: Getting started with sched_ext development (Abril, 2024)](https://arighi.blogspot.com/2024/04/getting-started-with-sched-ext.html)
-- [Blog de Changwoo: sched_ext: scheduler architecture and interfaces (Parte 2) (Junho, 2024)](https://blogs.igalia.com/changwoo/sched-ext-scheduler-architecture-and-interfaces-part-2/)
-- [Canal de YT de arighi: scx_bpfland Linux scheduler demo: topology awareness (Agosto, 2024)](https://youtu.be/R-FEZOveG-I)
-- [Palestra de David Vernet: Kernel Recipes 2024 - Scheduling with superpowers: Using sched_ext to get big perf gains (Setembro, 2024)](https://youtu.be/Cy7-oqdcUCs?si=bjKu3uidOdIzzAWv)
+- [Playlist YT do Sched_ext](https://youtube.com/playlist?list=PLLLT4NxU7U1TnhgFH6k57iKjRu6CXJ3yB&si=DETiqpfwMoj8Anvl)
+- [LWN: A classe de escalonador extensível (Fevereiro, 2023)](https://lwn.net/Articles/922405/)
+- [Blog do arighi: Implemente o seu próprio escalonador de CPU do kernel no Ubuntu com sched_ext (Julho, 2023)](https://arighi.blogspot.com/2023/07/implement-your-own-cpu-scheduler-in.html)
+- [Palestra do David Vernet : Kernel Recipes 2023 - sched_ext: escalonamento plugável no kernel Linux (Setembro, 2023)](https://youtu.be/8kAcnNVSAdI?si=F5Q-dkSS_sG9BTXA)
+- [Blog do Changwoo: sched_ext: uma classe de escalonador extensível por BPF (Parte 1) (Dezembro, 2023)](https://blogs.igalia.com/changwoo/sched-ext-a-bpf-extensible-scheduler-class-part-1/)
+- [Blog do arighi: Começar com o desenvolvimento sched_ext (Abril, 2024)](https://arighi.blogspot.com/2024/04/getting-started-with-sched-ext.html)
+- [Blog do Changwoo: sched_ext: arquitetura e interfaces do escalonador (Parte 2) (Junho, 2024)](https://blogs.igalia.com/changwoo/sched-ext-scheduler-architecture-and-interfaces-part-2/)
+- [Canal YT do arighi: demo do escalonador Linux scx_bpfland: consciência de topologia (Agosto, 2024)](https://youtu.be/R-FEZOveG-I)
+- [Palestra do David Vernet: Kernel Recipes 2024 - Escalonamento com superpoderes: Usar sched_ext para obter grandes ganhos de desempenho (Setembro, 2024)](https://youtu.be/Cy7-oqdcUCs?si=bjKu3uidOdIzzAWv)

--- a/src/content/docs/pt/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/pt/configuration/secure_boot_setup.mdx
@@ -1,25 +1,20 @@
 ---
 title: Configuração do Secure Boot
 description: Configurar o Secure Boot com o sbctl após instalar o CachyOS
+tableOfContents:
+  minHeadingLevel: 1
+  maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
-
-# sbctl
-
-O [sbctl](https://github.com/Foxboron/sbctl) é um gestor de chaves de Secure Boot intuitivo, capaz de configurar o Secure Boot, oferecer funcionalidades de gestão de chaves e manter o rastro dos ficheiros que precisam de ser assinados na cadeia de arranque (boot chain).
-
-## Instalar o sbctl
-
-```bash
-sudo pacman -S sbctl
-```
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 ## Pré-configuração
 
 ### Gestor de Arranque GRUB
 
-Se estiver a utilizar o GRUB, execute o seguinte comando para ativar o suporte ao Secure Boot no GRUB utilizando as chaves da CA (Autoridade de Certificação).
+Se estiver a utilizar o GRUB, execute o seguinte comando para ativar o suporte ao Secure Boot no GRUB utilizando as chaves da CA.
 
 ```bash
 sudo grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=cachyos --modules="tpm" --disable-shim-lock
@@ -30,8 +25,9 @@ O carregamento de módulos desnecessários no seu gestor de arranque tem o poten
 Apenas execute este comando se realmente necessitar do Secure Boot.
 :::
 
-### Entrar no Modo de Configuração (Setup Mode) no UEFI
-Primeiro, precisamos de aceder às definições do firmware e definir o modo do Secure Boot para "Setup Mode". Pode reiniciar um sistema que já esteja em execução para as definições de firmware com o seguinte comando.
+### Ativar o Setup Mode no UEFI
+
+Primeiro, precisamos de aceder às definições do firmware e definir o modo do Secure Boot para "Setup Mode". Pode reiniciar de um sistema que já esteja em execução para as definições de firmware com o seguinte comando.
 
 ```bash
 systemctl reboot --firmware-setup
@@ -40,90 +36,138 @@ systemctl reboot --firmware-setup
 <br />
 <ImageComponent imgsrc={import('~/assets/images/ideapad-bios-secure-boot.jpg')} />
 
-Esta é a aparência da BIOS num Lenovo Ideapad 5 Pro. Reponha para o "Setup Mode" (Modo de Configuração) ou restaure as chaves de fábrica ("Restore Factory Keys") e reinicie o sistema.
+Esta é a aparência da BIOS num Lenovo Ideapad 5 Pro. Reponha para o setup mode ou restaure as chaves de fábrica e reinicie de volta para o sistema.
 
-No entanto, algumas motherboards da MSI não possuem um modo de configuração. Para obter o mesmo efeito, siga os dois passos indicados na imagem abaixo:
+#### Auto Reset
+
+Em algumas motherboards Gigabyte, o "reset to setup mode" é imediatamente seguido de um diálogo "reset without saving"
+<ImageComponent imgsrc={import('~/assets/images/gigabyte-reset-without-saving.jpg')} />
+isto precisa de ser rejeitado, pois causará um reinício do sistema e depois desativará o setup mode.
+
+Em vez disso, inicie diretamente o SO (Save & Exit, e selecione o seu gestor de arranque em Boot Override).
+
+#### Sem setup mode
+
+Algumas motherboards MSI e ASUS não têm um Setup Mode.
+
+##### MSI
+
+Defina o Secure Boot Mode para "custom" e selecione a opção de compatibilidade "maximum security" (isto é importante: com o modo padrão, pode não conseguir iniciar o CachyOS a partir do seu gestor de arranque!). Depois, vá a "key management" e siga os dois passos ilustrados na imagem abaixo:
 <br />
 <ImageComponent imgsrc={import('~/assets/images/MSI-bios-secure-boot.jpg')} />
 
-## Configurar o sbctl
+##### ASUS
 
-```bash
-sudo sbctl status # Se o "setup mode" estiver ativado, podemos avançar para o próximo passo
-Installed:      ✘ sbctl is not installed
-Setup Mode:     ✘ Enabled
-Secure Boot     ✘ Disabled
+Navegue até Boot → Secure Boot, defina o Secure Boot Mode para Custom, depois abra Key Management e selecione "Delete all Secure Boot Variables".
 
-sudo sbctl create-keys # Crie as suas chaves personalizadas de Secure Boot
-Created Owner UUID a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
-Creating secure boot keys...✔
-Secure boot keys created!
+#### Instalar o sbctl e Registar Chaves
 
-sudo sbctl enroll-keys --microsoft # Registe as suas chaves juntamente com as chaves da Microsoft
-Enrolling keys to EFI variables...✔
-Enrolled keys to the EFI variables!
+Antes de prosseguir, certifique-se de verificar se o `sbctl` está instalado.
 
-sudo sbctl status
-# O sbctl deve estar agora instalado; podemos avançar para a assinatura das imagens do kernel e do gestor de arranque
-Installed:      ✔ sbctl is installed
-Owner GUID:     a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
-Setup Mode:     ✔ Disabled
-Secure Boot     ✘ Disabled
-Vendor Keys:    microsoft
-```
+O [sbctl](https://github.com/Foxboron/sbctl) é um gestor de chaves de Secure Boot intuitivo, capaz de configurar o Secure Boot,
+oferecendo funcionalidades de gestão de chaves e mantendo o rastro dos ficheiros que precisam de ser assinados na cadeia de arranque (boot chain).
+
+<details>
+    <summary>Como instalar o sbctl</summary>
+    ```bash title='Abra um terminal e execute o seguinte comando'
+    sudo pacman -S sbctl
+    ```
+</details>
+
+Agora que o `sbctl` está instalado, tem de configurar o sbctl e registar as suas chaves no firmware. Este processo é bastante simples, basta seguir os passos abaixo.
+
+<Steps>
+1. Verifique se o Setup Mode está ativado:
+    ```bash
+    sudo sbctl status
+    ```
+    <details>
+        <summary>Saída esperada</summary>
+        ```bash
+        Installed:      ✘ sbctl is not installed
+        Setup Mode:     ✘ Enabled
+        Secure Boot     ✘ Disabled
+        ```
+    </details>
+2. Crie as suas chaves personalizadas de Secure Boot:
+    ```bash
+    sudo sbctl create-keys
+    ```
+    <details>
+        <summary>Exemplo de criação de chaves bem-sucedida</summary>
+        ```bash
+        Created Owner UUID a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
+        Creating secure boot keys...✔
+        Secure boot keys created!
+        ```
+    </details>
+3. Registe as suas chaves com as chaves da Microsoft e as chaves integradas do firmware do OEM:
+    ```bash
+    sudo sbctl enroll-keys --microsoft --firmware-builtin
+    ```
+    <details>
+        <summary>Saída esperada</summary>
+        ```bash
+        Enrolling keys to EFI variables...✔
+        Enrolled keys to the EFI variables!
+        ```
+    </details>
+
+    :::caution[Placas-mãe ASUS / Gigabyte — Não utilize `--firmware-builtin`]
+    Em algumas placas-mãe ASUS e Gigabyte, o uso da flag `--firmware-builtin` causa entradas duplicadas
+    nas variáveis de chave EFI (por exemplo, `builtin-db` aparecendo várias vezes em `Vendor Keys`).
+    Ao ativar o Secure Boot nas definições UEFI posteriormente, a placa deteta esta
+    estrutura de chaves inconsistente e lança uma **Secure Boot Violation** antes que o gestor
+    de arranque possa carregar.
+
+    Utilize apenas `--microsoft` em placas ASUS / Gigabyte:
+
+    ```bash
+    sudo sbctl enroll-keys --microsoft
+    ```
+
+    Se `Vendor Keys` mostrar `microsoft builtin-db builtin-db ...`, as chaves precisam de ser
+    re-registadas. Reentre no Setup Mode no UEFI (usando delete all keys), depois execute
+    `sbctl enroll-keys --microsoft` novamente sem `--firmware-builtin`.
+    :::
+
+
+4. Verifique o estado do sbctl novamente para garantir que as chaves estão registadas e o setup mode está desativado:
+    ```bash
+    sudo sbctl status
+    ```
+    <details>
+        <summary>Saída esperada</summary>
+        ```bash
+        Installed:      ✔ sbctl is installed
+        Owner GUID:     a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
+        Setup Mode:     ✔ Disabled
+        Secure Boot     ✘ Disabled
+        Vendor Keys:    microsoft
+        ```
+    </details>
+
+    :::note[Setup Mode mostra Enabled?]
+    Se o `Setup Mode` mostrar **Enabled**, vá às definições do firmware e **desative temporariamente o Secure Boot**.
+    Inicie de volta no sistema, verifique o estado do sbctl novamente, prossiga com [Assinar a Imagem do Kernel e o Gestor de Arranque](#assinar-a-imagem-do-kernel-e-o-gestor-de-arranque)
+    abaixo, depois reinicie e reative o Secure Boot nas definições do firmware.
+    :::
+
+</Steps>
 
 ## Assinar a Imagem do Kernel e o Gestor de Arranque
 
-O CachyOS fornece o [sbctl-batch-sign](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/sbctl-batch-sign),
-um script que obtém a lista de ficheiros que precisam de ser assinados através de `sudo sbctl verify` e assina-os a todos.
-Os utilizadores do Limine devem saltar para a secção [Limine](#limine).
+<Tabs>
+<TabItem label='Limine'>
+O Limine é um gestor de arranque especial que permite verificar o hash das imagens do kernel
+e de outros ficheiros que o Limine utiliza durante o arranque. Se isto estiver ativado, qualquer
+tipo de configuração manual feita pelo utilizador, por exemplo, assinar a imagem via
+`sbctl-batch-sign`, irá modificar o hash dos ficheiros correspondentes e
+falhar a verificação de checksum do Limine.
 
-:::caution
-Em sistemas com uma disposição de partições separada para `/boot` e `/boot/efi`, o `sbctl` poderá apenas procurar binários EFI em `/boot/efi`.
-Isto faz com que as imagens do kernel localizadas em `/boot` não sejam detetadas. O `sbctl-batch-sign` contorna este problema ao procurar **sempre** ficheiros `vmlinuz-*` em `/boot`.
-:::
-
-```bash
-sudo sbctl verify
-# Verificar a base de dados de ficheiros e imagens EFI em /boot...
-✘ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn4.0.fc40.x86_64/linux is not signed
-✘ /boot/EFI/BOOT/BOOTX64.EFI is not signed
-✘ /boot/EFI/systemd/systemd-bootx64.efi is not signed
-✘ /boot/1c4b5246eef05ac3bc87339323cd5101/0-rescue/linux is not signed
-✘ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn3.0.fc40.x86_64/linux is not signed
-
-sudo sbctl-batch-sign
-
-sudo sbctl verify
-# Verificar a base de dados de ficheiros e imagens EFI em /boot...
-✔ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn4.0.fc40.x86_64/linux is signed
-✔ /boot/EFI/BOOT/BOOTX64.EFI is signed
-✔ /boot/EFI/systemd/systemd-bootx64.efi is signed
-✔ /boot/1c4b5246eef05ac3bc87339323cd5101/0-rescue/linux is signed
-✔ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn3.0.fc40.x86_64/linux is signed
-```
-
-Agora que todos os ficheiros estão assinados: **Reinicie o seu sistema e aceda às definições de UEFI para ativar o Secure Boot.**
-
-Note que este é um processo único, uma vez que a assinatura de ficheiros com a flag `-s` irá guardá-los na base de dados do `sbctl`.
-
-:::tip[Lembrete]
-O `sbctl` inclui um [pacman hook](https://wiki.archlinux.org/title/Pacman_hook), o que significa que irá assinar automaticamente todos os novos ficheiros após uma atualização do kernel ou do gestor de arranque.
-:::
-
-### systemd-boot
-
-O CachyOS utiliza o `systemd-boot-update.service` fornecido pelo systemd para atualizar o gestor de arranque ao reiniciar. Isto significa que o pacman hook do `sbctl` **não** irá assinar os binários EFI atualizados. Como solução alternativa, podemos assinar o gestor de arranque diretamente:
-
-```sh
-sudo sbctl sign -s -o /usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi
-```
-
-### Limine
-
-O Limine é um gestor de arranque especial que permite verificar o hash das imagens do kernel e de outros ficheiros que o Limine utiliza durante o arranque. Se esta funcionalidade estiver ativada, qualquer tipo de configuração manual feita pelo utilizador (por exemplo, assinar a imagem via `sbctl-batch-sign`) irá modificar o hash dos ficheiros correspondentes e falhar a verificação de checksum do Limine.
-
-No entanto, assinar estes ficheiros não é necessário no Limine, pois este possui um processo de arranque especial que ignora o chainloading de EFI e as verificações de assinatura. Os únicos binários EFI que precisam de ser assinados são os do próprio Limine.
+No entanto, assinar estes ficheiros não é necessário no Limine porque tem um processo de arranque especial
+que ignora o EFI chainloading e as verificações de assinatura. Os únicos binários EFI
+que precisam de ser assinados são o próprio Limine.
 
 :::caution[Limine >= 11.2.0]
 A partir do Limine 11.2.0, as políticas de Secure Boot são **estritamente aplicadas** quando o UEFI Secure Boot está ativo:
@@ -140,42 +184,146 @@ Para ativar o registo automático da soma de verificação de configuração, de
 ENABLE_ENROLL_LIMINE_CONFIG=yes
 ```
 
-Em seguida, execute:
+Prossiga para gerar um hash para a imagem splash do Limine:
+
+:::note[São necessárias permissões de root para executar os seguintes passos, certifique-se de usar sudo ou mudar para o utilizador root antes de prosseguir.]
+:::
+
+<Steps>
+
+1. Verifique o nome e caminho atuais da imagem splash no ficheiro de configuração:
+    ```sh title="Abra um terminal e execute o seguinte comando:"
+    sudo cat /boot/limine.conf
+    ```
+    Deve conseguir identificar uma linha como esta:
+    ```sh
+    wallpaper: boot():/limine-splash.png
+    ```
+2. Gere um hash BLAKE2B para a imagem splash e anexe-o ao caminho no ficheiro de configuração:
+    ```sh title="Execute o seguinte comando, substituindo o caminho pelo que encontrou no passo anterior:"
+    sudo b2sum /boot/limine-splash.png
+    ```
+    Isto irá produzir um hash como neste exemplo:
+    ```sh
+    75205d08fa9c61599897857e861d6b2f6da25465183fc4cc9efecffb22ee630efb510f2ef1b17677db94c28d5c69ad2ceb4d3892f5bec9cfa65c97b5ba16f52f
+    ```
+3. Após copiar o hash recém-gerado do passo anterior. Abra o ficheiro de configuração com um editor de texto e anexe o hash ao caminho da imagem splash, assim:
+    :::note[Não utilize o hash de exemplo acima, certifique-se de usar o que gerou no passo anterior.]
+    :::
+    ```sh
+    wallpaper: boot():/limine-splash.png#75205d08fa9c61599897857e861d6b2f6da25465183fc4cc9efecffb22ee630efb510f2ef1b17677db94c28d5c69ad2ceb4d3892f5bec9cfa65c97b5ba16f52f
+    ```
+    Como pode ver, o hash é anexado ao caminho com um símbolo `#`. Guarde o ficheiro após fazer a alteração.
+
+</Steps>
+
+Após ativar o registo da soma de verificação de configuração e gerar o hash para a imagem splash, execute os seguintes comandos para registar a soma de verificação de configuração e assinar o binário EFI do Limine:
 
 ```sh
-# Utilize o limine-enroll-config para registar a soma de verificação de configuração e assinar o binário EFI do Limine
-# Este comando utiliza o sbctl internamente
+# Utilize limine-enroll-config para registar a soma de verificação de configuração e assinar o binário EFI do Limine
+# Isto utiliza sbctl internamente
 sudo limine-enroll-config
 sudo limine-update
 ```
+</TabItem>
+<TabItem label='systemd-boot'>
 
-## Verificar se o Secure Boot está Ativado
+O CachyOS fornece o [sbctl-batch-sign](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/sbctl-batch-sign),
+um script que obtém a lista de ficheiros que precisam de ser assinados de `sudo sbctl verify` e assina-os todos.
 
-Para confirmar que o Secure Boot está efetivamente ativado, pode executar um dos seguintes comandos:
+:::caution
+Em sistemas com uma disposição de partições separada para `/boot` e `/boot/efi`, o `sbctl` pode apenas procurar binários EFI em `/boot/efi`.
+Isto faz com que as imagens do kernel que estão em `/boot` não sejam detetadas. O `sbctl-batch-sign` contorna isto ao procurar **sempre**
+`/boot` por ficheiros `vmlinuz-*`.
+:::
+
+```bash
+sudo sbctl verify
+Verifying file database and EFI images in /boot...
+✘ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn4.0.fc40.x86_64/linux is not signed
+✘ /boot/EFI/BOOT/BOOTX64.EFI is not signed
+✘ /boot/EFI/systemd/systemd-bootx64.efi is not signed
+✘ /boot/1c4b5246eef05ac3bc87339323cd5101/0-rescue/linux is not signed
+✘ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn3.0.fc40.x86_64/linux is not signed
+
+sudo sbctl-batch-sign
+
+sudo sbctl verify
+Verifying file database and EFI images in /boot...
+✔ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn4.0.fc40.x86_64/linux is signed
+✔ /boot/EFI/BOOT/BOOTX64.EFI is signed
+✔ /boot/EFI/systemd/systemd-bootx64.efi is signed
+✔ /boot/1c4b5246eef05ac3bc87339323cd5101/0-rescue/linux is signed
+✔ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn3.0.fc40.x86_64/linux is signed
+```
+
+Agora que todos os ficheiros estão assinados. **Reinicie o seu sistema e vá às suas Definições UEFI para ativar o Secure Boot.**
+
+:::caution[Placas-mãe ASUS — ativando o Secure Boot]
+Algumas placas-mãe ASUS comportam-se diferentemente de outros fabricantes ao ativar o Secure Boot:
+
+- **Utilize `Windows UEFI Mode`, não `Other OS`:**
+  O nome é enganador, esta definição simplesmente controla se o Secure Boot é aplicado.
+  Definir `OS Type` para `Other OS` **desativa ativamente** o Secure Boot em placas ASUS,
+  independentemente de qualquer outra definição. O `sbctl status` continuará a mostrar
+  `Secure Boot: Disabled` mesmo após reiniciar.
+
+- **Não existe um toggle separado de Secure Boot on/off** em algumas placas ASUS.
+  O Secure Boot é ativado implicitamente selecionando `Windows UEFI Mode`.
+
+A configuração correta da BIOS ASUS para ativar o Secure Boot neste caso é:
+```
+Boot → Secure Boot
+  OS Type          → Windows UEFI Mode
+  Secure Boot Mode → Custom
+```
+:::
+
+Consulte [esta parte para referência](/pt/configuration/secure_boot_setup#enabling-setup-mode-in-uefi)
+
+Note que este é um processo de uma vez só, pois assinar ficheiros com a flag `-s` irá guardar esses ficheiros na base de dados do `sbctl`.
+
+:::tip[Lembrete]
+O `sbctl` vem com um [pacman hook](https://wiki.archlinux.org/title/Pacman_hook), o que significa que irá assinar automaticamente
+todos os novos ficheiros após uma atualização do kernel ou do gestor de arranque.
+:::
+
+O CachyOS usa o `systemd-boot-update.service` fornecido pelo systemd para atualizar o gestor de arranque ao reiniciar. Isto significa que o pacman hook do `sbctl`
+**não** irá assinar os binários EFI atualizados. Como solução alternativa, podemos assinar o gestor de arranque diretamente:
+
+```sh
+sudo sbctl sign -s -o /usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi
+```
+</TabItem>
+</Tabs>
+
+## Verificação do Estado do Secure Boot
+
+Para verificar que o secure boot está de facto ativado. Pode executar um dos seguintes comandos:
 
 ```bash
 sudo sbctl status
-# O estado deverá agora confirmar que o Secure Boot está ativo
-Installed:      ✔ sbctl is installed
+Installed:      ✓ sbctl is installed
 Owner GUID:     a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
-Setup Mode:     ✔ Disabled
-Secure Boot:    ✔ Enabled
+Setup Mode:     ✓ Disabled
+Secure Boot:    ✓ Enabled
 Vendor Keys:    microsoft
 
 bootctl
-# Alternativamente, verifique o estado do sistema através do bootctl
 System:
       Firmware: UEFI 2.80 (INSYDE Corp. 28724.16435)
-  Firmware Arch: x64
-    Secure Boot: enabled (user)
+ Firmware Arch: x64
+   Secure Boot: enabled (user)
   TPM2 Support: yes
   Measured UKI: no
   Boot into FW: supported
 ```
 
-## Links e Créditos
+## Ligações e Créditos
 
 - [A Arch Wiki](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Assisted_process_with_sbctl)
 lançou as bases para este guia. A maior parte do conteúdo aqui presente foi retirada de lá.
-- [sbctl](https://github.com/Foxboron/sbctl) - Este guia simples para ativar o suporte ao Secure Boot não teria sido possível se não fosse o excelente trabalho realizado na criação deste software.
-- [Improving the Secure Boot Experience por Morten Linderud](https://linderud.dev/blog/improving-the-secure-boot-user-experience/) - Artigo no blog de Morten "Foxboron" Linderud sobre como a experiência do Secure Boot era complicada antes do `sbctl`.
+- [sbctl](https://github.com/Foxboron/sbctl) - Este guia simples para ativar o suporte ao Secure Boot não teria sido possível se não fosse
+o excelente trabalho realizado na criação deste software.
+- [Improving the Secure Boot Experience por Morten Linderud](https://linderud.dev/blog/improving-the-secure-boot-user-experience/) - Artigo no blog de Morten
+"Foxboron" Linderud sobre como a experiência do Secure Boot era complicada antes do `sbctl`.

--- a/src/content/docs/pt/features/cachy_chroot.mdx
+++ b/src/content/docs/pt/features/cachy_chroot.mdx
@@ -4,6 +4,7 @@ description: Ferramenta auxiliar para facilitar o processo de chroot em sistemas
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import {Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -41,40 +42,40 @@ O símbolo **?** indica um pedido de introdução de dados pelo utilizador (prom
     ```bash
     cachy-chroot
     ```
-        `cachy-chroot` irá analisar e listar todas as partições disponíveis.
-        <details>
-        <summary>Exemplo de saída com instalação BTRFS do CachyOS</summary>
+    `cachy-chroot` irá analisar e listar todas as partições disponíveis.
+    <details>
+    <summary>Exemplo de saída com instalação BTRFS do CachyOS</summary>
         ```bash
-        Info: Encontrados 3 dispositivos de bloco
-        Info: Partição encontrada: Partição: /dev/nvme0n1p1: FS: vfat UUID: EDA6-ED98
-        Info: Partição encontrada: Partição: /dev/nvme0n1p2: FS: btrfs UUID: b09a027e-a61d-424f-858f-2e02be61b342
-        Info: Partição encontrada: Partição: /dev/nvme0n1p4: FS: btrfs UUID: 66e84339-8c77-4131-afce-50ec2cf67a80
-        ? Selecione o dispositivo de bloco para a partição root (use as teclas de seta):  ›
-        Partição: /dev/nvme0n1p1: FS: vfat UUID: EDA6-ED98
-        ❯ Partição: /dev/nvme0n1p2: FS: btrfs UUID: b09a027e-a61d-424f-858f-2e02be61b342
+        Info: Found 3 block devices
+        Info: Found partition: Partition: /dev/nvme0n1p1: FS: vfat UUID: EDA6-ED98
+        Info: Found partition: Partition: /dev/nvme0n1p2: FS: btrfs UUID: b09a027e-a61d-424f-858f-2e02be61b342
+        Info: Found partition: Partition: /dev/nvme0n1p4: FS: btrfs UUID: 66e84339-8c77-4131-afce-50ec2cf67a80
+        ? Select the block device for the root partition (use arrow keys):  ›
+        Partition: /dev/nvme0n1p1: FS: vfat UUID: EDA6-ED98
+        ❯ Partition: /dev/nvme0n1p2: FS: btrfs UUID: b09a027e-a61d-424f-858f-2e02be61b342
         ```
     </details>
     <details>
     <summary>Exemplo de saída com EXT4</summary>
         ```bash
-        Info: Encontrados 8 dispositivos de bloco
-        Info: Partição encontrada: Partição: /dev/sda1: FS: ext4 UUID: b7fef200-fbb8-4783-9fad-46c5e8b7ca0e
-        Info: Partição encontrada: Partição: /dev/sda2: FS: vfat UUID: CA0D-2D5A
-        Info: Partição encontrada: Partição: /dev/sdb1: FS: ntfs UUID: A4763F77763F48F6
-        Info: Partição encontrada: Partição: /dev/sdc1: FS: ntfs UUID: C4CA216BCA215B46
-        Info: Partição encontrada: Partição: /dev/sdc2: FS: ntfs UUID: 060C28590C284651
-        Info: Partição encontrada: Partição: /dev/sdc3: FS: ntfs UUID: 3A3CF8B13CF86971
-        Info: Partição encontrada: Partição: /dev/sdd1: FS: exfat UUID: 4FDC-0AAB
-        Info: Partição encontrada: Partição: /dev/sdd2: FS: vfat UUID: 3105-B091
-        ? Selecione o dispositivo de bloco para a partição root (use as teclas de seta):  ›
-        ❯ Partição: /dev/sda1: FS: ext4 UUID: b7fef200-fbb8-4783-9fad-46c5e8b7ca0e
-        Partição: /dev/sda2: FS: vfat UUID: CA0D-2D5A
-        Partição: /dev/sdb1: FS: ntfs UUID: A4763F77763F48F6
-        Partição: /dev/sdc1: FS: ntfs UUID: C4CA216BCA215B46
-        Partição: /dev/sdc2: FS: ntfs UUID: 060C28590C284651
-        Partição: /dev/sdc3: FS: ntfs UUID: 3A3CF8B13CF86971
-        Partição: /dev/sdd1: FS: exfat UUID: 4FDC-0AAB
-        Partição: /dev/sdd2: FS: vfat UUID: 3105-B091
+        Info: Found 8 block devices
+        Info: Found partition: Partition: /dev/sda1: FS: ext4 UUID: b7fef200-fbb8-4783-9fad-46c5e8b7ca0e
+        Info: Found partition: Partition: /dev/sda2: FS: vfat UUID: CA0D-2D5A
+        Info: Found partition: Partition: /dev/sdb1: FS: ntfs UUID: A4763F77763F48F6
+        Info: Found partition: Partition: /dev/sdc1: FS: ntfs UUID: C4CA216BCA215B46
+        Info: Found partition: Partition: /dev/sdc2: FS: ntfs UUID: 060C28590C284651
+        Info: Found partition: Partition: /dev/sdc3: FS: ntfs UUID: 3A3CF8B13CF86971
+        Info: Found partition: Partition: /dev/sdd1: FS: exfat UUID: 4FDC-0AAB
+        Info: Found partition: Partition: /dev/sdd2: FS: vfat UUID: 3105-B091
+        ? Select the block device for the root partition (use arrow keys):  ›
+        ❯ Partition: /dev/sda1: FS: ext4 UUID: b7fef200-fbb8-4783-9fad-46c5e8b7ca0e
+        Partition: /dev/sda2: FS: vfat UUID: CA0D-2D5A
+        Partition: /dev/sdb1: FS: ntfs UUID: A4763F77763F48F6
+        Partition: /dev/sdc1: FS: ntfs UUID: C4CA216BCA215B46
+        Partition: /dev/sdc2: FS: ntfs UUID: 060C28590C284651
+        Partition: /dev/sdc3: FS: ntfs UUID: 3A3CF8B13CF86971
+        Partition: /dev/sdd1: FS: exfat UUID: 4FDC-0AAB
+        Partition: /dev/sdd2: FS: vfat UUID: 3105-B091
         ```
         Neste exemplo, a partição root é `/dev/sda1` com o sistema de ficheiros `ext4`. As outras partições não são relevantes para o chroot.
     </details>
@@ -82,27 +83,27 @@ O símbolo **?** indica um pedido de introdução de dados pelo utilizador (prom
     <details>
     <summary>Exemplo com CachyOS BTRFS</summary>
         ```bash title="Selecionar a partição root"
-        ✔ Selecione o dispositivo de bloco para a partição root (use as teclas de seta):  · Partição: /dev/nvme0n1p2: FS: btrfs UUID: b09a027e-a61d-424f-858f-2e02be61b342
-        Info: Partição BTRFS selecionada, a montar e a listar subvolumes...
-        Info: A montar partição /dev/nvme0n1p2 em /tmp/cachyos-chroot-temp-mount-b09a027e-a61d-424f-858f-2e02be61b342-hwAeIm com as opções: []
-        Info: A desmontar partição em /tmp/cachyos-chroot-temp-mount-b09a027e-a61d-424f-858f-2e02be61b342-hwAeIm
-        ? Deseja utilizar a predefinição BTRFS do CachyOS para montar automaticamente o subvolume root? (s/n) › # Introduza "s" (yes) se estiver no CachyOS
+        ✔ Select the block device for the root partition (use arrow keys):  · Partition: /dev/nvme0n1p2: FS: btrfs UUID: b09a027e-a61d-424f-858f-2e02be61b342
+        Info: Selected BTRFS partition, mounting and listing subvolumes...
+        Info: Mounting partition /dev/nvme0n1p2 at /tmp/cachyos-chroot-temp-mount-b09a027e-a61d-424f-858f-2e02be61b342-hwAeIm with options: []
+        Info: Unmounting partition at /tmp/cachyos-chroot-temp-mount-b09a027e-a61d-424f-858f-2e02be61b342-hwAeIm
+        ? Do you want to use CachyOS BTRFS preset to auto mount root subvolume? (y/n) › # Introduza "s" (yes) se estiver no CachyOS
         ```
         **Se estiver a utilizar o CachyOS com BTRFS**, introduza `y` para utilizar a predefinição BTRFS do CachyOS. Isto irá montar automaticamente o subvolume root e outros subvolumes importantes, tais como `/home`, `/var`, `/tmp` e `/srv`. Se estiver a utilizar um esquema BTRFS personalizado ou um sistema que não seja CachyOS, introduza `n` para selecionar os subvolumes manualmente.
     </details>
     <details>
-    <summary>Example with EXT4</summary>
+    <summary>Exemplo com EXT4</summary>
             ```bash title="Selecionar a partição root"
-            ✔ Selecione o dispositivo de bloco para a partição root (use as teclas de seta):  · Partição: /dev/sda1: FS: ext4 UUID: b7fef200-fbb8-4783-9fad-46c5e8b7ca0e
-            Info: A montar partição /dev/sda1 em /tmp/cachyos-chroot-root-mount-b7fef200-fbb8-4783-9fad-46c5e8b7ca0e-LtsXXC com as opções: []
-            Info: A montar partições adicionais baseadas em /etc/fstab...
-            Info: Encontradas 3 entradas em /etc/fstab
-            Aviso: Partição UUID=b7fef200-fbb8-4783-9fad-46c5e8b7ca0e já se encontra montada, a ignorar...
-            Info: A montar partição /dev/sda2 em /tmp/cachyos-chroot-root-mount-b7fef200-fbb8-4783-9fad-46c5e8b7ca0e-LtsXXC/boot com as opções: []
-            Info: Concluída a montagem de partições adicionais
-            ✔ Deseja montar partições adicionais? · não
-            Info: A entrar em chroot na partição root configurada...
-            Info: Para sair do chroot, escreva 'exit' ou prima Ctrl+D
+            ✔ Select the block device for the root partition (use arrow keys):  · Partition: /dev/sda1: FS: ext4 UUID: b7fef200-fbb8-4783-9fad-46c5e8b7ca0e
+            Info: Mounting partition /dev/sda1 at /tmp/cachyos-chroot-root-mount-b7fef200-fbb8-4783-9fad-46c5e8b7ca0e-LtsXXC with options: []
+            Info: Mounting additional partitions based on /etc/fstab...
+            Info: Found 3 entries in /etc/fstab
+            Warning: Partition UUID=b7fef200-fbb8-4783-9fad-46c5e8b7ca0e already mounted, skipping...
+            Info: Mounting partition /dev/sda2 at /tmp/cachyos-chroot-root-mount-b7fef200-fbb8-4783-9fad-46c5e8b7ca0e-LtsXXC/boot with options: []
+            Info: Finished mounting additional partitions
+            ✔ Do you want to mount additional partitions? · no
+            Info: Chrooting into the configured root partition...
+            Info: To exit the chroot, type 'exit' or press Ctrl+D
             ```
     </details>
 6. O `cachy-chroot` tentará montar automaticamente todas as partições e subvolumes listados no `/etc/fstab` do dispositivo root. Se alguma partição falhar ao ser montada, será notificado e ser-lhe-á dada a opção de as montar manualmente, se necessário. Pode escolher `no` para ignorar a montagem de partições adicionais.
@@ -110,21 +111,24 @@ O símbolo **?** indica um pedido de introdução de dados pelo utilizador (prom
     ```bash
     [root@CachyOS /]#
     ```
-    Agora pode executar comandos como se tivesse iniciado sessão no sistema instalado. Por exemplo, pode atualizar o sistema com:
+    Agora pode executar comandos como se tivesse iniciado no sistema instalado. Por exemplo, pode atualizar o sistema com:
     ```bash title="Atualizar o sistema em chroot"
     pacman -Syu
     ```
+    ```bash title="Regenerar o initramfs por precaução"
+    mkinitcpio -P
+    ```
     ou realizar outras tarefas de manutenção conforme necessário.
-8. Quando terminar, saia do ambiente chroot escrevendo `exit` na linha de comandos ou premindo `CTRL+D` no teclado.
+8. Quando terminar, saia do ambiente chroot passando `exit` no prompt ou premindo `CTRL+D` no teclado.
     ```bash title="Sair do chroot"
     exit
     ```
-9. Após sair, o `cachy-chroot` irá limpar automaticamente as partições montadas e fechar quaisquer contentores LUKS. Irá regressar à shell do ambiente live.
+9. Após sair, o `cachy-chroot` irá limpar automaticamente as partições montadas e fechar quaisquer contentores LUKS. Voltará à shell do ambiente live.
 </Steps>
 
 ### Resolução de problemas
 
-- **Nenhuma partição encontrada:** Certifique-se de que o disco que contém a sua instalação está ligado e é reconhecido pelo sistema live. Pode verificar com `lsblk` ou `fdisk -l`.
+- **Nenhuma partição encontrada:** Certifique-se de que o disco que contém a sua instalação está ligado e reconhecido pelo sistema live. Pode verificar com `lsblk` ou `fdisk -l`.
 - **A montagem automática falha para algumas partições:** Pode tentar montá-las manualmente a partir do ambiente chroot. O `cachy-chroot` irá ignorar as falhas e continuar.
 
 ### FAQ

--- a/src/content/docs/pt/features/cachyos_settings.mdx
+++ b/src/content/docs/pt/features/cachyos_settings.mdx
@@ -1,118 +1,412 @@
 ---
 title: Definições do CachyOS (CachyOS Settings)
+ai_translated: true
 ---
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 Juntamente com os nossos kernels e repositórios otimizados, também fornecemos definições que melhoram ainda mais a experiência de desktop, bem como alguns
 scripts de auxílio para melhorias na qualidade de vida (QoL). Todas estas configurações e scripts encontram-se no pacote `cachyos-settings`.
 
-## Ajustes sysctl (sysctl Tweaks)
+Consulte o [repositório CachyOS Settings](https://github.com/CachyOS/CachyOS-Settings?tab=readme-ov-file#cachyos-settings) para ler mais sobre todas as configurações e scripts que fornecemos.
+
+## Scripts e Ferramentas
+
+### [cachyos-bugreport.sh](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/cachyos-bugreport.sh)
+
+Aqui está como pode gerar um relatório de erro utilizando o script `cachyos-bugreport.sh`:
+<Steps>
+1. Abra um terminal e execute o seguinte comando:
+    ```sh
+    sudo cachyos-bugreport.sh
+    ```
+    <details>
+        <summary>Exemplo de Saída</summary>
+        ```sh
+        sudo cachyos-bugreport.sh
+        [sudo] password for array:
+        Starting with bugreport
+        Redacting personal information...
+        Do you want to upload this log to https://paste.cachyos.org? [Y]es/[N]o: Y
+        Uploading Log
+          % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
+                                         Dload  Upload  Total   Spent   Left   Speed
+        100 130.3k 100     10 100 130.3k      7  96934   00:01   00:01         117.7k
+        # Um URL será fornecido aqui após o upload estar completo.
+        ```
+    </details>
+2. O script irá gerar um ficheiro de log no seu diretório pessoal contendo informações do sistema e logs que podem ser úteis para depuração. Também irá perguntar se deseja carregar o log para o nosso serviço de pastebin, o que pode ser útil ao reportar bugs.
+</Steps>
+
+### DLSS Swapper
+
+Pode ser útil em alguns casos. Especialmente para a versão Proton fornecida pela Valve.
+
+:::note
+O Proton-CachyOS já fornece uma funcionalidade de atualização integrada.
+:::
+
+:::caution
+Não combine `PROTON_DLSS_UPGRADE=1` e `dlss-swapper` ao mesmo tempo, pois ambos fazem a mesma coisa e podem causar conflitos.
+:::
+
+O que faz é tentar atualizar as DLLs e predefinições do DLSS para a versão mais recente disponível, o que pode ser útil para alguns jogos que requerem uma versão específica do DLSS para funcionar corretamente.
+
+Como? injetando variáveis de ambiente no processo do jogo:
+
+<details>
+    <summary>Variáveis de Ambiente do dlss-swapper</summary>
+    ```sh
+    export PROTON_ENABLE_NGX_UPDATER=1
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    ```
+</details>
+<details>
+    <summary>Variáveis de Ambiente do dlss-swapper-dll</summary>
+    ```sh
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    ```
+</details>
+
+- Qual é a diferença entre `dlss-swapper` e `dlss-swapper-dll`?
+    - `dlss-swapper` atualiza as DLLs e predefinições do DLSS para as versões mais recentes disponíveis fornecidas pelo NGX Updater e `dlss-swapper-dll` depende das DLLs já presentes no diretório do jogo.
+
+
+### [game-performance](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/game-performance)
+
+Script minúsculo que ativa o perfil de desempenho do `powerprofilesctl` para o processo alvo (pode ser usado para jogos ou qualquer outro processo) e desativa o protetor de ecrã enquanto o processo está em execução.
+
+Perguntas e Respostas:
+
+<details>
+    <summary>Como usar</summary>
+    Digamos que deseja usar `game-performance` para um jogo do Steam. Pode fazer isso adicionando o comando `game-performance` como uma opção de lançamento para o jogo no Steam:
+        <Steps>
+            1. Abra o Steam e vá à sua Biblioteca.
+            2. Clique com o botão direito no jogo com que deseja usar `game-performance` e selecione "Propriedades".
+            3. Na aba "Geral", encontre a secção "Opções de Lançamento" e adicione o seguinte comando:
+                ```sh
+                game-performance %command%
+                ```
+                :::tip[Guia sobre como gerir opções de lançamento no Steam]
+                Wiki CachyOS - [Como Definir Corretamente Múltiplas Opções de Lançamento](/pt/configuration/gaming#how-to-properly-set-multiple-launch-options)
+                :::
+            4. Feche a aba de propriedades e inicie o jogo.
+        </Steps>
+        <details>
+            <summary>Utilização fora do Steam</summary>
+            Uma vez que `game-performance` é apenas um script wrapper, pode usá-lo para iniciar qualquer processo com o perfil de desempenho ativado. Basta executar o seguinte comando no terminal:
+            ```sh
+            game-performance <command>
+            ```
+        </details>
+</details>
+
+<details>
+    <summary>O game-performance oferece algum benefício para uma CPU antiga?</summary>
+    Geralmente não. Deve evitá-lo para CPUs antigas, pois pode causar mais danos do que benefícios.
+
+    Para uma orientação aproximada, usar game-performance em qualquer CPU abaixo de 6 núcleos/12 threads provavelmente não aumentará ou até diminuirá o desempenho. Como na maioria das opções, deve testar por si mesmo se elas melhoram o desempenho no seu sistema específico ou não.
+      - Para CPUs desktop Intel, o corte aproximado é portanto a 8ª geração (Coffee Lake) para CPUs i7 e i9 e a 10ª geração (Comet Lake) para CPUs i5. Todas as CPUs Intel Ultra devem funcionar.
+      - Para CPUs desktop AMD, é a série 1000 (Zen) para CPUs Ryzen 7 e Ryzen 9. Para CPUs Ryzen 5, é também a série 1000, mas apenas o Ryzen 5 1600 e superior. Este é o caso até à série 5000 (Zen 3), onde agora todos os CPUs Ryzen 5 têm 6 núcleos e 12 threads.
+      - CPUs desktop Intel i3 e Ryzen 3 nunca têm mais de quatro núcleos.
+      - As contagens de núcleos para CPUs mobile, workstation e server variam muito, então pesquise o que tem e experimente diferentes definições, essa é metade da diversão de ter hardware de PC!
+</details>
+
+<details>
+    <summary>Porque não está ativado por predefinição?</summary>
+    Ativar o perfil de desempenho pode não ser ideal para todos os utilizadores e pode causar maior consumo de energia e geração de calor. Ao não o ativar por predefinição, damos aos utilizadores a escolha de o ativar quando precisam, sem o impor a todos.
+</details>
+
+### [kerver](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/kerver)
+
+O kerver é um script que partilha um breve resumo de:
+
+- A sua versão atual do kernel
+    - Verifica o suporte x86_64 e otimizações do compilador da CPU
+- Agendador de I/O atual
+- Resumo da CPU, I/O e agendador sched-ext (se ativo).
+
+<details>
+    <summary>Utilização</summary>
+    ```sh title='Abra um terminal e execute o seguinte comando:'
+    kerver
+    ```
+    <details>
+        <summary>Exemplo de Saída</summary>
+        ```sh
+        kerver
+
+        Check kernel version:
+
+        Linux version 6.19.8-1-hC (linux-hC@hC) (clang version 22.1.1, LLD 22.1.1) #1 SMP PREEMPT_DYNAMIC Sun, 15 Mar 2026 16:27:53 +0000
+        Linux CatchyOS 6.19.8-1-hC #1 SMP PREEMPT_DYNAMIC Sun, 15 Mar 2026 16:27:53 +0000 x86_64 GNU/Linux
+
+
+        Check x86_64 support:
+
+          x86-64-v3 (supported, searched)
+          x86-64-v2 (supported, searched)
+
+
+        Check CPU config:
+
+        CONFIG_X86_NATIVE_CPU=y
+        # CONFIG_GENERIC_CPU is not set
+        # CONFIG_MZEN4 is not set
+
+
+        Current disk schedulers:
+
+        sda: none mq-deadline kyber [adios] bfq
+        sdb: none mq-deadline kyber [adios] bfq
+
+        Check available schedulers:
+
+        BORE CPU Scheduler modification 6.6.2 by Masahito Suzuki
+        rcu: RCU calculated value of scheduler-enlistment delay is 100 jiffies.
+        io scheduler mq-deadline registered
+        io scheduler kyber registered
+        Adaptive Deadline I/O Scheduler 3.2.0 by Masahito Suzuki
+        io scheduler adios registered
+        io scheduler bfq registered
+        sched_ext: BPF scheduler "bpfland_1.1.0_gc505008f_x86_64_unknown_linux_gnu" enabled with options scx_bpfland
+        ```
+    </details>
+</details>
+
+### [paste-cachyos](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/paste-cachyos)
+
+Uma ferramenta CLI simples que permite carregar texto para o nosso [serviço de pastebin](https://paste.cachyos.org). Pode ser útil para partilhar logs e outros conteúdos de texto ao reportar bugs ou pedir ajuda.
+
+:::note
+Para usar `paste-cachyos`, tem de encaminhar (`|`) o conteúdo que deseja carregar para o comando.
+
+Exemplo:
+```sh
+<command> | paste-cachyos
+```
+:::
+
+Aqui estão alguns exemplos de como usar `paste-cachyos`:
+
+<details>
+    <summary>Partilhar uma saída de atualização do pacman</summary>
+    ```sh
+    sudo pacman -Syu | paste-cachyos
+    ```
+    [Exemplo](https://paste.cachyos.org/p/079e1cc)
+</details>
+
+<details>
+    <summary>Log do journalctl do systemd-resolved</summary>
+    ```sh
+    journalctl -u systemd-resolved.service | paste-cachyos
+    ```
+</details>
+
+### [pci-latency](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/pci-latency)
+
+Um script simples destinado a tentar reduzir a latência e melhorar o desempenho para placas de som PCI ao alterar o temporizador de latência PCI.
+
+Disponível tanto em formato binário como de serviço systemd. O serviço systemd aplicará automaticamente as alterações no arranque, enquanto o binário pode ser usado para aplicar as alterações a pedido.
+
+<details>
+    <summary>Uso único para a sessão atual</summary>
+    ```sh
+    sudo pci-latency
+    ```
+</details>
+<details>
+    <summary>Ativar o serviço systemd</summary>
+    ```sh
+    systemctl enable pci-latency.service
+    ```
+</details>
+<details>
+    <summary>Desativar o serviço systemd</summary>
+    ```sh
+    systemctl disable pci-latency.service
+    ```
+</details>
+
+### [sbctl-batch-sign](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/sbctl-batch-sign)
+
+:::note
+Não compatível com Limine.
+:::
+
+O `sbctl-batch-sign` é um script de auxílio desenhado para facilitar aos utilizadores a assinatura de ficheiros necessários para o suporte ao Secure Boot.
+
+O caso óbvio em que este script ajuda muito é quando se faz dual boot com Windows, pois há muitos ficheiros do Windows que precisam de ser assinados no EFI.
+
+Breve resumo ao executar o script:
+
+- Procura ficheiros não assinados usando `sbctl verify`
+    - Se necessário, assina os ficheiros detetados usando `sbctl sign`
+- Evita ficheiros que pertencem ao Windows, GRUB ou por extensão de ficheiro: `.mui` e `.dll`
+
+Consulte a nossa secção [Configuração do Secure Boot](/pt/configuration/secure_boot_setup#assinar-a-imagem-do-kernel-e-o-gestor-de-arranque) para mais informações.
+
+### [topmem](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/topmem)
+
+Script Lua que mostra os processos que mais consomem memória pela sua utilização de RAM, SWAP e partilha KSM (Kernel Same-page Merging).
+
+<details>
+    <summary>Antes de usar</summary>
+    ```sh
+    # Instale lua-luv para executar o script:
+    sudo pacman -S lua-luv
+    ```
+</details>
+<details>
+    <summary>Utilização</summary>
+    ```sh
+    topmem
+    ```
+    <details>
+        <summary>Exemplo de Saída</summary>
+        ```sh
+        topmem
+
+        MEMORY                Top 10 processes        SWAP      KSM
+        1333M     node                                0M        0M
+        811M      exe                                 0M        0M
+        759M      VQ6B1EUZqoCU04zoRU= --cha...        0M        0M
+        681M      node                                0M        0M
+        531M      zed-editor                          0M        0M
+        484M      brave                               0M        0M
+        424M      qs                                  0M        0M
+        408M      mdx-language-server                 0M        0M
+        395M      Telegram                            0M        0M
+        365M      VQ6B1EUZqoCU04zoRU= --cha...        0M        0M
+        ```
+    </details>
+</details>
+
+### [zink-run](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/zink-run)
+
+Força o uso do Zink (OpenGL sobre Vulkan) para o processo alvo definindo as variáveis de ambiente apropriadas.
+
+<details>
+    <summary>Variáveis de ambiente utilizadas</summary>
+    ```sh
+    MESA_LOADER_DRIVER_OVERRIDE=zink
+    GALLIUM_DRIVER=zink
+    __GLX_VENDOR_LIBRARY_NAME=mesa
+    __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
+    ```
+</details>
+
+Pode ser útil no Steam para alguns jogos que têm melhor desempenho ou compatibilidade com Zink.
+
+<details>
+    <summary>Utilização</summary>
+    ```sh
+    zink-run <command>
+    ```
+</details>
+
+## Criação de Overrides
+
+O que é um override?
+
+Um override é um ficheiro de configuração que cria para alterar as definições padrão fornecidas pelo `cachyos-settings`. Isto permite personalizar o seu sistema sem modificar os ficheiros originais, o que pode ser útil para manter a compatibilidade com atualizações futuras do `cachyos-settings`.
+
+### sysctl
 
 Fornecemos diversos ajustes de sysctl que visam melhorar o desempenho geral do desktop. Cada entrada sysctl está bem documentada
 no ficheiro [70-cachyos-settings.conf](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/sysctl.d/70-cachyos-settings.conf).
 
-Para efetuar alterações em qualquer um destes valores, copie a entrada original e crie um novo ficheiro em `/etc/sysctl.d/` com o valor modificado.
+Para fazer alterações em qualquer um destes valores, copie a entrada original e crie um novo ficheiro em `/etc/sysctl.d/` com o valor modificado.
 
-### Modificar valores sysctl
+<details>
+    <summary>Exemplo de override sysctl</summary>
+    <Steps>
 
-<Steps>
+    1. Analise o valor original em `cachyos-settings`
 
-1. Analise o valor original em `cachyos-settings`
+        ```sh
+        cat /usr/lib/sysctl.d/70-cachyos-settings.conf
+        # Only experimental!
+        # Let Realtime tasks run as long they need
+        # sched: RT throttling activated
+        kernel.sched_rt_runtime_us=-1
+        ```
+    2. Crie um novo ficheiro em `/etc/sysctl.d` para fazer alterações nas definições de sysctl
 
-    ```sh
-    cat /usr/lib/sysctl.d/70-cachyos-settings.conf
-    # Apenas experimental!
-    # Permite que tarefas em Tempo Real (RT) corram o tempo que for necessário
-    # sched: RT throttling ativado
-    kernel.sched_rt_runtime_us=-1
-    ```
+        ```sh title="Reverter kernel.sched_rt_runtime_us= para o seu valor predefinido"
+        sudo micro /etc/sysctl.d/99-kernel-sched-rt.conf # Se o ficheiro não existir, este comando cria e permite-lhe editar o ficheiro
+        kernel.sched_rt_runtime_us=950000
+        ```
+    3. Guarde o ficheiro premindo `CTRL + S` e saia do editor premindo `CTRL + Q`.
+    4. Após fazer alterações nas definições de sysctl, certifique-se de aplicar as alterações:
+        ```sh
+        sudo sysctl --system
+        ```
+    </Steps>
+</details>
 
-2. Crie um novo ficheiro em `/etc/sysctl.d` para efetuar alterações nas definições de sysctl
+### Regras udev
 
-    ```sh title="Reverter kernel.sched_rt_runtime_us= para o seu valor predefinido"
-    sudo micro /etc/sysctl.d/99-kernel-sched-rt.conf # Se o ficheiro não existir, este comando cria e permite-lhe editar o ficheiro
-    kernel.sched_rt_runtime_us=950000
-    ```
+O mesmo vale para regras udev. Pode criar os seus próprios overrides criando um novo ficheiro em `/etc/udev/rules.d/` com o mesmo nome que o ficheiro original.
 
-</Steps>
+:::tip[Utilize o seguinte comando para encontrar os ficheiros originais]
+```sh
+pacman -Ql cachyos-settings | grep udev
+```
+:::
 
-## Regras udev (udev Rules)
+<details>
+    <summary>Exemplo de override de regra udev</summary>
+    1. Verifique a regra udev original do CachyOS:
+        ```sh
+        cat /usr/lib/udev/rules.d/60-ioschedulers.rules
+        ```
+        <details>
+            <summary>Saída:</summary>
+                ```sh
+                # HDD
+                ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
+                    ATTR{queue/scheduler}="bfq"
 
-- [Regras ZRAM](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/30-zram.rules) - Define o swappiness do ZRAM para um valor mais agressivo, para que a cache tenha maior probabilidade de fazer swap para o ZRAM
-- [Permissões HPET](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/40-hpet-permissions.rules) - Permite o acesso aos nós de dispositivo `rtc0` e `hpet` pelo grupo audio
-- [Gestão de Energia SATA](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/50-sata.rules) - Define a política de gestão de energia dos dispositivos SATA para `max_performance`. Apenas se o dispositivo suportar LPM.
-- [Regras de Agendador de I/O](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/60-ioschedulers.rules) - Seleciona o agendador (scheduler) ideal para cada tipo de unidade (HDD, SSD, NVMe)
-- [Regras hdparm](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/69-hdparm.rules) - Define HDDs SATA e IDE para o desempenho máximo
-- [NVIDIA RTD3](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/71-nvidia.rules) - Configura a funcionalidade de gestão dinâmica de energia para a geração de GPUs Turing. `O RTD3 não funciona corretamente em GPUs Turing com os módulos open`
-- [Latência de DMA da CPU](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/99-cpu-dma-latency.rules) - Permite o acesso ao nó de dispositivo `cpu_dma_latency` pelo grupo audio
-- [PM snd_hda_intel](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/20-audio-pm.rules) - Define a poupança de energia para `0` quando ligado à corrente (AC Power) e restaura o valor anterior ao mudar para a bateria
+                # SSD
+                ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
+                    ATTR{queue/scheduler}="mq-deadline"
 
-## Opções de modprobe
+                # NVMe SSD
+                ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
+                    ATTR{queue/scheduler}="none"
+                ```
+        </details>
+        Agora imagine que deseja alterar o agendador de I/O para SSDs e NVMe para `kyber` em vez de `mq-deadline` e `none`, respetivamente. Pode fazer isso criando um ficheiro de override.
+    2. Crie um novo ficheiro em `/etc/udev/rules.d` para substituir a regra original:
+        ```sh
+        sudo micro /etc/udev/rules.d/60-ioschedulers.rules # Se o ficheiro não existir, este comando cria e permite-lhe editar o ficheiro
+        # HDD
+        ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
+            ATTR{queue/scheduler}="bfq"
 
-- Força o controlador AMDGPU em Southern Islands (GCN 1.0) e Sea Islands (GCN 2.0)
-- Ativa [vários ajustes](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/modprobe.d/nvidia.conf) para NVIDIA
-- Coloca módulos watchdog na lista negra (blacklist)
-- Desativa o power_save para o controlador de áudio **sna_hda_intel**
+        # SSD
+        ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
+            ATTR{queue/scheduler}="kyber"
 
-## Scripts de Auxílio (Helper Scripts)
+        # NVMe SSD
+        ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
+            ATTR{queue/scheduler}="kyber"
+        ```
+    3. Guarde o ficheiro premindo `CTRL + S` e saia do editor premindo `CTRL + Q`.
+    4. Após fazer alterações nas regras udev, certifique-se de recarregar as regras e ativá-las:
 
-- `cachyos-bugreport.sh` - Recolhe vários registos (logs) do `inxi`, `dmesg` e `journalctl` para ajudar na resolução de problemas
-- `game-performance` - Script wrapper para o `powerprofilesctl` para mudar para o perfil de desempenho a pedido. Consulte [Mudança de Perfil de Energia a Pedido](/configuration/gaming#power-profile-switching-on-demand)
-- `dlss-swapper` - Script wrapper para forçar a predefinição de DLSS mais recente em jogos que suportam a tecnologia
-- `dlss-swapper-dll` - Semelhante ao `dlss-swapper`, mas requer a atualização manual da biblioteca `nvngx_dlss.dll` fornecida com o jogo; pode funcionar com jogos que tenham problemas com a versão regular do script
-- `kerver` - Script de qualidade de vida para mostrar informações sobre o kernel atual
-- `paste-cachyos` - Script para colar a saída do terminal para ficheiros de texto a partir do sistema
-
-    <Tabs>
-        <TabItem label="Carregar ficheiros de texto">
-            ```sh
-            paste-cachyos /path/to/file
-            ```
-        </TabItem>
-        <TabItem label="Carregar a Saída do Terminal">
-            ```sh
-            <command> | paste-cachyos
-            ```
-        </TabItem>
-    </Tabs>
-
-- [pci-latency](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/pci-latency) - Reduz o valor de `latency_timer` para `80` em placas de som PCI e redefine todos os outros dispositivos PCI para `20` e `0`
-    ```sh title="Ativar pci-latency em todo o sistema"
-    sudo systemctl enable --now pci-latency.service
-    ```
-- `sbctl-batch-sign` - Script de auxílio para assinar facilmente imagens de kernel e binários EFI para o Secure Boot, guardando-os na base de dados do sbctl
-- `topmem` - Mostra estatísticas de RAM, swap e ksm de 10 processos por ordem decrescente
-- `zink-run` - Facilita a execução de um programa OpenGL através do controlador Zink Gallium
-
-
-## Outras configurações
-
-### Ajustes de Utilização de Memória
-
-- Configuração do THP Shrinker `max_ptes_none = 409`
-- Define o tamanho máximo de `50MB` para o journal do systemd
-- [ZRAM Generator](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/systemd/zram-generator.conf) - Define o ZRAM com o mesmo tamanho da RAM e utiliza ZSTD para compressão
-
-### Regras Ananicy-cpp
-
-- [ananicy-cpp](https://gitlab.com/ananicy-cpp/ananicy-cpp) com [conjuntos de regras mantidos pela comunidade](https://github.com/CachyOS/ananicy-rules)
-
-### Modificações de Rede
-
-- [systemd-resolved como o Resolvedor de DNS predefinido](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/NetworkManager/conf.d/dns.conf) para o NetworkManager
-
-### Qualidade de Vida (QoL) em NTP
-
-- Servidor preferencial definido para `Cloudflare`
-- Servidores de recurso (fallback): `Google` e `Arch Linux`
-
-### Ajustes de Serviços systemd
-
-- Tempo limite (timeout) para iniciar um serviço/unidade definido para `15s`
-- Tempo limite para parar um serviço/unidade definido para `10s`
-- Limite flexível (soft limit) para descritores de ficheiros abertos definido para `2048`
-- Limite rígido (hard limit) para descritores de ficheiros abertos definido para `2097152`
-
-### X.Org
-
-- Ativa o [Toque para Clicar (Tap to Click)](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/share/X11/xorg.conf.d/20-touchpad.conf) por predefinição em todas as sessões X11
+        ```sh
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger
+        ```
+</details>

--- a/src/content/docs/pt/features/chwd/chwd.mdx
+++ b/src/content/docs/pt/features/chwd/chwd.mdx
@@ -1,9 +1,10 @@
 ---
 title: Gestão de Hardware com chwd
 description: Deteção e Configuração de Hardware para o CachyOS
+ai_translated: true
 ---
 
-O [CachyOS Hardware Detection](https://github.com/CachyOS/chwd/) (mais conhecido como `chwd`) permite-nos dar suporte a uma variedade de hardware, instalando os pacotes e controladores (drivers) necessários para o sistema em execução. Isto inclui sistemas com placas gráficas NVIDIA, Macbooks T2 e dispositivos portáteis (handhelds), como o Steam Deck e o ROG Ally.
+O [CachyOS Hardware Detection](https://github.com/CachyOS/chwd/) (mais conhecido como `chwd`) permite-nos dar suporte a uma variedade de hardware, instalando os pacotes e controladores necessários para o sistema em execução. Isto inclui sistemas com placas gráficas NVIDIA, Macbooks T2 e dispositivos portáteis (handhelds), como o Steam Deck e o ROG Ally.
 
 ## Utilização
 
@@ -23,30 +24,45 @@ Uma alternativa ao método acima é instalar cada perfil de forma específica.
 
 ```sh title='Listar todos os perfis disponíveis'
 chwd --list-all
-╭─────────────────────────┬─────────╮
-│ Nome                    ┆ NonFree │
-╞═════════════════════════╪═════════╡
-│ nvidia-open-dkms.prime  ┆ true    │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ nvidia-dkms             ┆ true    │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ macbook-t2              ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ phoenix                 ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ steam-deck              ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ amd                     ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ intel                   ┆ false   │
-╰─────────────────────────┴─────────╯
+> All PCI profiles:
+╭─────────────────────────┬──────────╮
+│ Name                    ┆ Priority │
+╞═════════════════════════╪══════════╡
+│ nouveau                 ┆ 18       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ nvidia-dkms-470xx       ┆ 14       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ nvidia-dkms-580xx       ┆ 12       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ nvidia-open-dkms        ┆ 10       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ macbook-t2              ┆ 9        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ virtualmachine          ┆ 5        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ amd                     ┆ 4        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ intel                   ┆ 4        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ fallback                ┆ 3        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld.intel-msi-claw ┆ 2        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld.rog-ally       ┆ 2        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld.steam-deck     ┆ 2        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld                ┆ 1        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ broadcom-wl             ┆ 1        │
+╰─────────────────────────┴──────────╯
 ```
 
 ```sh title='Instalar um perfil do chwd'
 sudo chwd -i amd
-> A instalar amd ...
+> Installing amd ...
 
-> amd instalado com sucesso
+> Successfully installed amd
 ```
 
 ### Outros

--- a/src/content/docs/pt/features/kernel.mdx
+++ b/src/content/docs/pt/features/kernel.mdx
@@ -4,6 +4,7 @@ description: Funcionalidades e alterações no kernel CachyOS
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 O Kernel CachyOS é um kernel personalizado que utiliza melhorias, configurações e patches provenientes do upstream.
@@ -13,42 +14,54 @@ O Kernel CachyOS é um kernel personalizado que utiliza melhorias, configuraçõ
 ### Otimizações de Desempenho
 
 - **Compilação Avançada**: PKGBUILD altamente personalizável com suporte para compiladores GCC e Clang.
-- **Link Time Optimization (LTO)**: Thin LTO ativado por predefinição para um melhor desempenho.
-- **Otimização Guiada por Perfil (PGO)**: Perfilagem AutoFDO + Propeller para uma geração de código ideal ([Saber mais](https://cachyos.org/blog/2411-kernel-autofdo/)).
+- **Link Time Optimization (LTO)**: Clang Thin LTO ativado por predefinição no pacote principal `linux-cachyos`
+- **Distributed ThinLTO**: Suporte para builds distribuídas do Clang ThinLTO para acelerar a compilação do kernel
+- **Otimização Guiada por Perfil (PGO)**: Perfilagem AutoFDO + Propeller no kernel padrão para geração de código ideal ([Saber mais](https://cachyos.org/blog/2411-kernel-autofdo/))
 - **Kernel Control Flow Integrity (kCFI)**: Disponível ao utilizar LLVM para maior segurança.
-- **Opções de Frequência de Temporizador (Timer)**: Configurável entre 300Hz, 500Hz, 600Hz, 750Hz e 1000Hz (predefinição: 1000Hz).
+- **Opções de Frequência de Temporizador (Timer)**: Configurável entre 100Hz, 250Hz, 300Hz, 500Hz, 600Hz, 750Hz e 1000Hz (predefinição: 1000Hz)
 - **Otimizações de Arquitetura**: Suporte para builds específicas de x86-64-v3, x86-64-v4 e AMD Zen4.
-- **Otimizações de Compilador**: Flags de GCC avançadas, incluindo `-fivopts` e `-fmodulo-sched`.
+- **Otimizações de Compilador**: Flags de GCC avançadas, incluindo `-fivopts` e `-fmodulo-sched`
+- **PREEMPT_DYNAMIC**: Modos de preempção selecionáveis em tempo de execução (full, lazy, voluntary, none)
 
 ### Melhorias de CPU
 
-- **Múltiplos Agendadores (Schedulers)**: Agendadores BORE, EEVDF e BMQ para diferentes otimizações de carga de trabalho.
+- **Múltiplos Agendadores (Schedulers)**: Agendadores BORE, EEVDF e BMQ para diferentes otimizações de carga de trabalho
+- **[POC Selector](https://github.com/masahitoS/scx_cake)**: Seletor rápido de CPU ociosa Piece-Of-Cake inspirado no scx_cake, reduzindo a latência de despertar
 - **Melhorias AMD P-State**: Suporte para "Preferred Core" e as mais recentes melhorias amd-pstate do linux-next.
 - **Suporte Real-Time**: Builds de kernel RT disponíveis com integração do agendador BORE.
 - **CachyOS Sauce**: Configuração personalizada `CONFIG_CACHY` com ajustes de agendador e de sistema.
-- **Otimizações de Baixa Latência**: Patches para melhor capacidade de resposta e redução de jitter.
+- **Otimizações de Baixa Latência**: Patches para melhor capacidade de resposta e redução de jitter
+- **sched/wait LIFO accept()**: Socket accept() processado em ordem LIFO para melhor eficiência de cache
+
+### Rede
+
+- **[BBR3 TCP](https://github.com/google/bbr)**: Controlo de congestionamento BBRv3 disponível como módulo separado juntamente com o BBRv1
 
 ### Sistema de Ficheiros e Memória
 
-- **Suporte ZFS**: Suporte nativo para o sistema de ficheiros ZFS com módulos pré-compilados.
-- **Integração NVIDIA**:
+- **Suporte ZFS**: Suporte nativo para o sistema de ficheiros ZFS com módulos pré-compilados
+- **Melhorias NTFS**: Correções do controlador NTFS upstream para validação de espelho MFT, verificação de limites de atributos e gestão de logfile
+- **Melhorias MGLRU**: Gestão melhorada de dirty writeback, estatísticas simplificadas de reclaim vmscan e ajuste Cachy Sauce MM (proteção do working set LRU-gen, ajustes de compaction/watermark, reclaim de hugepage)
   - Módulos de controlador proprietário NVIDIA com patches.
   - Suporte para controlador NVIDIA open-source.
   - Módulos prontos a usar no repositório.
 - **Melhorias no Agendador de I/O**:
   - Desempenho melhorado de BFQ e mq-deadline.
   - Suporte para o agendador de I/O alternativo [ADIOS](https://github.com/firelzrd/adios).
-- **Gestão de Memória**:
-  - Patch [le9uo](https://github.com/firelzrd/le9uo) para prevenir o "page thrashing" sob pressão de memória.
-  - Ajustes de gestão de memória do Zen-kernel (compactação, otimização de watermark).
+- **VRAM Cgroup (DMEM)**: Controlador de memória de dispositivo para restringir o uso de VRAM da GPU por cgroup no subsistema DRM
 
 ### Funcionalidades Adicionais
 
 #### Suporte de Hardware
-- **Hardware de Gaming**: Patches para Steam Deck (Áudio, HW Quirks, HID) e suporte para ROG Ally.
-- **Hardware Apple**: Suporte para MacBook T2 incluído por predefinição.
-- **Hardware ASUS**: Patches de compatibilidade alargada para hardware ASUS.
-- **Gráficos**: Suporte para HDR ativado, override de min_powercap em AMDGPU (`amdgpu_ignore_min_pcap`).
+- **AMD ISP4**: Novo controlador de câmara AMD ISP 4 para plataformas suportadas
+- **Hardware de Gaming**: Patches para Steam Deck (Áudio, HW Quirks, HID), suporte para ROG Ally e controlador HID MSI Claw (deckify)
+- **Hardware Apple**: Suporte para MacBook T2 com controlador apple-bce em staging
+- **Hardware ASUS**: Patches alargados de compatibilidade para hardware ASUS
+- **Hardware Lenovo**: Limitação de carga de bateria WMI, atributos ajustáveis de GPU/CPU e capdata debugfs
+- **Hardware HP**: Suporte para OMEN Slim e OMEN MAX laptop via hp-wmi
+- **Gráficos**: Suporte HDR ativado, override de min_powercap em AMDGPU (`amdgpu_ignore_min_pcap`)
+- **Ecrã**: HDMI VRR em AMD, propriedades ALLM e VRR passivo do conector, análise VESA DSC bits-per-pixel a partir do EDID
+- **Codecs de Áudio**: Suporte para codecs laterais HDA AW88399 e MAX98390
 
 #### Melhorias de Sistema
 - **Multimédia**: Módulos v4l2loopback incluídos por predefinição.

--- a/src/content/docs/pt/installation/desktop_environments.mdx
+++ b/src/content/docs/pt/installation/desktop_environments.mdx
@@ -1,6 +1,7 @@
 ---
 title: Ambientes de Desktop
 description: Ambientes de Desktop fornecidos pelo CachyOS
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
@@ -16,7 +17,7 @@ Por favor, selecione apenas um Ambiente de Desktop durante a instalação.
 As opções disponíveis são:
 
 1. **KDE Plasma:** um ambiente de desktop abrangente e flexível que oferece vários estilos de menus para aceder a aplicações. Inclui o gestor de janelas KWin. O KDE Plasma também possui uma interface intuitiva que permite descarregar e instalar facilmente novos temas, widgets e muito mais a partir da web.
-2. **Niri:** um compositor Wayland de mosaico (tiling) rolável que enfatiza a simplicidade e a gestão de janelas fluida. Utiliza um layout de grelha contínua, otimizado tanto para navegação por teclado como por touchpad. Encontre os nossos [dotfiles do Niri](https://github.com/CachyOS/cachyos-niri-settings).
+2. **Niri:** um compositor Wayland de mosaico (tiling) rolável que enfatiza a simplicidade e a gestão de janelas fluida. Utiliza um layout de grelha contínua, otimizado tanto para navegação por teclado como por touchpad. Encontre os nossos [dotfiles do Niri](https://github.com/CachyOS/cachyos-niri-noctalia).
 3. **i3:** um popular gestor de janelas tiling para X11, conhecido pelo seu ficheiro de configuração único e autónomo e pela sua utilização eficiente do espaço no ecrã. Encontre os nossos [dotfiles do i3 aqui](https://github.com/CachyOS/cachyos-i3wm-settings).
 4. **Qtile:** um gestor de janelas X11/Wayland configurado com a linguagem de programação Python. Oferece vários layouts e widgets. Encontre os nossos [dotfiles aqui](https://github.com/CachyOS/cachyos-qtile-settings).
 5. **Wayfire:** um compositor Wayland baseado no wlroots que equilibra personalização, extensibilidade e estética. Encontre os nossos [dotfiles do Wayfire](https://github.com/CachyOS/cachyos-wayfire-settings).
@@ -26,13 +27,12 @@ As opções disponíveis são:
 9. **Budgie:** um ambiente de desktop simples e elegante construído com o toolkit GTK. Foi desenhado para fornecer uma interface moderna e atraente, fácil de usar e altamente configurável.
 10. **Cinnamon:** um ambiente de desktop para Linux que equilibra funcionalidades avançadas com uma experiência de utilizador tradicional.
 11. **Cosmic:** um ambiente de desktop moderno e orientado para a performance, construído com Rust e Smithay. Desenhado para produtividade e utilizadores avançados, visa oferecer funcionalidades avançadas mantendo uma interface limpa e intuitiva.
-12. **Hyprland:** um compositor Wayland visualmente apelativo que utiliza mosaico dinâmico.
+12. **Hyprland:** um compositor Wayland visualmente apelativo que utiliza mosaico dinâmico. Vem com CachyOS Noctalia por predefinição. Veja os nossos dotfiles [aqui](https://github.com/CachyOS/cachyos-hypr-noctalia).
 13. **LXDE** (Lightweight X11 Desktop Environment): um ambiente de desktop rápido e económico em energia, desenhado para computadores antigos e sistemas com poucos recursos. Utiliza o Openbox como gestor de janelas padrão e foca-se numa interface simples, limpa e fácil de usar.
 14. **LXQt:** um ambiente de desktop leve formado pela fusão dos projetos LXDE e Razor-qt, construído com Qt.
 15. **Mate Desktop:** um ambiente de desktop tradicional derivado do GNOME 2. Caracteriza-se pelo seu visual clássico, com uma interface de utilizador simples e intuitiva. O Mate oferece uma experiência de desktop personalizável para utilizadores que preferem o aspeto clássico.
 16. **Openbox:** um gestor de janelas X11 altamente popular, conhecido pela sua excelente documentação e vasta seleção de temas disponíveis.
 17. **Sway:** um compositor Wayland de mosaico e substituto direto para o gestor de janelas i3 do X11. Funciona com a sua configuração atual do i3 e suporta a maioria das funcionalidades do mesmo, com alguns extras.
-18. **UKUI:** um ambiente de desktop leve, eficiente e que funciona bem em computadores antigos. Utiliza tecnologias GTK e Qt, e tem uma aparência visual semelhante ao Windows 7, tornando-o amigável para novos utilizadores de Linux.
 
 ## Capturas de Ecrã (Screenshots)
 
@@ -63,6 +63,11 @@ As opções disponíveis são:
 
 <br />
 <ImageComponent imgsrc={import('~/assets/images/niri.jpg')} />
+
+### Hyprland
+
+<br />
+<ImageComponent imgsrc={import('~/assets/images/hyprland.png')} />
 
 ### Qtile
 

--- a/src/content/docs/pt/installation/installation_handheld.mdx
+++ b/src/content/docs/pt/installation/installation_handheld.mdx
@@ -1,9 +1,10 @@
 ---
 title: Edição Handheld
 description: Como instalar o CachyOS em dispositivos portáteis (Handhelds)
+ai_translated: true
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 O CachyOS disponibiliza uma edição para dispositivos portáteis, como a Steam Deck, ROG Ally e Legion Go. Esta edição oferece uma experiência semelhante ao SteamOS com a funcionalidade de alternar para o "Game Mode", aplicações de jogo pré-instaladas e muito mais.
 
@@ -20,7 +21,7 @@ A Edição Handheld utiliza o `limine` como gestor de arranque com snapshots aut
 
 1. **Descarregue** o ISO Handheld mais recente a partir do website/fórum.
 
-2. [Grave (Flash)](/installation/installation_prepare) o ISO.
+2. [Grave (Flash)](/pt/installation/installation_prepare) o ISO.
 
 3. **Inicie (Boot)** o dispositivo através do ISO.
 
@@ -44,7 +45,7 @@ O primeiro arranque pode demorar um pouco, uma vez que o Steam está a ser desca
 
 1. **Descarregue** o ISO Handheld mais recente a partir do website/fórum.
 
-2. [Grave (Flash)](/installation/installation_prepare) o ISO.
+2. [Grave (Flash)](/pt/installation/installation_prepare) o ISO.
 
 3. **Inicie (Boot)** o dispositivo através do ISO.
 
@@ -52,11 +53,33 @@ O primeiro arranque pode demorar um pouco, uma vez que o Steam está a ser desca
 
 5. O Calamares irá abrir. Siga as instruções no ecrã.
 
-6. No passo de particionamento, deve selecionar **Manual Partition** (Particionamento Manual) e criar as seguintes partições:
+6. No passo de particionamento, deve selecionar **Manual Partition** (Particionamento Manual) e criar as seguintes partições dependendo do seu gestor de arranque:
 
-    - 2GB /boot
-    - XGB / (X pode ser qualquer quantidade de espaço que deseje alocar para o sistema de ficheiros raiz)
-
+    Uma partição de arranque:
+    <Tabs>
+    <TabItem label='Limine'>
+    - ##### Tamanho: Pelo menos **4096 MiB**
+    - ##### Sistema de Ficheiros: **FAT32**
+    - ##### Ponto de montagem: **/boot**
+    - ##### Flags: **boot**
+    Uma partição root:
+    - ##### Tamanho: Pelo menos **20000 MiB**
+    - ##### Sistema de Ficheiros: **BTRFS**
+    - ##### Ponto de montagem: **/**
+    - ##### Flags:
+    </TabItem>
+    <TabItem label='systemd-boot'>
+    - ##### Tamanho: Pelo menos **2048 MiB**
+    - ##### Sistema de Ficheiros: **FAT32**
+    - ##### Ponto de montagem: **/boot**
+    - ##### Flags: **boot**
+    Uma partição root:
+    - ##### Tamanho: Pelo menos **20000 MiB**
+    - ##### Sistema de Ficheiros: **BTRFS**
+    - ##### Ponto de montagem: **/**
+    - ##### Flags:
+    </TabItem>
+    </Tabs>
 7. Prossiga com os passos seguintes e instale o sistema.
 
 </Steps>

--- a/src/content/docs/pt/installation/installation_on_root.mdx
+++ b/src/content/docs/pt/installation/installation_on_root.mdx
@@ -6,6 +6,7 @@ sidebar:
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -20,7 +21,7 @@ Se apenas visualizar o GRUB e o Limine como opções de gestor de arranque após
 :::
 
 :::caution[O Secure Boot e o CSM devem estar desativados nas definições da BIOS/UEFI ao instalar em modo UEFI.]
-Para configurar o Secure Boot após a instalação, consulte a secção [Secure Boot](/configuration/secure_boot_setup).
+Para configurar o Secure Boot após a instalação, consulte a secção [Secure Boot](/pt/configuration/secure_boot_setup).
 
 A opção `Legacy USB Support` deve ser definida como `Auto`.
 :::
@@ -32,7 +33,7 @@ O `Manual partitioning` (Particionamento manual) é **fortemente preferido** ao 
 :::
 
 :::tip
-É altamente recomendável reiniciar o ISO após uma tentativa de instalação falhada.
+É altamente recomendável reiniciar no ISO após uma tentativa de instalação falhada.
 
 Caso contrário, podem ocorrer erros contínuos durante o processo de instalação.
 
@@ -47,16 +48,14 @@ Isto acontece porque o instalador não desmonta corretamente as partições numa
     ```sh title='Execute este comando no terminal'
     efibootmgr -v
     ```
-Se a mensagem de saída for `EFI variables are not supported on this system.`, então o sistema foi iniciado em modo Legacy/BIOS e deve garantir que o modo UEFI está configurado nas definições da BIOS/UEFI. Consulte a secção de [Requisitos](/installation/installation_on_root/#before-you-begin).
+Se a mensagem de saída for `EFI variables are not supported on this system.`, então o sistema foi iniciado em modo Legacy/BIOS e deve garantir que o modo UEFI está configurado nas definições da BIOS/UEFI. Consulte a secção de [Requisitos](/pt/installation/installation_on_root/#antes-de-começar).
 :::
-
-#### UEFI/GPT
-
-A tabela de partições varia para cada gestor de arranque. Siga as instruções para o gestor de arranque pretendido.
 
 <Tabs>
 
-<TabItem label='systemd-boot & rEFInd'>
+A tabela de partições para cada gestor de arranque varia. Siga as instruções no **Passo 5** para o gestor de arranque pretendido.
+
+<TabItem label='UEFI/GPT'>
 
 <Steps>
 
@@ -68,19 +67,35 @@ A tabela de partições varia para cada gestor de arranque. Siga as instruções
 
 4. Selecione **Manual partitioning** (Particionamento manual).
 
-5. Crie uma nova partição com o seguinte:
-   - ##### Tamanho: **2048 MiB**
-   - ##### Sistema de Ficheiros: **FAT32**
-   - ##### Ponto de montagem: **/boot**
-   - ##### Flags: **boot**
+5. Crie uma nova partição com os seguintes parâmetros dependendo do gestor de arranque de eleição:
+    <Tabs>
+        <TabItem label='Limine'>
+            - ##### Tamanho: Pelo menos **4096 MiB**
+            - ##### Sistema de Ficheiros: **FAT32**
+            - ##### Ponto de montagem: **/boot**
+            - ##### Flags: **boot**
+        </TabItem>
+        <TabItem label='systemd-boot & rEFInd'>
+            - ##### Tamanho: Pelo menos **2048 MiB**
+            - ##### Sistema de Ficheiros: **FAT32**
+            - ##### Ponto de montagem: **/boot**
+            - ##### Flags: **boot**
+        </TabItem>
+        <TabItem label='GRUB'>
+            - ##### Tamanho: Pelo menos **512 MiB**
+            - ##### Sistema de Ficheiros: **FAT32**
+            - ##### Ponto de montagem: **/boot/efi**
+            - ##### Flags: **boot**
+        </TabItem>
+    </Tabs>
 
 6. Crie outra partição para a **raiz (root)**:
    - ##### Tamanho: Pelo menos **20000 MiB**
-   - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/installation/filesystem)
+   - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/pt/installation/filesystem)
    - ##### Ponto de montagem: **/**
    - ##### Flags:
 
-7. Selecione o [Ambiente de Desktop](/installation/desktop_environments) de eleição.
+7. Selecione o [Ambiente de Desktop](/pt/installation/desktop_environments) de eleição.
 
 8. Escolha quais os pacotes que devem ser instalados durante o processo de instalação.
 
@@ -92,12 +107,7 @@ A tabela de partições varia para cada gestor de arranque. Siga as instruções
 
 </TabItem>
 
-<TabItem label='Limine'>
-
-:::note
-Em ambientes com espaço de armazenamento limitado, como máquinas virtuais, o tamanho da partição /boot pode ser reduzido para 2048MiB.
-:::
-
+<TabItem label='MBR/BIOS'>
 <Steps>
 
 1. Inicie o ISO e clique em **Launch Installer**.
@@ -106,95 +116,31 @@ Em ambientes com espaço de armazenamento limitado, como máquinas virtuais, o t
 
 3. Configure o **Layout do Teclado**.
 
-4. Selecione **Manual partitioning**.
+4. Selecione **Manual partitioning** (Particionamento manual).
 
-5. Crie uma nova partição com o seguinte:
-   - ##### Tamanho: **4192 MiB**
-   - ##### Sistema de Ficheiros: **FAT32**
-   - ##### Ponto de montagem: **/boot**
-   - ##### Flags: **boot**
-
-6. Crie outra partição para a **raiz (root)**:
-   - ##### Tamanho: Pelo menos **20000 MiB**
-   - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/installation/filesystem)
-   - ##### Ponto de montagem: **/**
-   - ##### Flags:
-
-7. Selecione o [Ambiente de Desktop](/installation/desktop_environments) de eleição.
-
-8. Escolha quais os pacotes que devem ser instalados durante o processo de instalação.
-
-9. Configure as credenciais de login.
-
-10. Reveja cuidadosamente o resumo da instalação. Prossiga com a instalação clicando em **Install Now** se tudo estiver correto. Caso contrário, volte atrás e faça as alterações necessárias.
-
-</Steps>
-
-</TabItem>
-
-<TabItem label='GRUB'>
-
-<Steps>
-
-1. Inicie o ISO e clique em **Launch Installer**.
-
-2. Defina o **Idioma** e **Região/Fuso Horário** preferidos.
-
-3. Configure o **Layout do Teclado**.
-
-4. Selecione **Manual partitioning**.
-
-5. Crie uma nova partição com o seguinte:
-    - ##### Tamanho: Pelo menos **512 MiB**
-    - ##### Sistema de Ficheiros: **FAT32**
-    - ##### Ponto de montagem: **/boot/efi**
-    - ##### Flags: **boot**
-
-6. Crie outra partição para a **raiz (root)**:
-    - ##### Tamanho: Pelo menos **20000 MiB**
-    - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/installation/filesystem)
-    - ##### Ponto de montagem: **/**
-    - ##### Flags:
-
-7. Selecione o [Ambiente de Desktop](/installation/desktop_environments) de eleição.
-
-8. Escolha quais os pacotes que devem ser instalados durante o processo de instalação.
-
-9. Configure as credenciais de login.
-
-10. Reveja cuidadosamente o resumo da instalação. Prossiga com a instalação clicando em **Install Now** se tudo estiver correto. Caso contrário, volte atrás e faça as alterações necessárias.
-
-</Steps>
-
-</TabItem>
-
-</Tabs>
-
-#### MBR/BIOS
-
-<Tabs>
-
-<TabItem label='GRUB'>
-
-<Steps>
-
-1. Inicie o ISO e clique em **Launch Installer**.
-
-2. Defina o **Idioma** e **Região/Fuso Horário** preferidos.
-
-3. Configure o **Layout do Teclado**.
-
-4. Selecione **Manual partitioning**.
-
-5. Crie uma nova partição com o seguinte:
-    - ##### Tamanho: Pelo menos **20000 MiB**
-    - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/installation/filesystem)
-    - ##### Ponto de montagem: **/**
-    - ##### Flags:
-
+5. Crie uma nova partição com os seguintes parâmetros dependendo do gestor de arranque de eleição:
+    <Tabs>
+        <TabItem label='GRUB'>
+            - ##### Tamanho: Pelo menos **20000 MiB**
+            - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/pt/installation/filesystem)
+            - ##### Ponto de montagem: **/**
+            - ##### Flags:
+        </TabItem>
+        <TabItem label='Limine'>
+            - ##### Tamanho: Pelo menos **4096 MiB**
+            - ##### Sistema de Ficheiros: **FAT32**
+            - ##### Ponto de montagem: **/boot**
+            - ##### Flags: **boot**
+            **É necessária outra partição para o sistema de ficheiros root com os seguintes parâmetros:**
+            - ##### Tamanho: Pelo menos **20000 MiB**
+            - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/pt/installation/filesystem)
+            - ##### Ponto de montagem: **/**
+            - ##### Flags:
+        </TabItem>
+    </Tabs>
 6. Verifique duas vezes se a opção **Install boot loader on:** está a apontar para o seu disco de arranque, por ex., **/dev/sda**.
 
-7. Selecione o [Ambiente de Desktop](/installation/desktop_environments) de eleição.
+7. Selecione o [Ambiente de Desktop](/pt/installation/desktop_environments) de eleição.
 
 8. Escolha quais os pacotes que devem ser instalados durante o processo de instalação.
 
@@ -206,75 +152,7 @@ Em ambientes com espaço de armazenamento limitado, como máquinas virtuais, o t
 
 </TabItem>
 
-<TabItem label='Limine'>
-
-:::note
-Em ambientes com espaço de armazenamento limitado, como máquinas virtuais, o tamanho da partição /boot pode ser reduzido para 2048MiB.
-:::
-
-<Steps>
-
-1. Inicie o ISO e clique em **Launch Installer**.
-
-2. Defina o **Idioma** e **Região/Fuso Horário** preferidos.
-
-3. Configure o **Layout do Teclado**.
-
-4. Selecione **Manual partitioning**
-
-5. Crie uma nova partição com o seguinte:
-    - ##### Tamanho: Pelo menos **4192 MiB**
-    - ##### Sistema de Ficheiros: **FAT32**
-    - ##### Ponto de montagem: **/boot**
-    - ##### Flags: **boot**
-
-6. Crie outra partição para a **raiz (root)**:
-    - ##### Tamanho: Pelo menos **20000 MiB**
-    - ##### Sistema de Ficheiros: **Qualquer**, consulte [Sistema de Ficheiros](/installation/filesystem)
-    - ##### Ponto de montagem: **/**
-    - ##### Flags:
-
-7. Verifique duas vezes se a opção **Install boot loader on:** está a apontar para o seu disco de arranque, por ex., **/dev/sda**.
-
-8. Selecione o [Ambiente de Desktop](/installation/desktop_environments) de eleição.
-
-9. Escolha quais os pacotes que devem ser instalados durante o processo de instalação.
-
-10. Configure as credenciais de login.
-
-11. Reveja cuidadosamente o resumo da instalação. Prossiga com a instalação clicando em **Install Now** se tudo estiver correto. Caso contrário, volte atrás e faça as alterações necessárias.
-
-</Steps>
-
-</TabItem>
-
 </Tabs>
-
-### Erase Disk (Apagar Disco)
-
-A opção **Erase Disk** no Calamares irá apagar o disco selecionado e instalar o CachyOS no destino.
-
-<Steps>
-
-1. Inicie o ISO e clique em **Launch Installer**.
-
-2. Selecione o [Gestor de Arranque](/installation/boot_managers) preferido.
-
-3. Defina o **Idioma** e **Região/Fuso Horário** preferidos.
-
-4. Configure o **Layout do Teclado**.
-
-5. Selecione **Erase Disk** e escolha um [Sistema de Ficheiros](/installation/filesystem).
-
-6. Selecione o [Ambiente de Desktop](/installation/desktop_environments) de eleição.
-
-7. Escolha quais os pacotes que devem ser instalados durante o processo de instalação.
-
-8. Configure as credenciais de login.
-
-9. Reveja cuidadosamente o resumo da instalação. Prossiga com a instalação clicando em **Install Now** se tudo estiver correto. Caso contrário, volte atrás e faça as alterações necessárias.
-
-</Steps>
 
 ## Dual Boot entre Windows e CachyOS
 
@@ -289,9 +167,9 @@ Uma forma de evitar este problema é instalar cada sistema operativo num disco s
 :::
 
 :::caution
-A partição EFI pode precisar de ser redimensionada, dependendo do tamanho mínimo recomendado para o gestor de arranque de destino. Consulte [Particionamento Manual](/installation/installation_on_root#manual-partitioning).
+A partição EFI pode precisar de ser redimensionada, dependendo do tamanho mínimo recomendado para o gestor de arranque de destino. Consulte [Particionamento Manual](/pt/installation/installation_on_root#particionamento-manual).
 
-Sistemas de ficheiros FAT não podem ser redimensionados "in-place" (no local). Para redimensionar corretamente a partição EFI em FAT, deve-se fazer uma cópia de segurança do sistema de ficheiros EFI existente, usar uma ferramenta como o `gparted` para redimensionar a partição existente e formatar a nova partição, e depois copiar a estrutura de ficheiros anterior de volta para a partição EFI.
+Sistemas de ficheiros FAT não podem ser redimensionados "in-place" (no local). Para redimensionar corretamente a partição EFI em FAT, deve-se fazer uma cópia de segurança do sistema de ficheiros EFI existente, usar uma ferramenta como o `gparted` para redimensionar a partição existente e reformatar a nova partição, e depois copiar a estrutura de ficheiros anterior de volta para a partição EFI.
 :::
 
 ### Pré-requisitos
@@ -315,9 +193,15 @@ Sistemas de ficheiros FAT não podem ser redimensionados "in-place" (no local). 
     - Identifique a sua partição principal do Windows (geralmente C:) e clique nela com o botão direito.
     - Clique em `Shrink Volume...` (Reduzir Volume...), especifique pelo menos **30720 MB** (30 GiB) e clique em `Shrink` (Reduzir).
 - Um USB de arranque com o CachyOS.
-  - Consulte a secção [Criar uma Unidade USB de Arranque do CachyOS](/installation/installation_prepare#creating-a-bootable-cachyos-usb-drive).
+  - Consulte a secção [Criar uma Unidade USB de Arranque do CachyOS](/pt/installation/installation_prepare#creating-a-bootable-cachyos-usb-drive).
 
 <Tabs>
+    <TabItem label='Limine'>
+        O Limine deverá detetar automaticamente a partição EFI do Windows e adicioná-la ao menu de arranque. Se o Windows não aparecer no menu de arranque, execute o seguinte comando:
+        ```bash
+        sudo limine-scan
+        ```
+    </TabItem>
     <TabItem label='systemd-boot'>
         **Precisamos de copiar os binários EFI do Windows para a partição EFI do Linux para que o gestor de arranque os possa reconhecer.**
 
@@ -363,7 +247,9 @@ Sistemas de ficheiros FAT não podem ser redimensionados "in-place" (no local). 
         </Steps>
     </TabItem>
 
-    <TabItem label='GRUB'>
+    <TabItem label='GRUB (Apenas para instalações mais antigas)'>
+        :::tip[O CachyOS ativa o os-prober por predefinição.]
+        :::
         **O GRUB utiliza o os-prober para detetar automaticamente a partição EFI do Windows e adicioná-la ao menu de arranque.**
 
         <Steps>
@@ -378,10 +264,10 @@ Sistemas de ficheiros FAT não podem ser redimensionados "in-place" (no local). 
             ```sh title='Prima CTRL+S para guardar e CTRL+Q para sair do Micro'
             sudo micro /etc/default/grub
             # /etc/default/grub
-            # A procura por outros sistemas operativos está desativada por razões de segurança. Leia
-            # a documentação sobre GRUB_DISABLE_OS_PROBER, se ainda desejar ativar esta
-            # funcionalidade instale o os-prober e retire o comentário para detetar e incluir outros
-            # sistemas operativos.
+            # Probing for other operating systems is disabled for security reasons. Read
+            # documentation on GRUB_DISABLE_OS_PROBER, if still want to enable this
+            # functionality install os-prober and uncomment to detect and include other
+            # operating systems.
             GRUB_DISABLE_OS_PROBER=false
 
             ```

--- a/src/content/docs/pt/installation/installation_t2macbook.mdx
+++ b/src/content/docs/pt/installation/installation_t2macbook.mdx
@@ -1,6 +1,7 @@
 ---
 title: MacBook T2
 description: Como instalar o CachyOS num MacBook T2
+ai_translated: true
 ---
 
 import { Steps } from '@astrojs/starlight/components';
@@ -21,7 +22,7 @@ Execute os passos abaixo dentro do macOS **antes** de iniciar o instalador do Ca
 
 ### Preparar a Unidade USB de Arranque do CachyOS
 
-Descarregue o [ISO do CachyOS](/cachyos_basic/download) e siga as instruções em [Criar uma Unidade USB de Arranque do CachyOS](/installation/installation_prepare#creating-a-bootable-cachyos-usb-drive) para criar o suporte de instalação.
+Descarregue o [ISO do CachyOS](/pt/cachyos_basic/download) e siga as instruções em [Criar uma Unidade USB de Arranque do CachyOS](/pt/installation/installation_prepare#creating-a-bootable-cachyos-usb-drive) para criar o suporte de instalação.
 
 ### (Opcional) Extrair o Firmware do Wi-Fi
 
@@ -99,12 +100,12 @@ Para uma visão geral adicional sobre a preparação de um Mac T2 para Linux, co
     * Deverá agora conseguir ligar-se a redes Wi-Fi através do ícone de rede na barra de sistema.
 3.  **Executar o Instalador do CachyOS:**
     * Inicie o instalador do CachyOS a partir do ambiente de trabalho ou do menu de aplicações.
-    * Siga o procedimento de instalação padrão, consultando o guia [Instalação na Raiz (Root)](/installation/installation_on_root).
+    * Siga o procedimento de instalação padrão, consultando o guia [Instalação na Raiz (Root)](/pt/installation/installation_on_root).
     * Ao particionar, selecione o espaço livre criado anteriormente. Deixe o instalador tratar da formatação.
         :::caution[Cuidado com o Particionamento]
         Seja **muito cuidadoso** durante o passo de particionamento no instalador. Certifique-se de que está a selecionar o espaço livre correto que preparou e **não** apague ou formate acidentalmente a sua partição macOS existente, especialmente se pretender manter o dual-boot. Verifique bem as suas seleções antes de prosseguir.
         :::
-    * A Deteção de Hardware do CachyOS ([chwd](/features/chwd/chwd)) deverá aplicar automaticamente os parâmetros de arranque e configurações específicas para T2 durante a instalação.
+    * A Deteção de Hardware do CachyOS ([chwd](/pt/features/chwd/chwd)) deverá aplicar automaticamente os parâmetros de arranque e configurações específicas para T2 durante a instalação.
 
 </Steps>
 


### PR DESCRIPTION
# Updating languages with local AI: Portuguese

As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

This is the second language by priority after Russian. Next I'll do Spanish, after that Chinese since you might argue Chinese is more important, but that's a whole new language so updating Russian, Portuguese and Spanish is first on my priority.

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one to spot syntax errors and if things are or aren't translated.

## As I have strong critical opinions on AI-use myself, I want the process to be ran on local hardware and as transparent as possible, which is why I'm listing prompt, model, soft- and hardware that were used. Feel free to suggest any changes or request any clarification of my approach.

### Prompt used:
"Today we are going to translate technical documentation for the CachyOS wiki (Arch-based Linux distro).

TRANSLATION RULES:

TRANSLATE:
- Body text and explanatory content
- Headings, titles, section labels
- UI labels (TabItem labels, button text, etc.)
- Link display text (visible text, not the URL itself)
- Explanatory comments (in code blocks and around terminal output)

DO NOT TRANSLATE:
- Actual commands and code
- Terminal output
- Program/package/file names and paths (pacman, gcc, /etc/pacman.conf, etc.)
- URLs
- Technical terms (bootloader, kernel, PGO, LTO, BOLT, etc.)
- External link URLs

GOAL: Translate the context so a native reader understands what to do, without over-translating. Users are expected to know basic Linux concepts by their English names.

INTERNAL LINKS: English files live at /src/content/docs/<path>.mdx, translations at /src/content/docs/<lang-code>/<path>.mdx. When a link points to another wiki page, add the language code (e.g., /ru/installation/...) so users stay on the translated site. External links stay unchanged.

UPDATING EXISTING TRANSLATIONS:
- Translated pages usually exist but are outdated; keep existing translation for unchanged content
- Apply all differences from English: add new content, remove deleted content, update changed content
- Minimal changes only; do not rewrite unchanged sections
- Match English formatting EXACTLY: same line breaks, same punctuation marks (' stays ', not ` or "), same spacing

Now, translate/update the English file <path/to/English/file> to Portuguese at <path/to/Portuguese/file>."

### Model used:
[A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

### Software used:
My own AUR packages [llama.cpp-sycl](https://github.com/cantosun99/llama.cpp-sycl) and [intel-deep-learning-essentials](https://github.com/cantosun99/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

### Hardware used:
Sparkle Intel Arc Pro B70 with 32GB VRAM
