### PR TITLE
Update Spanish translation

### DIFF
--- a/src/content/docs/es/cachyos_basic/faq.mdx
+++ b/src/content/docs/es/cachyos_basic/faq.mdx
@@ -4,17 +4,20 @@ description: Preguntas frecuentes y consejos
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 5
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 :::note
-Las siguientes preguntas y respuestas se aplican a CachyOS y a distribuciones basadas en Arch. `Esto no pretende reemplazar la información de la Arch Linux Wiki`
+Las siguientes preguntas y respuestas se aplican a CachyOS y a distribuciones basadas en Arch.
+
+**Esto no pretende reemplazar la información de la Arch Linux Wiki.**
 :::
 
 :::tip
-Mantente alerta a cualquier anuncio oficial de CachyOS en nuestro [Foro](https://discuss.cachyos.org/c/announcements/8), publicación de Reddit en nuestro [subreddit oficial](https://www.reddit.com/r/cachyos/) o en Discord en [#announcements](https://discord.com/channels/862292009423470592/873309651364610118) y [#updates-repo](https://discord.com/channels/862292009423470592/871739561364033566) sobre problemas conocidos con un paquete o actualizaciones que requieran intervención manual.
+Mantente alerta a cualquier anuncio oficial de CachyOS en nuestro [Foro](https://discuss.cachyos.org/c/announcements/5), publicación de Reddit en nuestro [subreddit oficial](https://www.reddit.com/r/cachyos/) o en [Discord #announcements](https://discord.com/channels/862292009423470592/873309651364610118) y [#updates-repo](https://discord.com/channels/862292009423470592/871739561364033566) sobre problemas conocidos con un paquete o actualizaciones que requieran intervención manual.
 :::
 
 ## Cómo reportar un problema o error a CachyOS
@@ -43,13 +46,13 @@ tldr git add
 ```
 :::
 
-### Lugares para reportar
+### Lugares para abrir reportes
 
 - [Github](https://github.com/CachyOS/distribution)
 - [Foro](https://discuss.cachyos.org/c/feedback/bugreports/10)
 - **Discord:** [Foro de Soporte](https://discord.com/channels/862292009423470592/1400865136373403708)
-  - Antes de crear una nueva publicación. Por favor, asegúrate de leer las [Directrices e Información de Soporte](https://discord.com/channels/862292009423470592/1402210965700739082) fijadas en el canal.
-    - O si crees que tu problema se puede resolver rápidamente, usa el canal [#support](https://discord.com/channels/862292009423470592/862294383470051348)
+  - Antes de crear una nueva publicación, lee las [directrices de soporte](https://discord.com/channels/862292009423470592/1522310323250397274) fijadas en el canal.
+    - O, si crees que tu problema se puede resolver rápidamente, usa el [canal #support](https://discord.com/channels/862292009423470592/862294383470051348)
 - [Reddit](https://www.reddit.com/r/cachyos/)
 
 ### Sé paciente y respetuoso
@@ -75,10 +78,10 @@ Aquí hay un par de cosas que deberías preguntarte:
 
 - ¿Qué es lo que no funciona?
 - ¿Bajar de versión el paquete X soluciona el problema?
-- Usa la función de búsqueda para encontrar problemas similares
+- ¿Otras personas experimentan este problema / ya se ha resuelto antes? (usa la función de búsqueda)
 - ¿El problema apareció después de una actualización?
 - ¿Has hecho modificaciones por tu cuenta?
-  - Ejemplo: `Añadir una bandera adicional en un archivo modprobe`
+  - Ejemplo: añadir una bandera adicional en un archivo modprobe
 - ¿Está relacionado con el hardware? (ej. GPU, WiFi, etc.)
 - ¿Está relacionado con el software? (ej. aplicación específica, entorno de escritorio, etc.)
 - ¿Es una instalación nueva o el problema apareció después de un tiempo de uso?
@@ -88,32 +91,34 @@ Aquí hay un par de cosas que deberías preguntarte:
 Hay muchas maneras de recopilar registros de tu sistema. Aquí hay un par de ejemplos y herramientas que puedes usar:
 
 ### Creando un reporte de error general
-- CachyOS proporciona una gran herramienta para recopilar registros del sistema llamada `cachyos-bugreport.sh`.
-  - Esta herramienta recopilará registros de:
-    - `dmesg`
-    - `journalctl`
-    - `inxi` (Para recopilar información de hardware)
-  - Cuando se recopilen los registros, se le preguntará al usuario si desea subirlos a nuestro sitio web de pegado.
-  - Ejecuta el siguiente comando en la terminal y pega el enlace con los errores en el tema:
-    ```sh
-    sudo cachyos-bugreport.sh
-    ```
+CachyOS proporciona una gran herramienta para recopilar registros del sistema llamada `cachyos-bugreport.sh`.
+Esta herramienta recopilará registros de:
+  - `dmesg`
+  - `journalctl`
+  - `inxi` (Para recopilar información de hardware)
+
+Después de recopilar los registros, se le pedirá al usuario que decida si desea subirlos a nuestro sitio web de pegado.
+
+Para ejecutar este script, ingresa el siguiente comando en la terminal y comparte el enlace generado en tu reporte:
+  ```sh
+  sudo cachyos-bugreport.sh
+  ```
 
 ### Recopilando registros de un programa que no se inicia
-- El programa X ya no se inicia:
-  - Hay muchas razones por las que un programa gráfico podría no iniciarse. La mejor manera de recopilar registros para este tipo de problema es ejecutar el programa desde una terminal. De esta manera, puedes ver cualquier mensaje de error o salida que pueda ayudar a diagnosticar el problema.
-  - Ejemplo:
-    ```sh
-    firefox
-    ```
-    - Si Firefox no se inicia, podrías ver un mensaje de error en la terminal que puede ayudar a identificar el problema.
-    :::tip
-    Si quieres guardar la salida en un archivo de texto para compartirla más fácilmente, puedes redirigir la salida de esta manera:
+Hay muchas razones por las que un programa gráfico podría no iniciarse. La mejor manera de recopilar registros para este tipo de problema es ejecutar el programa desde una terminal. De esta manera, puedes ver cualquier mensaje de error o salida que pueda ayudar a diagnosticar el problema.
+
+Por ejemplo, si Firefox no se inicia completamente, intenta iniciarlo desde la terminal y busca mensajes de error:
+  ```sh
+  firefox
+  ```
+
+:::tip
+  Si quieres guardar la salida en un archivo de texto para compartirla más fácilmente, puedes redirigir la salida de esta manera:
     ```sh
     firefox &> firefox-log.txt
     ```
-    Recuerda presionar `CTRL + C` para terminar el proceso después de que falle al iniciarse para que la terminal escriba la salida en el archivo.
-    :::
+  Recuerda presionar `CTRL + C` para terminar el proceso después de que falle al iniciarse para que la terminal escriba la salida en el archivo.
+:::
 
 ### Comprobar los últimos paquetes actualizados en pacman.
 
@@ -129,17 +134,15 @@ Ajusta el parámetro `-n` de tail para obtener más o menos líneas.
 
 ### Atajos de teclado para navegar en journalctl y dmesg
 
-Los atajos de teclado más comunes para navegar por los registros cuando se usa el modo `less` o legible por humanos:
+Los atajos de teclado más comunes para navegar por los registros cuando se usa `less` o el modo legible por humanos:
 
-`Teclas de Flecha`: para moverse hacia arriba y abajo línea por línea.
+`ArrowUp & ArrowDown or J & K` para desplazarse hacia arriba o abajo línea por línea.
 
-`Av Pág y Re Pág o Ctrl + A/D`: para desplazarse hacia abajo o hacia arriba una página a la vez.
+`PageUp & PageDown or Ctrl + B/D` para desplazarse hacia arriba o abajo una página a la vez.
 
-`j & k`: para moverse hacia abajo o hacia arriba línea por línea (similar a Vim).
+`G or Home` para saltar al principio del registro.
 
-`g o Inicio`: para saltar al principio del registro.
-
-`Shift + G o Fin`: para saltar al final del registro.
+`Shift + G or End` para saltar al final del registro.
 
 ### Usando journalctl para recopilar registros del sistema
 
@@ -551,10 +554,10 @@ Por eso puede tardar un poco en cargar el instalador.
 
 Esto sucede cuando el instalador tiene dificultades para descargar paquetes. Suele ser una señal de una conexión a internet muy lenta o inestable. Por favor, revisa tu conexión de red e inténtalo de nuevo.
 
-## Recuperación del Gestor de Arranque e Instantáneas de Btrfs
+## Recuperación del Gestor de Arranque
 
 :::note
-En caso de que la partición `/boot` haya sido eliminada, por favor cree una nueva siguiendo el [esquema de particionado](/es/installation/installation_on_root#uefigpt) correspondiente a partir del paso 5.
+En caso de que la partición `/boot` haya sido eliminada, por favor crea una nueva siguiendo el [esquema de particionado](/es/installation/installation_on_root#uefigpt) correspondiente a partir del paso 5.
 :::
 
 ### Pasos para recuperar tu gestor de arranque
@@ -633,28 +636,6 @@ Si no estás seguro de cómo usar `cachy-chroot`, por favor consulta primero la 
         ```
     6. Reinicia tu sistema.
 </Steps>
-
-### Usando una instantánea de Btrfs como punto de restauración
-
-:::note
-Aunque CachyOS crea automáticamente instantáneas de Btrfs antes de cada actualización del sistema mediante el uso de hooks de pacman, siempre es una buena idea crear tus propias instantáneas antes de realizar cambios importantes en tu sistema.
-:::
-
-Para obtener más información sobre las instantáneas de Btrfs, consulte la [documentación de Btrfs](https://btrfs.readthedocs.io/en/latest/).
-
-Una instantánea de BTRFS aparece como una entrada de arranque adicional en el menú de tu gestor de arranque y generalmente tiene un nombre como:
-- `10 | 30-10-2025 14:37:10`
-<details>
-<summary>Ejemplo en una captura de pantalla:</summary>
-<ImageComponent imgsrc={import('~/assets/images/btrfs-snapshot-boot-entry.jpg')} />
-</details>
-
-También puedes usar la aplicación Btrfs Assistant para gestionar tus instantáneas. Proporciona una interfaz gráfica para crear, eliminar y restaurar instantáneas.
-
-<details>
-    <summary>Captura de pantalla de Btrfs Assistant:</summary>
-    <ImageComponent imgsrc={import('~/assets/images/btrfs-assistant-example.png')} />
-</details>
 
 ## Gestión de Paquetes y Actualizaciones
 
@@ -851,6 +832,29 @@ Para solucionar este problema, sigue la [guía de solución de la Arch Wiki](htt
 
 ### Preguntas Generales
 
+#### Recientemente, mi sistema tarda mucho en arrancar
+
+Dado que este problema puede ser causado por muchas cosas diferentes. Comencemos con lo básico verificando systemd-analyze para ver dónde está luchando el sistema:
+
+Abre una terminal y ejecuta uno de los dos siguientes comandos:
+
+```sh
+systemd-analyze blame
+```
+
+o:
+
+```sh
+systemd-analyze critical-chain
+```
+
+Si la salida muestra `cachyos-rate-mirrors.service` tardando mucho en ejecutarse. Entonces deberías ejecutar el siguiente comando para enmascarar este servicio, lo que evitará que se ejecute en el arranque:
+
+```sh
+systemctl mask cachyos-rate-mirrors
+systemctl mask cachyos-rate-mirrors.timer
+```
+
 #### ¿Cuál es el origen de CachyOS y por qué se llama así?
 
 CachyOS recibe su nombre del planificador "Cachy", que era el nombre original del [planificador cacULE](https://github.com/hamadmarri/cacule-cpu-scheduler), un planificador de CPU para el kernel de Linux.
@@ -887,13 +891,13 @@ Limine: `sudo limine-mkinitcpio`
 #### Enviar Solicitudes de Paquetes a CachyOS
 
 CachyOS ofrece una extensa lista de paquetes AUR precompilados, que son de uso común.
-Los usuarios pueden crear solicitudes para paquetes AUR, los cuales, si son aprobados, son actualizados automáticamente por nuestro servidor de compilación.
+Los usuarios pueden crear solicitudes para paquetes AUR de las siguientes maneras:
 
 Si quieres que agreguemos un paquete, puedes enviar una solicitud en GitHub o en el foro.
 
-- [GitHub:](https://github.com/CachyOS/distribution/issues)
-- [Foro:](https://discuss.cachyos.org/c/feedback/repository/11)
-- [Discord: Canal de Feedback](https://discord.com/channels/862292009423470592/1150723027986813018)
+- [GitHub](https://github.com/CachyOS/distribution/issues)
+- [Foro](https://discuss.cachyos.org/c/feedback/repository/11)
+- [Canal de feedback de Discord](https://discord.com/channels/862292009423470592/1150723027986813018)
 
 ## Seguridad y Buenas Prácticas
 
@@ -915,14 +919,17 @@ El AUR ofrece una vasta selección, pero la seguridad es primordial. Aquí tiene
 
 ¡Mantente alerta para mantener seguro tu sistema basado en Arch!
 
+### Mantenimiento Regular de CachyOS
+
+Sigue la Arch Wiki para esto: https://wiki.archlinux.org/title/System_maintenance
+
 ### Elegir un Gestor de Paquetes Gráfico (GUI)
 
 Aunque los gestores de paquetes gráficos ofrecen comodidad, se sabe que algunos causan problemas graves en sistemas de lanzamiento continuo (rolling-release) como CachyOS y deben evitarse para gestionar paquetes del sistema.
 
--   **Pamac:** es conocido por manejar incorrectamente ciertas tareas de gestión de paquetes, como corromper los llaveros de claves de paquetes del sistema. Esto puede llevar a errores de firma PGP que te impidan actualizar tu sistema.
+- **Pamac:** es conocido por manejar incorrectamente ciertas tareas de gestión de paquetes, como corromper los llaveros de claves de paquetes del sistema. Esto puede llevar a errores de firma PGP que te impidan actualizar tu sistema.
+- **Discover (KDE) & Centro de Software de GNOME:** Estas tiendas de aplicaciones usan el backend PackageKit. Aunque generalmente son seguras para gestionar Flatpaks, usarlas para instalar o actualizar **paquetes del sistema** es arriesgado. Los gestores basados en PackageKit también pueden ser inestables o propensos a fallar, lo que podría dejar tu sistema en un estado roto después de una transacción fallida.
 
--   **Discover (KDE) y Centro de Software de GNOME:** Estas tiendas de aplicaciones usan el backend PackageKit. Aunque generalmente son seguras para gestionar Flatpaks, usarlas para instalar o actualizar **paquetes del sistema** es arriesgado. Los gestores basados en PackageKit también pueden ser inestables o propensos a fallar, lo que podría dejar tu sistema en un estado roto después de una transacción fallida.
+Para máxima estabilidad y fiabilidad, **recomendamos encarecidamente** gestionar los paquetes del sistema a través de la línea de comandos con `pacman`
 
-Para máxima estabilidad y fiabilidad, **recomendamos encarecidamente** gestionar los paquetes del sistema a través de la línea de comandos con `pacman`.
-
-Si prefieres una interfaz gráfica, los front-ends gráficos como **[Octopi](/es/configuration/post_install_setup/#actualizando-el-sistema)** o el **Instalador de Paquetes de CachyOS** se consideran alternativas seguras, ya que son envoltorios (wrappers) más directos de la funcionalidad de pacman.
+Si prefieres una interfaz gráfica, front-ends gráficos como **[Shelly](/es/configuration/post_install_setup/#actualizando-el-sistema)** o el **Instalador de Paquetes de CachyOS** se consideran alternativas seguras, ya que son envoltorios (wrappers) más directos de la funcionalidad de pacman.

--- a/src/content/docs/es/configuration/automount_with_fstab.mdx
+++ b/src/content/docs/es/configuration/automount_with_fstab.mdx
@@ -1,75 +1,287 @@
 ---
-title: Montar Unidades Adicionales Automáticamente al Arrancar con fstab
-description: Montar unidades estáticas adicionales al arrancar utilizando el archivo que se encuentra en /etc/fstab
+title: Montar Unidades Adicionales Automáticamente al Arrancar
+description: Montar unidades estáticas adicionales al arrancar utilizando montajes de systemd o el archivo que se encuentra en /etc/fstab
+ai_translated: true
 ---
 
-Este tutorial describe los conceptos básicos de cómo utilizar el archivo fstab ubicado en /etc/ para montar unidades estáticas durante el arranque. Explica brevemente cómo encontrar el UUID de una partición o unidad, qué hacen algunas opciones y lecturas adicionales en caso de que la información proporcionada sea insuficiente.
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+
+Este tutorial describe los conceptos básicos de utilizar tanto archivos de montaje de systemd como el archivo fstab ubicado en /etc/ para montar unidades estáticas durante el arranque. Explica brevemente cómo encontrar el UUID de una partición o unidad, qué hacen algunas opciones y lecturas adicionales en caso de que la información proporcionada sea insuficiente.
 
 ## Prerrequisitos
 
 - Acceso root o sudo
 
-## Añadir Entradas a /etc/fstab
-
 :::note[NTFS en Linux]
-El sistema de archivos NTFS puede ser inestable en Linux, ya sea usando el controlador ntfs3 o ntfs-3g. Úselo bajo su propio riesgo. Para una mejor estabilidad y rendimiento, considere sistemas de archivos nativos de Linux como ext4, xfs o btrfs.
+El sistema de archivos NTFS puede ser inestable en Linux, ya sea usando el controlador ntfs, ntfs3 o ntfs-3g. Úselo bajo su propio riesgo. Para una mejor estabilidad y rendimiento, considere sistemas de archivos nativos de Linux como ext4, xfs o btrfs.
 :::
 
-### 1. Listar los UUID de sus particiones
+## Método Más Seguro y Amigable para Principiantes: Montar Unidades con Archivos de Montaje de Systemd
 
-```sh title="Abra una terminal y ejecute el siguiente comando"
+La ventaja de montar mediante systemd es que incluso si cometes algún error en tu archivo de montaje, tu sistema seguirá arrancando. Mientras que un error en el fstab puede dejar tu sistema sin capacidad de arranque.
+
+### 1. Listar los UUID de tus particiones
+
+```sh title="Abre una terminal y ejecuta el siguiente comando"
 lsblk -f
 ```
 
-```text title="Salida de ejemplo"
-# NAME        FSTYPE FSVER LABEL UUID                                 FSAVAIL FSUSE% MOUNTPOINTS
-# zram0                                                                              [SWAP]
-# nvme0n1
-# ├─nvme0n1p1 vfat   FAT32       E04D-9F05
-# ├─nvme0n1p2
-# ├─nvme0n1p3 ntfs               08A24E90A24E81E4                      715.4G    50%
-# ├─nvme0n1p4 vfat   FAT32       E09C-D4DA                             628.1M    39% /boot
-# ├─nvme0n1p5 ext4   1.0         187a9f06-9411-48d9-b941-f03c2e605812  203.6G    47% /
-# └─nvme0n1p6 ntfs
+```sh title="Salida de ejemplo"
+NAME          FSTYPE FSVER LABEL UUID                                 FSAVAIL   FSUSE% MOUNTPOINTS
+zram0                                                                              [SWAP]
+nvme0n1
+├─nvme0n1p1   vfat   FAT32       E04D-9F05
+├─nvme0n1p2
+├─nvme0n1p3   ntfs               08A24E90A24E81E4                      715.4G   50%
+├─nvme0n1p4   vfat   FAT32       E09C-D4DA                             628.1M   39% /boot
+├─nvme0n1p5   ext4   1.0         187a9f06-9411-48d9-b941-f03c2e605812  203.6G   47% /
+└─nvme0n1p6   ntfs
+nvme1n1
+└─nvme1n1p1   ext4               4e55896f-3f1f-4bc5-aa8a-fec099689cd9  931.5G   0%
+
 ```
 
-En nuestro ejemplo, sabemos que queremos montar una partición de Windows, que es ntfs. También sabemos que aproximadamente la mitad de su espacio está disponible. Por lo tanto, podemos determinar que la partición que queremos montar es `nvme0n1p3` y su UUID es `08A24E90A24E81E4`, con un sistema de archivos `ntfs` en este ejemplo.
+En este ejemplo, queremos montar una unidad extra recién formateada como ext4. Sabemos que es una unidad de 1TB y que aún no se ha almacenado nada en ella. Por lo tanto, podemos determinar que la partición a montar es `nvme1n1p1` que tiene un UUID de `4e55896f-3f1f-4bc5-aa8a-fec099689cd9`.
 
-### 2. Identificar su partición
+### 2. Identificando tu partición
 
-A menudo, `lsblk -f` le proporcionará toda la información que necesita para montar su disco a través de /etc/fstab en este punto. Si aún no está seguro de cuál es la partición correcta, puede ejecutar el siguiente comando:
+A menudo `lsblk -f` te proporcionará toda la información que necesitas para montar tu disco con systemd en este punto. Si aún no estás seguro de cuál es la partición correcta, puedes ejecutar el siguiente comando:
 
 ```sh
 sudo fdisk -l
 ```
 
-```text title="Salida de ejemplo"
-# Device              Start        End    Sectors  Size Type
-# /dev/nvme0n1p1       2048     206847     204800  100M EFI System
-# /dev/nvme0n1p2     206848     239615      32768   16M Microsoft reserved
-# /dev/nvme0n1p3     239616 2997384182 2997144567  1.4T Microsoft basic data
-# /dev/nvme0n1p4 2997385216 2999482367    2097152    1G EFI System
-# /dev/nvme0n1p5 2999482368 3905454079  905971712  432G Linux root (x86-64)
-# /dev/nvme0n1p6 3905454080 3907026943    1572864  768M Windows recovery environment
+```sh title="Salida de ejemplo"
+Device          Start       End         Sectors     Size    Type
+/dev/nvme0n1p1  2048        206847      204800      100M    EFI System
+/dev/nvme0n1p2  206848      239615      32768       16M     Microsoft reserved
+/dev/nvme0n1p3  239616      2997384182  2997144567  1.4T    Microsoft basic data
+/dev/nvme0n1p4  2997385216  2999482367  2097152     1G      EFI System
+/dev/nvme0n1p5  2999482368  3905454079  905971712   432G    Linux root (x86-64)
+/dev/nvme0n1p6  3905454080  3907026943  1572864     768M    Windows recovery environment
+/dev/nvme1n1p1  2048        1953523711  1953521664  931.5G  Linux filesystem
+
 ```
 
-Ya conocemos nuestro UUID en este ejemplo. Sin embargo, `fdisk -l` puede aclararnos un poco más las cosas al mostrar el tamaño exacto de la partición (1.4T) así como su tipo (Microsoft basic data).
+Ya conocemos nuestro UUID en este ejemplo. Sin embargo, `fdisk -l` puede hacérselo un poco más claro al mostrar el tamaño exacto de la partición (931.5G) así como su tipo (Linux filesystem).
+
+Eso debería dejarnos meridianamente claro que la partición que queremos es `nvme1n1p1` con un UUID de `4e55896f-3f1f-4bc5-aa8a-fec099689cd9` como se describió anteriormente. Ya lo sabíamos antes, pero ahora lo sabemos con certeza.
+
+Una vez que estés seguro de haber encontrado la partición correcta, copia el UUID. Copiar desde el emulador de terminal se hace normalmente con `ctrl+shift+C`.
+
+### 3. Creando el Archivo de Montaje de Systemd
+Digamos que queremos usar esta unidad principalmente para juegos, un buen lugar para montarla es en tu home de usuario. Puede ser en cualquier lugar que quieras, pero por simplicidad vamos a usar /home/user (reemplaza user con tu nombre de usuario de Linux). Esto importa porque la ruta de montaje determina el nombre del archivo de montaje de systemd. Como esta unidad está destinada a juegos, la montaremos en la carpeta de juegos del home de usuario, `/home/user/games`.
+
+Para un archivo de montaje de systemd, eso se traduce a home-$USER-games.mount (las barras diagonales `/` se reemplazan con guiones `-`) y los archivos de montaje de systemd van en /etc/systemd/system.
+
+:::tip
+Si quieres usar un espacio, un guion, un carácter CJK o un carácter acentuado en el nombre de tu carpeta de montaje, debe formatearse de manera diferente. Digamos que quieres usar la ruta de carpeta `/home/grzegorz/brzęczyszczykiewicz`, ejecuta el siguiente comando para obtener el nombre que necesitas usar con tu archivo:
+```bash
+systemd-escape -p --suffix=mount "/home/grzegorz/brzęczyszczykiewicz"
+```
+Como necesitas escapar cualquier `\`, crearías el archivo de montaje como `/etc/systemd/system/home-grzegorz-brz\\xc4\\x99czyszczykiewicz.mount`
+:::
+
+Siéntete libre de usar tu editor de texto preferido, en este ejemplo usaremos `micro`.
+
+```sh
+micro /etc/systemd/system/home-$USER-games.mount
+```
+:::note
+Si estás montando en tu home de usuario, puedes mantener el $USER anterior en el nombre del archivo, tu nombre de usuario tomará su lugar automáticamente.
+:::
+
+Pega esta plantilla en el archivo vacío:
+```ini
+[Unit]
+Description=
+
+[Mount]
+What=
+Where=
+Type=
+Options=
+
+[Install]
+WantedBy=multi-user.target
+```
+A continuación se describen los campos del archivo:
+
+<Tabs>
+  <TabItem label='Description'>
+  Description puede ser lo que quieras, es para tu propio reconocimiento.
+  </TabItem>
+  <TabItem label= 'What'>
+  Pon el UUID que copiaste anteriormente. Aquí será `UUID=4e55896f-3f1f-4bc5-aa8a-fec099689cd9`
+  </TabItem>
+  <TabItem label= 'Where'>
+  Este es el punto de montaje. Se creará una carpeta si no existe. Aquí, será `/home/user/games`. Reemplaza "user" con tu nombre de usuario si montas en tu carpeta home.
+  </TabItem>
+  <TabItem label= 'Type'>
+  Tipo de sistema de archivos, aquí será `ext4`
+  </TabItem>
+  <TabItem label= 'Options'>
+  Cualquier opción de montaje que quieras. Aquí, usaremos `defaults,exec,rw,noatime`. No usar espacios es importante aquí.
+  </TabItem>
+</Tabs>
+---
+
+Siguiendo el ejemplo, el archivo de montaje completado debería verse así:
+```ini
+[Unit]
+Description=Mount games drive (/home/user/games)
+
+[Mount]
+What=UUID=4e55896f-3f1f-4bc5-aa8a-fec099689cd9
+Where=/home/user/games
+Type=ext4
+Options=defaults,exec,rw,noatime
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### 4. Finalizando
+Para montar la unidad para la que acabamos de crear una entrada, ejecuta lo siguiente:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now home-$USER-games.mount
+```
+
+Deberías ver la carpeta que elegiste para el punto de montaje, y puedes verificar el estado del montaje con `systemctl status home-$USER-games.mount`:
+
+```sh
+● home-user-games.mount - Mount games drive (/home/user/games)
+     Loaded: loaded (/proc/self/mountinfo; enabled; preset: disabled)
+     Active: active (mounted) since Sat 2026-05-02 13:02:31 CDT; 23h ago
+ Invocation: e52ef8fe3d754c64a3825bc1ee89e7da
+      Where: /home/user/games
+       What: /dev/nvme1n1p1
+      Tasks: 0 (limit: 74118)
+     Memory: 316K (peak: 3.9M)
+        CPU: 5ms
+     CGroup: /system.slice/home-user-games.mount
+
+May 02 13:02:31 cachyos systemd[1]: Mounting Mount games drive (/home/user/games)...
+May 02 13:02:31 cachyos systemd[1]: Mounted Mount games drive (/home/user/games).
+```
+
+### tl;dr
+
+- Encuentra el **UUID** de tu partición
+
+```sh
+lsblk -f
+```
+
+- Crea el archivo de montaje
+
+```sh
+micro /etc/systemd/system/mnt-foo.mount
+```
+
+Reemplazando `mnt-foo` con la ruta completa de donde quieres montar, cambiando el `/` por `-`.
+
+- Completa el archivo de montaje
+
+```sh
+[Unit]
+Description=Mount drive
+
+[Mount]
+What=UUID=<partition UUID>
+Where=/mnt/foo
+Type=somefs
+Options=defaults
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reemplazando `<partition UUID>`, `/mnt/foo`, y `somefs` con tu UUID, directorio y sistema de archivos. p. ej., ext4, así como estableciendo cualquier otra opción que quieras después de defaults, como `_netdev` para un NAS, o `nofail` para cualquier unidad no crítica.
+
+- Recarga tu daemon
+
+```sh
+sudo systemctl daemon-reload
+```
+
+- Monta tu unidad y configúrala para que se monte en el arranque
+
+```sh
+sudo systemctl enable --now mnt-foo.mount
+```
+
+### Lecturas adicionales
+
+- [Estándar de Jerarquía del Sistema de Archivos](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)
+- [FHS sobre /media/](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s11.html)
+- [Manual para dump](<https://linux.die.net/man/8/dump>)
+- [Manual para fsck](https://man.archlinux.org/man/fsck.8)
+- [systemd-mount](https://manual.siduction.org/systemd-mount_en.html)
+
+## Método Avanzado: Añadir Entradas a /etc/fstab
+
+:::danger
+El archivo fstab se lee durante el arranque, y si hay un error en el archivo, puede causar que tu sistema falle al arrancar. Asegúrate de verificar dos veces tu entrada en busca de errores tipográficos antes de reiniciar. Si cometes un error, normalmente puedes arreglarlo arrancando en un entorno live y [haciendo chroot en tu instalación](/es/features/cachy_chroot) para editar el archivo.
+:::
+
+### 1. Listar los UUID de tus particiones
+
+```sh title="Abre una terminal y ejecuta el siguiente comando"
+lsblk -f
+```
+
+```sh title="Salida de ejemplo"
+NAME        FSTYPE FSVER LABEL UUID                                 FSAVAIL FSUSE% MOUNTPOINTS
+zram0                                                                              [SWAP]
+nvme0n1
+├─nvme0n1p1 vfat   FAT32       E04D-9F05
+├─nvme0n1p2
+├─nvme0n1p3 ntfs               08A24E90A24E81E4                      715.4G    50%
+├─nvme0n1p4 vfat   FAT32       E09C-D4DA                             628.1M    39% /boot
+├─nvme0n1p5 ext4   1.0         187a9f06-9411-48d9-b941-f03c2e605812  203.6G    47% /
+└─nvme0n1p6 ntfs
+```
+
+En nuestro ejemplo, sabemos que queremos montar una partición de Windows, que es ntfs. También sabemos que aproximadamente la mitad de su espacio está disponible. Por lo tanto, podemos determinar que la partición que queremos montar es `nvme0n1p3` y su UUID es `08A24E90A24E81E4`, con un sistema de archivos de `ntfs` en este ejemplo.
+
+### 2. Identificando tu partición
+
+A menudo `lsblk -f` te proporcionará toda la información que necesitas para montar tu disco a través de /etc/fstab en este punto. Si aún no estás seguro de cuál es la partición correcta, puedes ejecutar el siguiente comando:
+
+```sh
+sudo fdisk -l
+```
+
+```sh title="Salida de ejemplo"
+Device              Start        End    Sectors  Size Type
+/dev/nvme0n1p1       2048     206847     204800  100M EFI System
+/dev/nvme0n1p2     206848     239615      32768   16M Microsoft reserved
+/dev/nvme0n1p3     239616 2997384182 2997144567  1.4T Microsoft basic data
+/dev/nvme0n1p4 2997385216 2999482367    2097152    1G EFI System
+/dev/nvme0n1p5 2999482368 3905454079  905971712  432G Linux root (x86-64)
+/dev/nvme0n1p6 3905454080 3907026943    1572864  768M Windows recovery environment
+```
+
+Ya conocemos nuestro UUID en este ejemplo. Sin embargo, `fdisk -l` puede hacérselo un poco más claro al mostrar el tamaño exacto de la partición (1.4T) así como su tipo (Microsoft basic data).
 
 Eso debería dejarnos meridianamente claro que la partición que queremos es `nvme0n1p3` con un UUID de `08A24E90A24E81E4` como se describió anteriormente. Ya lo sabíamos antes, pero ahora lo sabemos con certeza.
 
-Una vez que esté seguro de haber encontrado la partición correcta, copie el UUID. Copiar desde el emulador de terminal se hace normalmente con `ctrl+shift+C`.
+Una vez que estés seguro de haber encontrado la partición correcta, copia el UUID. Copiar desde el emulador de terminal se hace normalmente con `ctrl+shift+C`.
 
 ### 3. Añadir una Entrada a /etc/fstab
 
 Ahora que hemos obtenido el UUID de nuestra partición, es hora de abrir el archivo fstab.
 
-Siéntase libre de usar su editor de texto preferido. En este ejemplo, usaremos nano. Para editar el archivo fstab, debe abrirse como root:
+Siéntete libre de usar tu editor de texto preferido. En este ejemplo, usaremos nano. Para editar el archivo fstab, debe abrirse como root:
 
 ```sh
 sudo nano /etc/fstab
 ```
 
-Usando las teclas de flecha, navegue hasta el final del archivo fstab, luego cree nuestra nueva entrada en una nueva línea vacía:
+Usando las teclas de flecha, navega hasta el final del archivo fstab, luego crea nuestra nueva entrada en una nueva línea vacía:
 
 ```sh
 UUID=08A24E90A24E81E4 /media/windows ntfs3 defaults,nofail,uid=1000,gid=1000,rw,user,exec,umask=000 0 0
@@ -81,13 +293,13 @@ UUID=08A24E90A24E81E4 /media/windows ntfs3 defaults,nofail,uid=1000,gid=1000,rw,
 
 El desglose de esta entrada es el siguiente:
 
-- `UUID=08A24E90A24E81E4` es el sistema de archivos que queremos montar, identificado por su UUID. Hay otros métodos para identificar su sistema de archivos, aunque el UUID tiende a ser el más seguro. Métodos adicionales listados [aquí](https://wiki.archlinux.org/title/Fstab#Identifying_file_systems).
+- `UUID=08A24E90A24E81E4` es el sistema de archivos que queremos montar, identificado por su UUID. Hay otros métodos para identificar tu sistema de archivos, aunque UUID tiende a ser el más seguro. Métodos adicionales listados [aquí](https://wiki.archlinux.org/title/Fstab#Identifying_file_systems).
 
-- `/media/windows` es el punto de montaje de nuestra unidad. El [Estándar de Jerarquía del Sistema de Archivos de Linux](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html) (Linux Filesystem Hierarchy Standard) dice que `/media/` es la ubicación adecuada para montar unidades extraíbles. `windows` indica el directorio en el que deseamos montar nuestra unidad. Cada unidad que queramos montar necesitará su propio directorio.
+- `/media/windows` es el punto de montaje de nuestra unidad. El [Estándar de Jerarquía del Sistema de Archivos de Linux](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html) dice que `/media/` es la ubicación adecuada para montar unidades extraíbles. `windows` indica el directorio en el que deseamos montar nuestra unidad. Cada unidad que queramos montar necesitará su propio directorio.
 
-- `ntfs3` es el tipo de sistema de archivos a utilizar. En nuestro ejemplo estamos usando explícitamente el controlador del kernel ntfs3. Otros ejemplos serían `ext4`, `xfs` o similares. Esta declaración explícita del tipo de sistema de archivos puede ser reemplazada por `auto` para permitir que el comando mount haga su mejor suposición.
+- `ntfs3` es el tipo de sistema de archivos a utilizar. Estamos usando explícitamente el controlador del kernel ntfs3 en nuestro ejemplo. Otros ejemplos serían `ext4`, `xfs` o similares. Esta declaración explícita del tipo de sistema de archivos puede ser reemplazada por `auto` para permitir que el comando mount haga su mejor suposición.
 
-- `defaults,nofail,uid=1000,gid=1000,rw,user,exec,umask=000`: Estas son las opciones de montaje:
+- `defaults,nofail,uid=1000,gid=1000,rw,user,exec,umask=000`: Estas son opciones de montaje:
 
   - `defaults`: un conjunto estándar de opciones que incluye `rw, suid, dev, exec, auto, nouser, y async.`
 
@@ -103,29 +315,29 @@ El desglose de esta entrada es el siguiente:
 
   - `umask=000`: establece la máscara de permisos de archivo para permitir permisos de lectura, escritura y ejecución para todos.
 
-  - `el primer 0` (dump) está típicamente obsoleto en los sistemas modernos. Dejarlo en 0 no causará ningún problema. Puede leer más al respecto [aquí](https://linux.die.net/man/8/dump).
+  - `el primer 0` dump está típicamente obsoleto en sistemas modernos. Dejarlo en 0 no causará ningún problema. Siéntete libre de leer más sobre ello [aquí](https://linux.die.net/man/8/dump).
 
-  - `el segundo 0` establece el orden para las comprobaciones del sistema de archivos en el momento del arranque. Para una partición raíz, esto debería ser 1, a menos que su sistema de archivos raíz sea btrfs, que en ese caso debería establecerse en 0. Todos los demás sistemas de archivos en su fstab deberían ser 0 (deshabilitado) o 2. Más información [aquí](https://man.archlinux.org/man/fsck.8).
+  - `el segundo 0` establece el orden para las comprobaciones del sistema de archivos en el momento del arranque. Para una partición raíz, esto debería ser 1 a menos que tu sistema de archivos raíz sea btrfs, que debería establecerse en 0 en cambio. Todos los demás sistemas de archivos en tu fstab deberían ser 0 (deshabilitado) o 2. Más información [aquí](https://man.archlinux.org/man/fsck.8).
 
-Para una visión más detallada de cada opción, visite estas dos páginas del manual: [página man de fstab](https://man7.org/linux/man-pages/man5/fstab.5.html) y [página man de mount](https://man7.org/linux/man-pages/man8/mount.8.html).
+Para una visión más detallada de cada opción, visita estas dos [página man de fstab](https://man7.org/linux/man-pages/man5/fstab.5.html) y [página man de mount](https://man7.org/linux/man-pages/man8/mount.8.html).
 
 #### Más información
 
-Como apunte, todas las opciones después de la declaración del tipo de sistema de archivos son opcionales si no las cambia de las predeterminadas.
+Como nota al margen, todas las opciones después de la declaración del tipo de sistema de archivos son opcionales si no las cambias de las predeterminadas.
 
 Por lo tanto
 
-`UUID=<UUID de la partición> /media/foo algunfs`
+`UUID=<partition UUID> /media/foo somefs`
 
 y
 
-`UUID=<UUID de la partición> /media/foo algunfs defaults 0 0`
+`UUID=<partition UUID> /media/foo somefs defaults 0 0`
 
-son equivalentes. `algunfs` seguido de nada es implícitamente `algunfs defaults 0 0`.
+son equivalentes. `somefs` seguido de nada es implícitamente `somefs defaults 0 0`
 
 ### 4. Finalizando
 
-Si desea montar ahora la unidad para la que creó una entrada, necesita ejecutar lo siguiente:
+Si deseas montar ahora la unidad para la que creaste una entrada, necesitas ejecutar lo siguiente:
 
 ```sh
 sudo systemctl daemon-reload
@@ -137,7 +349,7 @@ y luego:
 sudo mount -a
 ```
 
-Su unidad debería aparecer ahora en `/media/windows` y aparecerá allí cada vez que reinicie.
+Tu unidad debería aparecer ahora en `/media/windows` y aparecerá allí cada vez que reinicies.
 
 ```sh
 ls /media/windows
@@ -153,7 +365,7 @@ ls /media/windows
 # Intel                    'Ship of Harkinian'
  ```
 
- Si desea crear un enlace a su unidad recién montada en su directorio personal, puede ejecutar lo siguiente:
+ Si deseas crear un enlace a tu unidad recién montada en tu directorio home, puedes ejecutar lo siguiente:
 
  ```sh
  ln -s /media/windows ~/Windows
@@ -175,35 +387,35 @@ ls /media/windows
 # Intel                    'Ship of Harkinian'
  ```
 
-## tl;dr
+### tl;dr
 
-- Encuentre el **UUID** de su partición
+- Encuentra el **UUID** de tu partición
 
 ```sh
 lsblk -f
 ```
 
-- Abra `/etc/fstab`
+- Abre `/etc/fstab`
 
 ```sh
 sudo nano /etc/fstab
 ```
 
-- Cree una entrada al final del archivo
+- Crea una entrada al final del archivo
 
 ```sh
-UUID=<UUID de la partición> /media/foo algunfs defaults 0 0
+UUID=<partition UUID> /media/foo somefs defaults 0 0
 ```
 
-Reemplazando `<UUID de la partición>`, `foo`, y `algunfs` con su UUID, directorio y sistema de archivos. p. ej., ext4, así como estableciendo cualquier otra opción que desee después de defaults, como `_netdev` para un NAS, o `nofail` para cualquier unidad no crítica.
+Reemplazando `<partition UUID>`, `foo`, y `somefs` con tu UUID, directorio y sistema de archivos. p. ej., ext4, así como estableciendo cualquier otra opción que quieras después de defaults, como `_netdev` para un NAS, o `nofail` para cualquier unidad no crítica.
 
-- Recargue su daemon
+- Recarga tu daemon
 
 ```sh
 sudo systemctl daemon-reload
 ```
 
-- Monte su unidad
+- Monta tu unidad
 
 ```sh
 sudo mount -a
@@ -211,9 +423,9 @@ sudo mount -a
 
 Esta unidad está ahora montada, y de ahora en adelante también se montará en cada arranque.
 
-## Lecturas adicionales
+### Lecturas adicionales
 
-- [Estándar de Jerarquía del Sistema de Archivos (Filesystem Hierarchy Standard)](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)
+- [Estándar de Jerarquía del Sistema de Archivos](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)
 - [FHS sobre /media/](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s11.html)
 - [Manual para dump](<https://linux.die.net/man/8/dump>)
 - [Manual para fsck](https://man.archlinux.org/man/fsck.8)

--- a/src/content/docs/es/configuration/boot_manager_configuration.mdx
+++ b/src/content/docs/es/configuration/boot_manager_configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuración del Gestor de Arranque
 description: Configura los ajustes del gestor de arranque y pasa parámetros del kernel a la línea de comandos
+ai_translated: true
 ---
 
 ## systemd-boot
@@ -224,7 +225,7 @@ Aunque las entradas se gestionan automáticamente, puedes **configurar los pará
 ## Aprende más
 
 * [Página del manual de loader.conf](https://man.archlinux.org/man/loader.conf.5)
-* [rEFInd: Configurando el gestor de arranque (en inglés)](https://www.rodsbooks.com/refind/configfile.html)
-* [Manual de GRUB: Configuración (en inglés)](https://www.gnu.org/software/grub/manual/grub/grub.html#Configuration)
-* [Documentación Oficial de Configuración de Limine (en inglés)](https://github.com/limine-bootloader/limine/blob/v9.x/CONFIG.md)
-* [Proyecto limine-entry-tool (en inglés)](https://gitlab.com/Zesko/limine-entry-tool)
+* [rEFInd: Configurando el gestor de arranque](https://www.rodsbooks.com/refind/configfile.html)
+* [Manual de GRUB: Configuración](https://www.gnu.org/software/grub/manual/grub/grub.html#Configuration)
+* [Documentación Oficial de Configuración de Limine](https://github.com/limine-bootloader/limine/blob/v12.x/CONFIG.md)
+* [Proyecto limine-entry-tool](https://gitlab.com/Zesko/limine-entry-tool)

--- a/src/content/docs/es/configuration/btrfs_snapshots.mdx
+++ b/src/content/docs/es/configuration/btrfs_snapshots.mdx
@@ -4,6 +4,7 @@ description: Gestionando instantáneas de Btrfs en CachyOS
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 5
+ai_translated: true
 ---
 
 import { Steps } from '@astrojs/starlight/components';
@@ -255,10 +256,31 @@ Aquí hay una lista de los comandos más comunes de Snapper.
     <details>
         <summary>Ejemplo de Salida:</summary>
         ```bash
-        ❯ snapper list-configs
-        Config │ Subvolume
-        ───────┼──────────
-        root   │ /
+        Key                    │ Value
+        ───────────────────────┼──────
+        ALLOW_GROUPS           │
+        ALLOW_USERS            │
+        BACKGROUND_COMPARISON  │ yes
+        EMPTY_PRE_POST_CLEANUP │ yes
+        EMPTY_PRE_POST_MIN_AGE │ 1800
+        FREE_LIMIT             │ 0.2
+        FSTYPE                 │ btrfs
+        NUMBER_CLEANUP         │ yes
+        NUMBER_LIMIT           │ 10
+        NUMBER_LIMIT_IMPORTANT │ 10
+        NUMBER_MIN_AGE         │ 3600
+        QGROUP                 │
+        SPACE_LIMIT            │ 0.5
+        SUBVOLUME              │ /
+        SYNC_ACL               │ no
+        TIMELINE_CLEANUP       │ yes
+        TIMELINE_CREATE        │ no
+        TIMELINE_LIMIT_DAILY   │ 0
+        TIMELINE_LIMIT_HOURLY  │ 0
+        TIMELINE_LIMIT_MONTHLY │ 0
+        TIMELINE_LIMIT_WEEKLY  │ 0
+        TIMELINE_LIMIT_YEARLY  │ 0
+        TIMELINE_MIN_AGE       │ 1800
         ```
     </details>
 </details>
@@ -368,7 +390,7 @@ La instantánea 0 no se puede eliminar ya que representa el estado actual del si
 
 [Guía de la Wiki de Arch:](https://wiki.archlinux.org/title/Snapper)
 
-### Recomendaciones y Consejos para Limine
+### Recomendaciones y Consejos de Limine
 
 #### Ajustar la configuración de visualización de instantáneas del gestor de arranque Limine
 
@@ -426,7 +448,7 @@ Si la instantánea desde la que quieres restaurar implicó una actualización de
             <MultipleImageComponent
                 images={[
                 import('~/assets/images/limine-snapshotMenu-2.jpg'),
-                import('~/assets/images/limine-snapshotMenu-1.jpg')]}
+                import('~/assets/images/limine-snapshotMenu-3.jpg')]}
             />
         3. Tu sistema está ahora en `modo de solo lectura`. Debería aparecer una notificación emergente indicando que se detectó una instantánea y preguntando si quieres restaurar desde ella:
             <ImageComponent imgsrc={import('~/assets/images/kde-snapshot-popup.png')} />

--- a/src/content/docs/es/configuration/desktop_environments/hyprland.mdx
+++ b/src/content/docs/es/configuration/desktop_environments/hyprland.mdx
@@ -1,0 +1,246 @@
+---
+title: Configuración Post Instalación e Inicio Rápido de Hyprland
+description: Tareas comunes después de la instalación y resumen de atajos de teclado
+ai_translated: true
+---
+
+import { Kbd } from 'starlight-kbd/components'
+import ImageComponent from '~/components/image-component.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+:::note
+Hyprland es un compositor wayland que soporta varios diseños como dwindle (tiling), scrolling, master, monocle y diseños personalizados. **No** es un entorno de escritorio completo (DE).
+:::
+
+### ¿Por qué usar Hyprland?
+
+Hyprland es un hermoso gestor de tiling dinámico que ofrece una variedad de diseños y funcionalidad avanzada de compositor como VRR, tearing y HDR. Los dots de CachyOS para Hyprland están configurados con valores predeterminados generales que deberían ser completamente utilizables sin configuración adicional, con aplicaciones que siguen el tema general del sistema.
+
+**Dotfiles mantenidos por [Jinra](https://github.com/Jinra)**
+
+Para problemas relacionados con Noctalia, consulta la [documentación de Noctalia](https://docs.noctalia.dev/).
+
+## Tareas Post Configuración
+Querrás configurar algunas cosas específicas del usuario después de la configuración. Para configuraciones adicionales, consulta el wiki de Hyprland https://wiki.hypr.land/Configuring/Start/
+
+### Ubicación `~/.config/hypr/config`
+* `monitors.lua` configurará tus monitores. (más información en https://wiki.hypr.land/Configuring/Basics/Monitors/). Se crea un bloque predeterminado para ti, puedes añadir más para monitores adicionales.
+  * `output` edita `variables.lua` en su lugar con el valor del monitor; puedes ejecutar `hyprctl monitors` para obtener este id (p. ej. `DP-1`). Si añades más monitores usa MONITOR2, MONITOR3, etc y añádelos también a `variables.lua`.
+  * `mode` debe estar en un formato como `1920x1080@60` (horizontal x vertical @ tasa de refresco).
+  * `scale` Lo más probable es que quieras `1`, pero puede que quieras un valor más alto para monitores de mayor resolución.
+  * Puede que necesites reiniciar después del primer ajuste, pero los ajustes futuros deberían reflejarse en vivo.
+* `variables.lua`
+  * Añade tus asignaciones de monitores aquí. Tu `PRIMARY_MONITOR` y `MONITOR1` generalmente deberían ser el mismo monitor. Puedes eliminar/añadir variables `MONITOR#` según sea necesario.
+  * Define tu número de espacios de trabajo por monitor. No excedas 10.
+* `input.lua` Puedes definir tus varios ajustes de entrada de hypr aquí. Probablemente quieras ajustar la `sensitivity`.
+* `binds.lua` Revisa este archivo para ver todos los atajos de teclado de estos dots. También puedes consultar el resumen general a continuación.
+* `windowrules.lua` Si te preguntas por qué ciertas ventanas tienen ciertos comportamientos, revisa este archivo; también puedes añadir/eliminar reglas según consideres oportuno.
+* `workspaces.lua` Añade varios ajustes de espacio de trabajo aquí. Se recomienda añadir 3 espacios de trabajo por monitor (como se muestra en los ejemplos) más el espacio de trabajo de juegos al monitor principal.
+* `environment.lua` se usa para establecer variables de entorno específicas de hypr o del usuario. No es necesario ajustarlo si estás usando UWSM, y es más preferible añadir estas al archivo env de UWSM en su lugar (ver abajo).
+### Ubicación `~/.config/uwsm`
+* `env` es un archivo usado para definir variables globales, puedes usarlo para variables generales que necesitan ser asignadas para tu cuenta de usuario específica (Ejemplos: `HYPRCURSOR_THEME`, `XCURSOR_THEME`, `QT_QPA_PLATFORM`, etc.)
+### Ubicación `~/.config/noctalia` (Solo V5; V4 tendrá archivos aquí, pero no necesitas tocarlos ya que pueden configurarse a través de los ajustes de Noctalia)
+* `config.toml` es donde vive la configuración predeterminada para cachyos-hypr-noctalia. Si te preguntas por qué los valores predeterminados difieren de una instalación vanilla de noctalia v5, esta es la razón. No deberías tener que tocar nada en este archivo.
+### Ubicación `ajustes de noctalia` (Super + Z)
+* Puedes editar los ajustes de Noctalia aquí. Se recomienda ir a la sección de plantillas y activar cualquier plantilla de color para las aplicaciones que puedas usar.
+* También echa un vistazo a la tienda de plugins para plugins oficiales y de la comunidad útiles.
+
+## Atajos de Teclado
+
+La mayoría de las combinaciones de teclas requieren el uso de la tecla mod que en nuestro caso es la tecla Windows/Command (referenciada como SUPER), puedes cambiarla en `binds.lua`.
+
+### Gestión de Ventanas
+
+| Descripción | Tecla |
+|-------------|-----|
+| Forzar cierre de app/ventana (mantén la combinación y haz clic) | <Kbd linux="Super+Escape" /> |
+| Cerrar ventana/app enfocada | <Kbd linux="Super+Q" /> |
+| Alternar flotante/tiling | <Kbd linux="Super+Alt+Space" /> |
+| Maximizar ventana enfocada | <Kbd linux="Super+D" /> |
+| Pantalla completa ventana enfocada | <Kbd linux="Super+F" /> |
+| Alternar dirección de división | <Kbd linux="Super+J" /> |
+| Enfocar izquierda | <Kbd linux="Super+Left" /> |
+| Enfocar derecha | <Kbd linux="Super+Right" /> |
+| Enfocar arriba | <Kbd linux="Super+Up" /> |
+| Enfocar abajo | <Kbd linux="Super+Down" /> |
+| Cambiar enfoque de ventana en espacio de trabajo | <Kbd linux="Alt+Tab" /> |
+| Abrir cambiador de ventanas | <Kbd linux="Super+Tab" /> |
+| Mover ventana enfocada al monitor | <Kbd linux="Super+Shift+#" /> |
+| Mover ventana enfocada al espacio de trabajo | <Kbd linux="Super+Shift+Control+#" /> |
+| Mover ventana enfocada al espacio de trabajo especial | <Kbd linux="Super+Shift+S" /> |
+| Mover ventana enfocada a la derecha | <Kbd linux="Super+Shift+Right" /> |
+| Mover ventana enfocada a la izquierda | <Kbd linux="Super+Shift+Left" /> |
+| Mover ventana enfocada arriba | <Kbd linux="Super+Shift+Up" /> |
+| Mover ventana enfocada abajo | <Kbd linux="Super+Shift+Down" /> |
+| Mover ventana enfocada al siguiente espacio de trabajo | <Kbd linux="Super+Control+Shift+Right" /> |
+| Mover ventana enfocada al espacio de trabajo anterior | <Kbd linux="Super+Control+Shift+Left" /> |
+| Mover ventana enfocada al espacio de trabajo anterior (ratón) | <Kbd linux="Super+Control+Shift+Scroll&nbsp;up" /> |
+| Mover ventana enfocada al siguiente espacio de trabajo (ratón) | <Kbd linux="Super+Control+Shift+Scroll&nbsp;down" /> |
+| Mover ventana enfocada al siguiente monitor | <Kbd linux="Super+Shift+Scroll&nbsp;down" /> |
+| Mover ventana enfocada al monitor anterior | <Kbd linux="Super+Shift+Scroll&nbsp;up" /> |
+| Mover ventana (ratón) | <Kbd linux="Super+Left&nbsp;Click" /> |
+| Redimensionar ventana (ratón) | <Kbd linux="Super+Right&nbsp;Click" /> |
+
+### Lanzador
+
+| Descripción | Tecla |
+|-------------|-----|
+| Abrir Terminal | <Kbd linux="Super+Return" /> |
+| Abrir Gestor de Archivos | <Kbd linux="Super+E" /> |
+| Abrir Editor | <Kbd linux="Super+T" /> |
+| Abrir Calculadora | <Kbd linux="Super+C" /> |
+| Abrir Navegador | <Kbd linux="Super+W" /> |
+| Abrir Monitor del Sistema (btop) | <Kbd linux="Control+Shift+Escape" /> |
+| Alternar Ajustes de Noctalia | <Kbd linux="Super+Z" /> |
+| Alternar Centro de Control | <Kbd linux="Super+X" /> |
+| Alternar Lanzador de Apps | <Kbd linux="Super+Space" /> |
+| Abrir Lanzador de Emoji | <Kbd linux="Super+period" /> |
+| Bloquear pantalla | <Kbd linux="Super+L" /> |
+| Alternar menú de sesión | <Kbd linux="Super+Alt+C" /> |
+
+### Controles de Hardware
+
+| Descripción | Tecla |
+|-------------|-----|
+| Subir Volumen | <Kbd linux="Volume Up" /> |
+| Bajar Volumen | <Kbd linux="Volume Down" /> |
+| Silenciar Salida de Audio | <Kbd linux="Mute" /> |
+| Silenciar Entrada del Micrófono | <Kbd linux="MicMute" /> |
+| Reproducir/Pausar Media | <Kbd linux="Play" /> / <Kbd linux="Pause" /> |
+| Siguiente Pista de Media | <Kbd linux="Next" /> |
+| Pista Anterior de Media | <Kbd linux="Previous" /> |
+| Aumentar Brillo de Pantalla | <Kbd linux="Brightness Up" /> |
+| Disminuir Brillo de Pantalla | <Kbd linux="Brightness Down" /> |
+
+### Utilidades
+
+| Descripción | Tecla |
+|-------------|-----|
+| Selector de Color | <Kbd linux="Super+P" /> |
+| Captura de Pantalla y Anotar | <Kbd linux="Print" /> |
+| Captura de Ventana y Anotar (v4) | <Kbd linux="Super+Print" /> |
+| Captura de Monitor y Anotar (v5) | <Kbd linux="Super+Print" /> |
+| Alternar Grabador de Pantalla (solo v4) | <Kbd linux="Super+R" /> |
+| Alternar Menú de Fondos de Pantalla | <Kbd linux="Super+Shift+W" /> |
+| Abrir Historial del Portapapeles | <Kbd linux="Super+V" /> |
+| Alternar Historial de Notificaciones | <Kbd linux="Super+A" /> |
+| Acercar | <Kbd linux="Super+Plus" /> |
+| Alejar | <Kbd linux="Super+Minus" /> |
+
+### Espacios de Trabajo y Monitores
+
+| Descripción | Tecla |
+|-------------|-----|
+| Cambiar al espacio de trabajo [1-10] | <Kbd linux="Super+[0-9]" /> |
+| Mover ventana al espacio de trabajo [1-10] (seguir) | <Kbd linux="Super+Shift+[0-9]" /> |
+| Mover ventana al espacio de trabajo [1-10] (no seguir) | <Kbd linux="Super+Alt+[0-9]" /> |
+| Enfocar espacio de trabajo (Relativo) | <Kbd linux="Super+Control+#" /> |
+| Enfocar espacio de trabajo (Absoluto) | <Kbd linux="Super+Alt+#" /> |
+| Enfocar siguiente espacio de trabajo | <Kbd linux="Super+Control+Right" /> |
+| Enfocar espacio de trabajo anterior | <Kbd linux="Super+Control+Left" /> |
+| Enfocar primer espacio de trabajo vacío | <Kbd linux="Super+Control+Down" /> |
+| Enfocar siguiente espacio de trabajo (ratón) | <Kbd linux="Super+Control+Scroll&nbsp;down" /> |
+| Enfocar espacio de trabajo anterior (ratón) | <Kbd linux="Super+Control+Scroll&nbsp;up" /> |
+| Enfocar siguiente monitor (ratón) | <Kbd linux="Super+Scroll&nbsp;down" /> |
+| Enfocar monitor anterior (ratón) | <Kbd linux="Super+Scroll&nbsp;up" /> |
+| Alternar espacio de trabajo especial (scratchpad) | <Kbd linux="Super+S" /> |
+
+## Migración desde otro DE/WM
+
+Si ya tienes otro DE/WM instalado, puedes migrar a estos dots con las instrucciones a continuación.
+
+:::note
+Aunque es posible usar la misma cuenta de usuario con Hyprland, se recomienda encarecidamente crear una nueva cuenta de usuario (instrucciones incluidas). Además, incluso con una nueva cuenta de usuario, puede haber conflictos de demonios con tu DE/WM anterior, por lo que es más ideal usar un solo entorno.
+:::
+
+Asegúrate de reemplazar las variables entre corchetes angulares (\<\>) a continuación, incluidos los corchetes angulares mismos.
+
+1. Ejecuta `sudo pacman -S cachyos-hypr-noctalia`. Si te encuentras con un conflicto de paquetes con otro paquete `-settings` (como `cachyos-kde-settings`), puedes eliminar el paquete conflictivo ya que estos paquetes no afectan a los usuarios actuales.
+1. Para crear un nuevo usuario ejecuta `sudo useradd -m <new_user> -s /bin/fish`. También puedes usar otro shell si prefieres (p. ej. /bin/zsh).
+1. Ejecuta `sudo passwd <new_user>` para establecer una contraseña para la cuenta.
+    * Si _realmente_ quieres usar la misma cuenta (altamente desaconsejado), en su lugar copia los dots a la carpeta del usuario `cp -r /etc/skel/. ~` (¡asegúrate de crear una copia de seguridad/instantánea primero!)
+1. Opcionalmente instala `noctalia-greeter` o `sddm` como tu gestor de pantalla de inicio de sesión. `noctalia-greeter` se integra mejor con Noctalia, pero la configuración es ligeramente más complicada.
+    * Para habilitar sddm como tu gestor de pantalla de inicio de sesión, instálalo con `sudo pacman -Syu sddm`, luego ejecuta `systemctl disable display-manager` y `systemctl enable sddm`.
+    * Para instalar [Noctalia Greeter](https://github.com/noctalia-dev/noctalia-greeter), ejecuta `sudo pacman -Syu noctalia-greeter`, y sigue la sección "Setting up greetd" del documento enlazado. Después, ejecuta `systemctl disable display-manager` y `systemctl enable greetd`.
+1. Reinicia y selecciona la sesión Hyprland (UWSM) desde tu gestor de pantalla de inicio de sesión.
+    * Si el shell falla al cargar, intenta reiniciar una vez más.
+1. Inicia sesión y sigue las [Tareas Post Configuración](/es/configuration/desktop_environments/hyprland/#tareas-post-configuración).
+
+## Migración desde dots v4 a V5 / Actualización de tus dots
+
+Si actualmente estás usando cachyos-hypr-noctalia con Noctalia v4 y has actualizado desde la versión de paquete 1.0 a una versión más nueva, o quieres actualizar tus dots, sigue las instrucciones a continuación.
+Consulta los registros de cambios completos en el release para determinar si deberías actualizar tus dots.
+https://github.com/CachyOS/cachyos-hypr-noctalia/releases
+
+### Actualizaciones de Hypr
+
+:::note
+Una vez que migres tus atajos de teclado de v4 a v5, ya no funcionarán para llamar a las llamadas IPC de Noctalia.
+:::
+
+1. Instala `meld` si no lo tienes (`pacman -Q meld` para verificar si lo tienes).
+1. Ejecuta `meld /etc/skel/.config/hypr ~/.config/hypr`.
+1. Desde meld verás un resumen de todos los archivos con cambios. Los archivos azules tienen cambios, mientras que los archivos verdes son nuevos.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/meld_overview.png')} />
+1. Haz clic en un archivo azul para ver los cambios a aplicar. Puedes usar tu mejor juicio para determinar qué aplicar, pero si no has hecho ningún cambio, es seguro sobrescribir todo el archivo. Haz clic en la flecha para aplicar cambios y en la x para eliminar líneas antiguas.
+    <Aside type="note">Asegúrate de no sobrescribir cosas que hayas cambiado como tus ajustes de monitor.</Aside>
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/merge.png')} />
+1. También puedes fusionar todo.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/merge_all_1.png')} />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/merge_all_2.png')} />
+1. Cuando termines con tus cambios para el archivo, guarda y sal.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/save_exit.png')} />
+1. Los archivos verdes nuevos te preguntarán dónde quieres guardarlo. Puedes guardarlo en `~/.config/hypr/config/` con el mismo nombre. Hay 4 archivos nuevos.
+    * defaults.lua ahora es variables.lua. Debes mover manualmente cualquier adición/cambio personalizado al nuevo archivo.
+    * keybinds.lua ahora es binds.lua. Debes mover manualmente cualquier adición/cambio personalizado al nuevo archivo.
+    * input.lua ahora es inputs.lua. Debes mover manualmente cualquier adición/cambio personalizado al nuevo archivo.
+    * workspaces.lua es nuevo y puede moverse limpiamente sin cambios.
+    <br />
+    <ImageComponent imgsrc={import('~/assets/images/v4-v5-migration/workspaces.png')} />
+
+### Actualizaciones de Noctalia
+
+1. Ejecuta `rm -rf ~/.config/noctalia` para eliminar las configuraciones actuales. Alternativamente, muévelas a otro lugar si crees que puedes necesitar algo ahí.
+1. `cp -r /etc/skel/.config/noctalia ~/.config` copiará la nueva configuración a tu carpeta de inicio.
+
+:::note
+El único archivo importante es config.toml, así que puedes copiarlo individualmente en lugar de eliminar y reemplazar toda la carpeta cuando el paquete se actualice si quieres.
+:::
+
+### Otras Actualizaciones
+
+Otros archivos pueden tener actualizaciones, puedes usar meld para integrarlas. Consulta el registro de cambios completo del release para ver qué más puede haber cambiado.
+
+### Eliminar dependencias huérfanas (migración v4->v5)
+
+Después de actualizar el paquete, las dependencias antiguas quedarán huérfanas, puedes eliminarlas ejecutando `shelly purify -o`.
+
+### Reinicio
+
+Reiniciar debería hacer que los cambios surtan efecto. Si el shell falla al cargar, intenta reiniciar una vez más.
+
+## FAQ
+
+> _"Mi historial del portapapeles no persiste a través de los reinicios"_
+
+Necesitas configurar un almacén de secretos para que esto funcione correctamente. Kwallet está instalado por defecto pero también puedes usar gnome-keyring u otro almacén de secretos. Si quieres usar kwallet, instala `kwalletmanager` del repo, luego ábrelo y crea una nueva cartera. Es más fácil dejar la contraseña en blanco, pero también puedes configurar el desbloqueo automático con tu gestor de pantalla de inicio de sesión, lo cual está fuera del alcance de este wiki; consulta el [arch wiki](https://wiki.archlinux.org/title/KDE_Wallet#Configuration) para más detalles. Después de configurar una cartera, inicialízala en tu archivo `autostart.lua` con `hl.exec_cmd("kwalletd6")`.
+
+> _"¿Cómo evito que satty aparezca después de tomar una captura de pantalla?"_
+
+Puedes descartar fácilmente satty presionando ctrl + s para guardar tu captura de pantalla o ctrl + c para copiar. Si no quieres que satty aparezca en absoluto, puedes configurar la opción para copiar al portapapeles o guardar en archivo en los ajustes de Noctalia > shell > screenshot.
+
+> _"¿Cómo cambio mi entrada de teclado?"_
+
+Edita `inputs.lua` y añade `kb_layout`. Consulta [aquí](https://wiki.hypr.land/Configuring/Basics/Variables/#input)
+
+> _"¿Por qué algunas opciones de tema no funcionan (iconos de Dolphin, algunos elementos QT, etc)"_
+
+El repo predeterminado de Cachy solo proporciona `qt6ct` (QT6 Configuration Tool). Sin embargo, hay otra herramienta que funciona mejor para aplicaciones Plasma QT como dolphin, gwenview, etc. Descarga `qt6ct-kde` del AUR en su lugar y aplica el tema Noctalia con él. Esto debería hacer que tus apps de plasma tengan mejor tema en Hyprland.
+
+> _"¿Cómo cambio mi navegador predeterminado?"_
+
+Ejecuta `xdg-settings set default-web-browser your_browser.desktop`. Puedes encontrar el nombre del archivo desktop de tu navegador ejecutando `ls /usr/share/applications/`

--- a/src/content/docs/es/configuration/desktop_environments/switch_desktop.mdx
+++ b/src/content/docs/es/configuration/desktop_environments/switch_desktop.mdx
@@ -4,6 +4,7 @@ description: Guía sobre cómo instalar otro DE/WM en una instalación existente
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -99,7 +100,10 @@ Tendrás que estar atento al repositorio de GitHub del respectivo DE/WM para cua
 
 Aquí tienes una lista de todos los repositorios de los diferentes DEs y WMs mantenidos por CachyOS:
 - [KDE Plasma](https://github.com/CachyOS/cachyos-kde-settings)
-- [Niri](https://github.com/CachyOS/cachyos-niri-settings)
+- [GNOME](https://github.com/CachyOS/cachyos-gnome-settings)
+- [Niri](https://github.com/cachyos/cachyos-niri-noctalia)
+- [Hyprland](https://github.com/CachyOS/cachyos-hypr-noctalia)
+- [MangoWM](https://github.com/CachyOS/cachyos-mangowc-dms)
 - [i3](https://github.com/CachyOS/cachyos-i3wm-settings)
 - [Qtile](https://github.com/CachyOS/cachyos-qtile-settings)
 - [Wayfire](https://github.com/CachyOS/cachyos-wayfire-settings)

--- a/src/content/docs/es/configuration/dual_gpu.mdx
+++ b/src/content/docs/es/configuration/dual_gpu.mdx
@@ -1,5 +1,6 @@
 ---
 title: Guía de configuración de doble GPU
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
@@ -107,6 +108,12 @@ prime-run %command%
 Asegúrate de añadir `%command%` después de `prime-run`. Recuerda que las opciones del juego van después del marcador de posición,
 mientras que las variables de entorno del sistema o los comandos deben precederlo.
 
+Para ejecutar un juego en los gráficos integrados en su lugar, usa la siguiente opción de lanzamiento como ejemplo para gráficos integrados Radeon. Esto puede ser deseable para una mayor duración de la batería y un menor ruido del ventilador para juegos de menor potencia.
+
+```bash
+VK_DRIVER_FILES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/usr/share/vulkan/icd.d/radeon_icd.i686.json %command%
+```
+
 <br />
 <ImageComponent imgsrc={import('~/assets/images/steam-prime.png')} />
 
@@ -153,6 +160,17 @@ Similar a Plasma, Cinnamon también te permite seleccionar la GPU para aplicacio
 Si no está disponible, asegúrate de tener `switcheroo-control` instalado y
 su servicio habilitado, porque todos los entornos de escritorio dependen de él para esta
 funcionalidad.
+
+## Solución de problemas
+
+### "Mi monitor externo va muy lento con PRIME"
+
+Este es un problema conocido del controlador de NVIDIA. Debes tener el último controlador de NVIDIA
+instalado y usar Wayland con un compositor que soporte "explicit sync".
+Para GNOME, esto se ha solucionado en la versión 46.2. Para Plasma 6, probablemente se
+solucionará con la versión 6.1, aunque algunos usuarios ya reportan un rendimiento normal en la 6.0.
+Otros entornos/gestores de ventanas todavía tienen este problema, por lo que necesitas cambiar
+a la última versión de GNOME o Plasma para solucionarlo.
 
 ## Solución de problemas
 

--- a/src/content/docs/es/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
+++ b/src/content/docs/es/configuration/enabling_hardware_acceleration_in_google_chrome.mdx
@@ -1,6 +1,7 @@
 ---
 title: Aceleración por hardware en navegadores basados en Chromium
 description: Configura la aceleración por hardware para la decodificación/codificación de vídeo en navegadores basados en Chromium en CachyOS. Incluye la configuración para GPUs de AMD y una plantilla para otras GPUs/navegadores.
+ai_translated: true
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -16,20 +17,53 @@ Esta guía describe cómo habilitar la aceleración por hardware en navegadores 
 **Opcional:**
 
 * **amdgpu_top:** Instala `amdgpu_top` desde el repositorio a través del gestor de paquetes si deseas monitorear la actividad de la GPU AMD desde la terminal.
-* **nvtop:** (Solo para GPUs Intel) Instala `nvtop` (Lunar Lake) y `intel-gpu-tools` (anteriores a Lunar Lake) a través del gestor de paquetes octopi si deseas monitorear la actividad de la GPU Intel desde la terminal.
-
+* **nvtop:** (Solo para GPUs Intel) Instala `nvtop` (Lunar Lake) y `intel-gpu-tools` (anteriores a Lunar Lake) a través del gestor de paquetes Shelly si deseas monitorear la actividad de la GPU Intel desde la terminal.
 
 ## Contribución
 
-Esta guía es extensible. Si tienes una configuración de aceleración por hardware que funciona para una GPU y un navegador basado en Chromium específicos, contribuye añadiendo una nueva sección en "Configuraciones de GPU y Navegador". Incluye:
+Esta guía es extensible. Si tienes una configuración de aceleración por hardware que funciona para una GPU y un navegador basados en Chromium específicos, contribuye añadiendo una nueva sección en "Configuraciones de GPU y Navegador". Incluye:
 
 * **Nombre del navegador**
 * **Modelo de GPU**
-* **Flags (indicadores):** Contenido de `~/.config/[navegador]-flags.conf`.
+* **Flags:** Contenido de `~/.config/[navegador]-flags.conf`.
 * **Ruta del archivo:** Ruta completa al archivo de flags.
 * **Notas (Opcional):** Controladores clave, paquetes o detalles específicos de la configuración.
 
-## Pasos de configuración
+### Plantilla para contribuir
+
+#### [Tu Navegador] - [Tu Modelo de GPU] (Aportado por [Tu Nombre/Alias])
+
+* **Navegador:** [p. ej., Brave, Ungoogled Chromium, Microsoft Edge, Vivaldi, Opera, Chromium]
+
+* **GPU:** [p. ej., NVIDIA GeForce RTX 3080, Intel Iris Xe]
+
+* **Ruta del archivo de flags:** (¡Crucial, varía según el navegador!)
+
+  * Rutas comunes para `.conf`:
+
+    * Chromium: `~/.config/chromium-flags.conf`
+
+    * Brave Browser: `~/.config/brave-flags.conf`
+
+    * Ungoogled Chromium: `~/.config/ungoogled-chromium-flags.conf`
+
+* Modificación del archivo `.desktop`:
+    * Algunos navegadores (Brave, Edge, Vivaldi, Opera) pueden requerir editar la línea `Exec=` en su archivo `.desktop` (primero copia de `/usr/share/applications/` a `~/.local/share/applications/`).
+
+Contenido de los flags (para archivo `.conf` o línea `Exec=`):
+
+```bash
+# Pega tus flags aquí.
+# Para archivos .desktop, los flags se separan por espacios después del ejecutable.
+```
+
+**Notas (Opcional):**
+
+* Controladores requeridos (p. ej., `nvidia-dkms`, `intel-media-driver`).
+
+* Consideraciones específicas de configuración o instrucciones para la modificación del archivo `.desktop`.
+
+### Pasos de configuración
 
 <Steps>
 
@@ -139,10 +173,9 @@ Esta guía es extensible. Si tienes una configuración de aceleración por hardw
 --use-gl=angle
 --use-angle=vulkan
 --enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
---ozone-platform-hint=x11
 ```
 
-**Notas:** Aprovecha Vulkan (a través de ANGLE) y VA-API. `--ozone-platform-hint=x11` puede ser útil incluso en Wayland para ciertas vías de aceleración.
+**Notas:** Aprovecha Vulkan (a través de ANGLE) y VA-API. `--ozone-platform=x11` puede ser útil en Wayland para ciertas vías de aceleración.
 
 ### Nvidia RTX 4090 (Vivaldi)
 
@@ -188,16 +221,7 @@ Alternativamente, puedes hacer lo siguiente para KDE:
 
 ```bash
 --enable-wayland-ime
---ozone-platform=wayland
 --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,WaylandSessionManagement,WaylandTextInputV3,WaylandUiScale,WaylandWindowDecorations
-```
-
-**Notas:**
-
-Si estás usando X11, usa esto:
-```bash
---ozone-platform=x11
---enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder
 ```
 
 ### Nvidia RTX 5070 TI (Brave)
@@ -216,38 +240,142 @@ Si estás usando X11, usa esto:
 - La decodificación **y** codificación de vídeo se muestran como `Hardware accelerated` en `brave://gpu`.
 - A veces, al inspeccionar la pestaña `media` en un vídeo de YouTube, mostrará aceleración por hardware, y a veces no.
 
+### Brave - 7700xt (Aportado por DaJRJesus)
 
----
+* **Navegador:** Brave
 
-### Plantilla para contribuir
+* **GPU:** AMD Radeon RX 7700 XT
 
-### [Tu Navegador] - [Tu Modelo de GPU] (Aportado por [Tu Nombre/Alias])
-
-* **Navegador:** [p. ej., Brave, Ungoogled Chromium, Microsoft Edge, Vivaldi, Opera, Chromium]
-
-* **GPU:** [p. ej., NVIDIA GeForce RTX 3080, Intel Iris Xe]
-
-* **Ruta del archivo de flags:** (¡Crucial, varía según el navegador!)
-
-  * Rutas comunes para `.conf`:
-
-    * Chromium: `~/.config/chromium-flags.conf`
-
-    * Brave Browser: `~/.config/brave-flags.conf`
-
-    * Ungoogled Chromium: `~/.config/ungoogled-chromium-flags.conf`
-
-  * Modificación de archivo `.desktop`: Algunos navegadores (Brave, Edge, Vivaldi, Opera) pueden requerir editar la línea `Exec=` en su archivo `.desktop` (primero copia de `/usr/share/applications/` a `~/.local/share/applications/`).
-
-Contenido de los flags (para archivo `.conf` o línea `Exec=`):
+* **Ruta del archivo de flags:** `~/.config/brave-flags.conf`
 
 ```bash
-# Pega tus flags aquí.
-# Para archivos .desktop, los flags se separan por espacios después del ejecutable.
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,CanvasOopRasterization,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
 ```
 
-**Notas (Opcional):**
+**Notas:**
+Desactivar "Ambient Mode" en la configuración de YouTube es necesario para evitar retrasos en la interfaz.
 
-* Controladores requeridos (p. ej., `nvidia-dkms`, `intel-media-driver`).
+### Vivaldi - AMD Radeon RX 9070 XT (Aportado por tTrmc)
 
-* Consideraciones específicas de configuración o instrucciones para la modificación del archivo `.desktop`.
+* **Navegador:** Vivaldi
+
+* **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
+
+* **Ruta del archivo de flags:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```
+
+**Notas:**
+- Probado en CachyOS con kernel 6.19.11-1-cachyos, Mesa 26.0.3, GNOME (Wayland), pantalla 2560x1440.
+- Confirmado funcionando: `vivaldi://gpu` muestra Video Decode y Video Encode como "Hardware accelerated". Compatibilidad completa de códecs para H264, VP9, HEVC, AV1 decodificación y H264, AV1 codificación. La pestaña Media de DevTools muestra `VaapiVideoDecoder` como el decodificador activo.
+- La RX 9070 XT (RDNA 4) puede estar en la lista de bloqueo de GPU de Chromium, por lo que `--ignore-gpu-blocklist` es necesario.
+- El registro puede mostrar una advertencia: `'--ozone-platform=wayland' is not compatible with Vulkan` — esto no impide que la aceleración por hardware funcione.
+
+### Google Chrome - AMD Radeon RX 9070 XT (Aportado por naknak)
+
+* **Navegador:** Google Chrome
+
+* **GPU:** AMD Radeon RX 9070 XT (RDNA 4 / gfx1201)
+
+* **Ruta del archivo de flags:** `~/.config/chrome-flags.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--use-gl=angle
+--use-angle=vulkan
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo,Vulkan,VulkanFromANGLE,DefaultANGLEVulkan
+```
+
+**Notas:**
+- La decodificación **y** codificación de vídeo se muestran como `Hardware accelerated` en `chrome://gpu`.
+- A veces, al inspeccionar la pestaña `media` en un vídeo de YouTube, mostrará aceleración por hardware, y a veces no.
+
+### Vivaldi - AMD Ryzen AI Max+ 395 (Aportado por woutervanelten)
+
+* **Navegador:** Vivaldi (8.0.4033.35)
+
+* **APU:** AMD Radeon 8060S (GFX1151/Strix Halo)
+
+* **Ruta del archivo de flags:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--ozone-platform=wayland
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```
+
+**Notas:**
+- Probado en CachyOS con kernel 7.0.10-2-cachyos, Mesa 26.1.1, GNOME (Wayland), pantalla 5120x1440.
+- Confirmado funcionando: `vivaldi://gpu` muestra Canvas, Compositing, Rasterization, Video Decode, Video Encode, WebGL, WebGPU y WebGPU interop como "Hardware accelerated". Compatibilidad completa de códecs para H264, H265, VP9, AV1 decodificación y H264, H265 y AV1 codificación.
+
+### Vivaldi - NVIDIA RTX 5090 (Aportado por icetea)
+
+* **Navegador:** Vivaldi (8.1)
+
+* **GPU:** NVIDIA GeForce RTX 5090 (Blackwell)
+
+* **Ruta del archivo de flags:** `~/.config/vivaldi-stable.conf`
+
+```bash
+--enable-features=VaapiVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks
+--use-gl=angle
+--use-angle=gl
+--disable-features=Vulkan
+--ignore-gpu-blocklist
+--ozone-platform=wayland
+```
+
+**Notas:**
+- Requiere `libva-nvidia-driver`. Probado en julio de 2026: controlador 610.43.03, KDE Plasma (Wayland), Vivaldi 8.1.
+- `VaapiIgnoreDriverChecks` es el flag clave en NVIDIA — sin él, la decodificación se inicializa y `vivaldi://gpu` afirma "Hardware accelerated", pero la decodificación en tiempo de ejecución falla (`vaEndPicture failed, VA error: internal decoding error`) y vuelve silenciosamente al software.
+- Verifica con DevTools → pestaña Media (`VaapiVideoDecoder` como nombre del decodificador) y `nvidia-smi dmon -s u` (columna DEC > 0 durante la reproducción). No confíes solo en `vivaldi://gpu`.
+- La decodificación AV1 está rota en `libva-nvidia-driver` 0.0.17 (arreglo en el master upstream, sin lanzar — ver [elFarto/nvidia-vaapi-driver#419](https://github.com/elFarto/nvidia-vaapi-driver/issues/419)). Bloquea AV1 (p. ej., enhanced-h264ify) para que YouTube sirva VP9.
+
+### Google Chrome - NVIDIA RTX 5070 (Aportado por pisyukaev)
+
+* **Navegador:** Google Chrome
+
+* **GPU:** NVIDIA GeForce RTX 5070 (Blackwell / GB205)
+
+* **Ruta del archivo de flags:** `~/.config/chrome-flags.conf`
+
+```bash
+--enable-features=AcceleratedVideoDecodeLinuxGL,VaapiVideoDecoder,VaapiIgnoreDriverChecks,VaapiOnNvidiaGPUs
+--ignore-gpu-blocklist
+```
+
+**Notas:**
+- Requiere `libva-nvidia-driver` y `nvidia-utils` (probado con controlador 610.43.03).
+- **Flag crítico:** `VaapiOnNvidiaGPUs` — este es el flag clave que habilita VA-API en GPUs NVIDIA en Chrome/Chromium. Sin él, Chrome tiene un bloqueo hardcodeado en dispositivos NVIDIA en `vaapi_wrapper.cc` y vuelve silenciosamente a la decodificación por software.
+- `VaapiIgnoreDriverChecks` también es recomendado para prevenir fallos de decodificación en tiempo de ejecución.
+- `AcceleratedVideoDecodeLinuxGL` habilita la decodificación de vídeo acelerada por hardware a través del backend OpenGL de ANGLE.
+- Confirmado funcionando: `chrome://gpu` → Video Acceleration Information muestra soporte de decodificación para H264 (baseline, main, high), VP8, VP9 (profile0, profile2), HEVC (main, main 10, main still-picture) y AV1.
+- Para verificar: Abre `chrome://gpu` y confirma que "Video Acceleration Information" lista los códecs de decodificación. Reproduce un vídeo HEVC y verifica DevTools → pestaña Media para `VaapiVideoDecoder` como el decodificador activo.
+- El flag `--ozone-platform=wayland` no es necesario — Chrome detecta automáticamente Wayland en CachyOS. Si experimentas problemas, puedes añadir `--ozone-platform=wayland` explícitamente.
+
+### Brave Origin - AMD Radeon RX 7600 (Aportado por RyuuPendragon)
+
+* **Navegador:** Brave Origin
+
+* **GPU:** AMD Radeon RX 7600
+
+* **Ruta del archivo de flags:** `~/.config/brave-origin-flags.conf`
+
+```bash
+--ignore-gpu-blocklist
+--enable-gpu-rasterization
+--enable-zero-copy
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoEncoder,CanvasOopRasterization,VaapiIgnoreDriverChecks,UseMultiPlaneFormatForHardwareVideo
+```

--- a/src/content/docs/es/configuration/gaming.mdx
+++ b/src/content/docs/es/configuration/gaming.mdx
@@ -4,11 +4,12 @@ description: 'Cubre la instalación de paquetes esenciales, jugar en Steam con P
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
 import MultipleImageComponent from '~/components/multiple-images-component.astro';
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
 
 Bienvenido a la guía para Jugar en CachyOS. Esto te guiará a través de los aspectos esenciales sobre cómo configurar todo para jugar.
 
@@ -34,26 +35,26 @@ Para facilitar la configuración de CachyOS para jugar, todos los paquetes de ju
 
 Sigue los pasos a continuación para comenzar con la configuración de juegos.
 <Tabs>
+    <TabItem label='CachyOS Hello'>
+      - Abre CachyOS Hello. Ve a **Aplicaciones/Ajustes** y haz clic en `Instalar paquetes de juegos`.
+      <ImageComponent imgsrc={import('~/assets/images/cachyos_hello-gaming.png')} />
+      *CachyOS Hello instala tanto `cachyos-gaming-meta` como `cachyos-gaming-applications`.*
+    </TabItem>
     <TabItem label='Metapaquete'>
-        El metapaquete `cachyos-gaming-meta` incluye muchas bibliotecas relacionadas con los juegos.
-        ```sh
-        sudo pacman -S cachyos-gaming-meta
-        ```
+      El metapaquete `cachyos-gaming-meta` incluye muchas bibliotecas relacionadas con los juegos.
+      ```sh
+      sudo pacman -S cachyos-gaming-meta
+      ```
     </TabItem>
     <TabItem label='Herramientas y Tiendas'>
-        El metapaquete `cachyos-gaming-applications` incluye lo siguiente:
-          - Herramientas
-            - Gamescope, Goverlay, MangoHud
-          - Lanzadores
-            - Steam, Heroic Games Launcher, Lutris
-        ```sh
-        sudo pacman -S cachyos-gaming-applications
-        ```
-    </TabItem>
-    <TabItem label= 'CachyOS Hello'>
-    - Ve a **Aplicaciones/Ajustes** y haz clic en `Instalar paquetes de juegos`.
-
-    *CachyOS Hello instala tanto `cachyos-gaming-meta` como `cachyos-gaming-applications`.*
+      El metapaquete `cachyos-gaming-applications` incluye lo siguiente:
+      - Herramientas
+        - Gamescope, GOverlay, MangoHud
+      - Lanzadores
+        - Steam, Heroic Games Launcher, Lutris, Faugus Launcher
+      ```sh
+      sudo pacman -S cachyos-gaming-applications
+      ```
     </TabItem>
 </Tabs>
 
@@ -637,34 +638,30 @@ Después de reiniciar, el tamaño máximo de la caché de shaders debería haber
 
 </TabItem>
 
-<TabItem label='Heroic Games Launcher'>
+  <TabItem label='Heroic Games Launcher'>
+    <Steps>
+      1. En el panel izquierdo abre `Ajustes`.
+      2. Ve a `Valores predeterminados del juego` y luego haz clic en `Avanzado`.
+      3. En la sección de comando `envoltorio`. Añade la siguiente línea sin ningún argumento:
+          ```sh
+          dlss-swapper
+          ```
+      4. Haz clic en el signo `+` para guardar los cambios.
+    </Steps>
+  </TabItem>
 
-<Steps>
-1. En el panel izquierdo abre `Ajustes`.
-2. Ve a `Valores predeterminados del juego` y luego haz clic en `Avanzado`.
-3. En la sección de comando `envoltorio`. Añade la siguiente línea sin ningún argumento:
-   ```sh
-   dlss-swapper
-   ```
-4. Haz clic en el signo `+` para guardar los cambios.
-</Steps>
-
-</TabItem>
-
-<TabItem label='Lutris'>
-
-<Steps>
-1. En la parte superior derecha abre el `menú de hamburguesa`.
-2. Ve a `Preferencias/Opciones globales`.
-3. Activa el `Modo avanzado` en la parte superior derecha.
-4. Desplázate hacia abajo hasta `Prefijo de comando` y añade la siguiente línea:
-   ```sh
-   dlss-swapper
-   ```
-5. Guarda los cambios.
-</Steps>
-
-</TabItem>
+  <TabItem label='Lutris'>
+    <Steps>
+      1. En la parte superior derecha abre el `menú de hamburguesa`.
+      2. Ve a `Preferencias/Opciones globales`.
+      3. Activa el `Modo avanzado` en la parte superior derecha.
+      4. Desplázate hacia abajo hasta `Prefijo de comando` y añade la siguiente línea:
+          ```sh
+          dlss-swapper
+          ```
+      5. Guarda los cambios.
+    </Steps>
+  </TabItem>
 
 </Tabs>
 

--- a/src/content/docs/es/configuration/general_system_tweaks.mdx
+++ b/src/content/docs/es/configuration/general_system_tweaks.mdx
@@ -4,9 +4,10 @@ description: Cosas que puedes hacer para ajustar después de la instalación
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
 ## Ajustes de Rendimiento de AMD
@@ -47,12 +48,11 @@ También puedes cambiar entre los modos de operación en tiempo de ejecución pa
 
 Para más información:
 
-*   [https://www.kernel.org/doc/html/v6.9/admin-guide/pm/amd-pstate.html](https://www.kernel.org/doc/html/v6.9/admin-guide/pm/amd-pstate.html)
-*   [https://lore.kernel.org/lkml/20221110175847.3098728-1-Perry.Yuan@amd.com/](https://lore.kernel.org/lkml/20221110175847.3098728-1-Perry.Yuan@amd.com/)
-*   [https://lore.kernel.org/lkml/20230119115017.10188-1-wyes.karny@amd.com/](https://lore.kernel.org/lkml/20230119115017.10188-1-wyes.karny@amd.com/)
+<LinkButton icon="external" href="https://www.kernel.org/doc/html/latest/admin-guide/pm/amd-pstate.html">Documentación de AMD P-State</LinkButton>
+<LinkButton icon="external" href="https://www.kernel.org/doc/html/latest/admin-guide/pm/amd-pstate.html#amd-pstate-driver-operation-modes">Modos de Operación del Controlador AMD P-State</LinkButton>
+<LinkButton icon="external" href="https://www.kernel.org/doc/html/latest/admin-guide/pm/amd-pstate.html#user-space-interface-in-sysfs-per-policy-control">Interfaz de Espacio de Usuario de AMD P-State</LinkButton>
 
 ### Configurando AMD P-State EPP
-
 
 Para usar el P-State EPP, hay dos gobernadores de escalado de frecuencia de CPU disponibles: `powersave` y `performance`. Se recomienda usar el gobernador powersave y establecer una preferencia.
 
@@ -67,20 +67,20 @@ echo power | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_pr
 
 Preferencias disponibles: `performance`, `power`, `balance_power`, `balance_performance`
 
-Los benchmarks para cada preferencia se pueden encontrar aquí:
-[https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/](https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/)
+<LinkButton icon="external" href="https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/">Benchmark Oficial para cada preferencia</LinkButton>
 
-### Optimizador de V-Cache 3D de AMD
+### Optimizador AMD 3D V-Cache
 
-AMD publicó un parche para optimizar la programación de la caché en las CPU 3D de doble CCD, como la 7950X3D y la 7900X3D.
-Necesitas establecer en la BIOS, bajo la opción CPPC, la opción "Driver". Esto permitirá sobreescribir con sysfs el modo utilizado.
+AMD publicó un parche para optimizar la Programación de Caché en CPUs 3D de doble CCD, como 7950X3D y 7900X3D.
+Necesitas configurar en la BIOS bajo la Opción CPPC a la Opción "Driver". Esto permitirá sobrescribir con sysfs el modo utilizado.
 
 Hay dos modos:
-1. Frequency (Frecuencia)
-2. Cache (Caché)
 
-Si se establece `cache`, el controlador intentará poner las tareas primero en el CCD con la caché más alta, lo cual es principalmente beneficioso en juegos.
-La opción `frequency` intentará poner las tareas en el segundo CCD, que tiene una frecuencia más alta que el CCD con 3D Cache.
+1. Frecuencia
+2. Caché
+
+Si se establece `cache`, el controlador intentará poner las tareas primero en el CCD con la caché más grande, esto es principalmente beneficioso en juegos.
+La opción `frequency` intentará poner las tareas en el segundo CCD, que tiene una frecuencia más alta que el CCD de caché 3D.
 
 Frecuencia (Predeterminado):
 ```sh
@@ -92,30 +92,28 @@ Caché:
 echo cache | sudo tee /sys/bus/platform/drivers/amd_x3d_vcache/AMDI0101:00/amd_x3d_mode
 ```
 
-Después de cambiar los modos, las estadísticas de núcleos preferidos de amd deberían proporcionar una clasificación diferente. Puedes leerla con:
+Después de cambiar los modos, las estadísticas de núcleos preferidos de amd deberían proporcionar un ranking diferente. Puedes leerlo con:
 ```sh
 grep -v /sys/devices/system/cpu/cpu*/cpufreq/amd_pstate_prefcore_ranking
 ```
 
-### AMD P-State Core Performance Boost
+### Impulso de Rendimiento de Núcleo AMD P-State
 
-AMD Core Performance Boost, también conocido como AMD Turbo Core, es una tecnología de escalado dinámico de frecuencia de AMD que permite al
-procesador ajustar y controlar dinámicamente la frecuencia de operación en ciertas versiones de sus procesadores,
-lo que permite un mayor rendimiento cuando es necesario, mientras se mantienen parámetros de energía y térmicos más bajos durante el funcionamiento normal.
+AMD Core Performance Boost aka AMD Turbo Core es una tecnología de escalado dinámico de frecuencia de AMD que permite al
+procesor ajustar y controlar dinámicamente la frecuencia de operación del procesador en ciertas versiones de sus procesadores,
+lo que permite un mayor rendimiento cuando es necesario mientras mantiene parámetros de energía y térmicos más bajos durante la operación normal.
 
-Desde `linux-cachyos` 6.9.6, el kernel está parcheado con soporte de CPB para los controladores p-state de AMD (incluye `passive`, `active` y `guided`).
-Los usuarios pueden cambiar el estado de boost de cada CPU a través del archivo de boost de sysfs `/sys/devices/system/cpu/cpuX/cpufreq/boost`
-(X se refiere al número de núcleo, por ejemplo, cpu0 es el primer núcleo, cpu1 el segundo, etc.).
+Para gestionar AMD CPB en CachyOS, puedes usar los siguientes comandos:
 
 ```sh
-❯ echo 0 | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/boost # Deshabilita el boost para todos los núcleos
-❯ lscpu -ae # Esto muestra que AMD CPB está deshabilitado globalmente
+❯ echo 0 | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/boost # Desactiva boost para todos los núcleos
+❯ lscpu -ae # Esto muestra que AMD CPB está desactivado globalmente
 CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE    MAXMHZ   MINMHZ       MHZ
   0    0      0    0 0:0:0:0          yes 3301.0000 400.0000 1212.8250
   1    0      0    0 0:0:0:0          yes 3301.0000 400.0000 1394.2180
   2    0      0    1 1:1:1:0          yes 3301.0000 400.0000 1204.4600
 
-❯ echo 1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/boost # Habilita el boost en cpu0
+❯ echo 1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/boost # Habilita boost en cpu0
 ❯ lscpu -ae
 CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE    MAXMHZ   MINMHZ       MHZ
   0    0      0    0 0:0:0:0          yes 4564.0000 400.0000 1393.2380
@@ -123,53 +121,53 @@ CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE    MAXMHZ   MINMHZ       MHZ
   2    0      0    1 1:1:1:0          yes 3301.0000 400.0000 2157.8469
 ```
 
-CachyOS también proporciona una versión de `power-profiles-daemon` que incorpora un commit que habilita
-el soporte para AMD CPB. AMD CPB se desactivará si se está utilizando el perfil `powersave`, y se activará en `balanced` o `performance`.
+CachyOS también proporciona una versión de `power-profiles-daemon` que hace backport de un commit que habilita
+el soporte para AMD CPB. AMD CPB se desactivará si se está usando el perfil `powersave`, y se habilitará en `balanced` o `performance`.
 
-Para más información, consulta:
+Para más información ver:
 - https://lore.kernel.org/linux-pm/1a78eeaa-fadd-4734-aaeb-2fe11e96e198@amd.com/T/#m4a0c8917ea8fb033504055bd61512c80c85410c8
 - https://lore.kernel.org/linux-pm/20240624213400.67773-1-mario.limonciello@amd.com/
 
 ## Mejoras de Rendimiento
 
-### [Planificador de E/S ADIOS](https://github.com/firelzrd/adios)
+### [Programador I/O ADIOS](https://github.com/firelzrd/adios)
 
 Creado por [firelzrd](https://github.com/firelzrd)
 
 :::note
 CachyOS incluye la rama estable de ADIOS en el kernel.
 
-Versión actual en **linux-cachyos**: `3.1.7`
+Versión actual en **linux-cachyos**: `3.2.0`
 
-Versión actual en **linux-cachyos-rc**: `3.1.7`
+Versión actual en **linux-cachyos-rc**: `3.2.0`
 :::
 
 Breve introducción del README:
 
-- *ADIOS (Adaptive Deadline I/O Scheduler) es un planificador de E/S de la capa de bloques para el kernel de Linux, diseñado para dispositivos de bloques modernos de múltiples colas (blk-mq). Su objetivo es proporcionar una baja latencia para las operaciones de E/S combinando los principios de la planificación por plazos con un mecanismo de control de latencia adaptativo basado en el aprendizaje.*
-  - *Inspirado y basado en conceptos de los planificadores de E/S mq-deadline y Kyber. Su característica principal es la capacidad de predecir la latencia de finalización de E/S basándose en el rendimiento pasado y las características de la solicitud (tipo de operación, tamaño) y usar esta predicción para ajustar dinámicamente los plazos de las solicitudes y el comportamiento de agrupación.*
+- *ADIOS (Adaptive Deadline I/O Scheduler) es un programador de E/S de capa de bloques para el kernel de Linux, diseñado para dispositivos de bloques multi-cola modernos (blk-mq). Su objetivo es proporcionar baja latencia para operaciones de E/S combinando principios de programación de plazos con un mecanismo de control de latencia adaptativo basado en aprendizaje.*
+  - *Inspirado en y construido sobre conceptos de los programadores de E/S mq-deadline y Kyber. Su característica principal es la capacidad de predecir la latencia de finalización de E/S basada en el rendimiento pasado y las características de la solicitud (tipo de operación, tamaño) y usar esta predicción para ajustar dinámicamente los plazos de las solicitudes y el comportamiento de agrupación.*
 
-En resumen: ADIOS funciona aprendiendo el perfil de latencia de tu dispositivo de almacenamiento y utilizando ese conocimiento para establecer dinámicamente plazos para las solicitudes de E/S. Prioriza las solicitudes en cuatro niveles, desde operaciones críticas del sistema (Nivel 0) hasta tareas en segundo plano (Nivel 3), para garantizar una experiencia de usuario fluida. Aunque se enfoca en la capacidad de respuesta, su comportamiento puede ajustarse a través de la configuración de sysfs para equilibrar la latencia y el rendimiento.
+TLDR: ADIOS funciona aprendiendo el perfil de latencia de tu dispositivo de almacenamiento y usando ese conocimiento para establecer dinámicamente plazos para solicitudes de E/S. Prioriza las solicitudes en cuatro niveles, desde operaciones críticas del sistema (Nivel 0) hasta tareas en segundo plano (Nivel 3), para asegurar una experiencia de usuario fluida. Aunque se centra en la capacidad de respuesta, su comportamiento puede afinarse a través de configuraciones sysfs para equilibrar latencia y rendimiento.
 
-Para una demostración en vivo, puedes ver este [video](https://www.youtube.com/watch?v=L9WDcEeHgy4)
+Para una demostración en vivo, puedes ver este [vídeo](https://www.youtube.com/watch?v=L9WDcEeHgy4)
 
 #### Cómo habilitar ADIOS
 
 <Tabs>
-    <TabItem label='Temporalmente (efecto en tiempo de ejecución)'>
-        Este método establece el planificador para la sesión actual. El cambio se perderá al reiniciar.
+    <TabItem label='Temporalmente (entra en efecto en tiempo de ejecución)'>
+        Este método establece el programador para la sesión actual. El cambio se perderá al reiniciar.
         ```sh
-        sync && echo adios | sudo tee /sys/block/<tudisco>/queue/scheduler
-            # Reemplaza <tudisco> con el identificador real del disco (ej. sda, sdb, nvme0n1)
+        sync && echo adios | sudo tee /sys/block/<tudir>/queue/scheduler
+            # Reemplaza <tudir> con el identificador real del dispositivo (p. ej. sda, sdb, nvme0n1)
         ```
     </TabItem>
-    <TabItem label='Persistente después de reiniciar'>
+    <TabItem label='Persistente después del reinicio'>
         <Steps>
-            1. Abre o crea un nuevo archivo de reglas udev en tu editor de texto preferido (ej., nano, micro, vim)
+            1. Abre o crea un nuevo archivo de reglas udev en tu editor de texto preferido (p. ej., nano, micro, vim)
                 ```sh title='Ejemplo'
                 sudo nano /etc/udev/rules.d/60-ioschedulers.rules
                 ```
-            2. Añade las siguientes reglas al archivo. Estas reglas aplican automáticamente un planificador de E/S específico según el tipo de disco (HDD, SSD o NVMe).
+            2. Añade las siguientes reglas al archivo. Estas reglas aplican automáticamente un programador de E/S específico basado en el tipo de dispositivo (HDD, SSD o NVMe).
                 ```text
                 # HDD
                 ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
@@ -183,8 +181,8 @@ Para una demostración en vivo, puedes ver este [video](https://www.youtube.com/
                 ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
                     ATTR{queue/scheduler}="adios"
                 ```
-              3.  Guarda el archivo y cierra el editor.
-              4.  Recarga las reglas de `udev` para aplicar los cambios inmediatamente sin necesidad de reiniciar.
+              3. Guarda el archivo y cierra el editor.
+              4. Recarga las reglas de `udev` para aplicar los cambios inmediatamente sin reiniciar.
                   ```sh
                   sudo udevadm control --reload-rules
                   sudo udevadm trigger
@@ -193,17 +191,17 @@ Para una demostración en vivo, puedes ver este [video](https://www.youtube.com/
     </TabItem>
 </Tabs>
 
-Preguntas frecuentes:
+FAQ:
 
 - Si mejora la capacidad de respuesta, ¿por qué no está habilitado por defecto?
-  - ADIOS todavía está en desarrollo activo y pruebas continuas. Aunque ofrece beneficios significativos para la capacidad de respuesta del escritorio, aún no se considera lo suficientemente estable como para ser el predeterminado para todas las cargas de trabajo y tipos de hardware. En algunos casos extremos, los errores podrían provocar problemas como bloqueos del sistema. Por esta razón, es una característica opcional para los usuarios que deseen probar y beneficiarse de sus últimas mejoras.
+  - ADIOS está aún bajo desarrollo activo y pruebas continuas. Aunque ofrece beneficios significativos para la capacidad de respuesta del escritorio, aún no se considera lo suficientemente estable para ser el predeterminado para todas las cargas de trabajo y tipos de hardware. En algunos casos extremos, errores podrían llevar a problemas como bloqueos del sistema. Por esta razón, es una función opcional para usuarios que deseen probar y beneficiarse de sus últimas mejoras.
 
-### NVIDIA Smooth Motion (Series RTX 40xx y 50xx)
+### NVIDIA Smooth Motion (Series RTX 40xx & 50xx)
 
-:::note[Compatibilidad con juegos.]
-Juegos que funcionan con DX11, DX12 y Vulkan.
+:::note[Compatibilidad de Juegos.]
+Juegos que se ejecutan en DX11, DX12 y Vulkan. Ver FAQ para una solución alternativa para OpenGL.
 
-Tanto DXVK como VKD3D funcionan sin problemas.
+Tanto DXVK como VKD3D funcionan bien.
 
 **Solo se admiten aplicaciones de 64 bits. Smooth Motion no funcionará con aplicaciones de 32 bits (p. ej., juegos antiguos de DX11).**
 
@@ -211,7 +209,7 @@ Tanto DXVK como VKD3D funcionan sin problemas.
 
 Cita directa de la documentación de NVIDIA:
 
-*NVIDIA Smooth Motion es un nuevo modelo de IA basado en el controlador que proporciona una jugabilidad más fluida al inferir un fotograma adicional entre dos fotogramas renderizados. Para los juegos sin DLSS Frame Generation, NVIDIA Smooth Motion es una nueva opción para mejorar tu experiencia en las GPU GeForce RTX Serie 40 y más recientes.*
+*NVIDIA Smooth Motion es un nuevo modelo basado en IA del controlador que ofrece una jugabilidad más fluida al inferir un fotograma adicional entre dos fotogramas renderizados. Para juegos sin Generación de Fotogramas DLSS, NVIDIA Smooth Motion es una nueva opción para mejorar tu experiencia en GeForce RTX 40 Series y GPUs más nuevas.*
 
 - Cómo habilitar NVIDIA Smooth Motion para un juego:
   - Añade la siguiente variable de entorno:
@@ -219,60 +217,82 @@ Cita directa de la documentación de NVIDIA:
     NVPRESENT_ENABLE_SMOOTH_MOTION=1
     ```
 
-Preguntas frecuentes:
+FAQ:
 
-- ¿Por qué usar Smooth Motion en lugar de DLSS Frame Generation?
-  - Cuando un juego no es compatible con DLSS Frame Generation, Smooth Motion sirve como alternativa gracias a su modelo de IA basado en el controlador.
-- ¿Hay alguna desventaja al usar Smooth Motion?
-  - Sí, habilitar Smooth Motion puede introducir un ligero retardo de entrada (input lag) debido al proceso de inferencia de fotogramas adicionales.
-  - Es propenso a causar problemas con superposiciones (overlays) de terceros. Para evitar esto, incluye la siguiente variable de entorno:
+- ¿Por qué usar Smooth Motion en lugar de Generación de Fotogramas DLSS?
+  - Cuando un juego no tiene soporte para Generación de Fotogramas DLSS, Smooth Motion sirve como alternativa gracias a su modelo basado en IA del controlador.
+- ¿Hay alguna desventaja en usar Smooth Motion?
+  - Sí, habilitar Smooth Motion puede introducir un ligero retraso de entrada debido al proceso adicional de inferencia de fotogramas.
+  - Propenso a causar problemas con superposiciones de terceros. Para evitar esto, incluye la siguiente variable de entorno:
     ```text
     NVPRESENT_QUEUE_FAMILY=1
     ```
-    :::note[Se puede observar un impacto en el rendimiento al usar esta variable.]
+    :::note[Puede observarse un impacto en el rendimiento al usar esta variable.]
     :::
-- ¿Por qué MangoHud no informa del aumento en la tasa de fotogramas?
-  - Actualmente, MangoHud no tiene en cuenta los fotogramas adicionales generados por Smooth Motion, lo que lleva a que la tasa de fotogramas informada sea engañosa.
-    - Usar el contador de FPS integrado de un monitor proporcionará la tasa de fotogramas correcta.
-- ¿Cómo es la calidad de imagen en comparación con DLSS Frame Generation?
+- ¿Por qué MangoHud no reporta el aumento de framerate?
+  - Actualmente, MangoHud no tiene en cuenta los fotogramas adicionales generados por Smooth Motion, lo que lleva a un framerate reportado engañoso.
+    - Usar el contador de FPS integrado del monitor proporcionará el framerate correcto.
+- ¿Cómo es la calidad de imagen comparada con Generación de Fotogramas DLSS?
   - La calidad de imagen no es tan buena y puede introducir artefactos, especialmente durante escenas de movimiento rápido.
-- ¿Es compatible con herramientas externas para limitar los fotogramas? Ejemplo: MangoHud.
-  - No. El limitador del propio juego debería funcionar sin problemas.
-- ¿Se puede combinar Smooth Motion con DLSS Frame Generation?
-  - No. Solo puede haber un método de generación de fotogramas activo a la vez.
+- ¿Es compatible con herramientas externas de limitación de fotogramas? Ejemplo: MangoHud.
+  - No. El límite en el juego debería funcionar bien.
+- ¿Se puede combinar Smooth Motion con Generación de Fotogramas DLSS?
+  - No. Solo un método de generación de fotogramas puede estar activo a la vez.
+- ¿Se puede usar Smooth Motion con aplicaciones OpenGL?
+  - No directamente, ya que está implementado como una capa Vulkan, pero es posible aprovechando [Zink](https://docs.mesa3d.org/drivers/zink.html) para traducir llamadas OpenGL a Vulkan:
+    ```text
+    NVPRESENT_ENABLE_SMOOTH_MOTION=1 zink-run <comando>
+    ```
+    :::note
+    Usar Zink probablemente tendrá un impacto en el rendimiento y puede introducir errores gráficos en algunos juegos.
+
+    Los usuarios de doble GPU necesitan establecer `DRI_PRIME=1` para utilizar la dGPU de Nvidia en lugar de usar métodos más típicos de selección de GPU.
+    :::
 
 ## Ajustes de Ahorro de Energía
 
+### thermald
+
+`thermald` es un demonio de gestión térmica para sistemas Intel. Monitorea sensores térmicos y aplica acciones de enfriamiento, como límites de energía de CPU o cambios de estado de rendimiento, antes de que el firmware necesite usar estrangulamiento más agresivo.
+
+Es principalmente útil en portátiles, convertibles, tablets, dispositivos handheld y PCs de formato pequeño de Intel que exponen controles térmicos de Intel a través de `/sys/class/thermal`. Los sistemas admitidos comúnmente usan sensores de temperatura de CPU Intel, Intel P-state, Intel power clamp, RAPL, `INT340X` o tablas térmicas ACPI DPTF/adaptive. Las CPUs AMD no son admitidas por `thermald`.
+
+Instala y habilita con:
+
+```sh
+sudo pacman -S thermald
+sudo systemctl enable --now thermald.service
+```
+
+Verifica que se inició correctamente:
+
+```sh
+systemctl status thermald.service
+journalctl -u thermald.service -b
+```
+
+Para más información:
+
+<LinkButton icon="external" href="https://github.com/intel/thermal_daemon">Repositorio upstream de thermald</LinkButton>
+<LinkButton icon="external" href="https://man.archlinux.org/man/thermald.8">Página manual de thermald</LinkButton>
+
 ### Habilitar RCU Lazy
 
-RCU Lazy ayuda a reducir el consumo de energía en sistemas inactivos o con poca carga. Esto puede ser útil para portátiles y dispositivos de mano.
-La mejora es de entre un 5% y un 10% en términos de ahorro de energía. Sin embargo, es importante tener en cuenta que esta función de ahorro de energía puede tener el costo de un rendimiento ligeramente reducido dependiendo del escenario.
+RCU Lazy ayuda a reducir el consumo de energía en reposo o en sistemas con carga ligera. Esto puede ser útil para portátiles y dispositivos handheld.
+La mejora está entre 5-10% en términos de ahorro de energía. Sin embargo, es importante tener en cuenta que esta función de ahorro de energía puede venir a costa de un rendimiento ligeramente reducido dependiendo del escenario.
 El kernel linux-cachyos-deckify tendrá esta opción habilitada por defecto, ya que el ahorro de energía es clave y necesario para estos dispositivos.
 
-Para habilitar RCU Lazy, añade el siguiente parámetro a tu lista de parámetros de [línea de comandos](/es/configuration/boot_manager_configuration/) del kernel:
+Para habilitar RCU Lazy, añade el siguiente parámetro a tu lista de parámetros [cmdline](/es/configuration/boot_manager_configuration/) del kernel:
 ```text
 rcutree.enable_rcu_lazy=1
 ```
 
 ## Solución de Problemas de NVIDIA
 
-### Deshabilitar el backend Wayland de SDDM
-
-:::note
-A partir de cachyos-kde-settings 4.3, SDDM utiliza KWin como su compositor Wayland por defecto.
-:::
-
-Aunque este es un buen paso adelante, podría introducir algunas molestias como romper el soporte para overclocking usando nvidia-settings o causar incompatibilidad con GPUs más antiguas que tienen dificultades con Wayland.
-
-Para revertir este cambio, elimina el paquete cachyos-kde-settings:
-```sh
-sudo pacman -R cachyos-kde-settings
-```
-
 ### Firmware GSP de NVIDIA
 
-El Firmware GSP de NVIDIA puede **"en algunos casos"** llevar a una disminución del rendimiento. Aunque el controlador de NVIDIA 555.58.02 ha solucionado en gran medida este problema, puede persistir en ciertos sistemas.
-Si estás experimentando tirones en KDE o un mal rendimiento en algunos casos, puedes deshabilitar el Firmware GSP con el siguiente archivo de configuración:
+El Firmware GSP de NVIDIA puede **"en algunos casos"** llevar a un rendimiento disminuido. Aunque el controlador NVIDIA 555.58.02 ha abordado en gran medida este problema, puede persistir en ciertos sistemas.
+Si estás experimentando microcortes en KDE o mal rendimiento en algunos casos, puedes deshabilitar el Firmware GSP con el siguiente archivo de configuración:
 `/etc/modprobe.d/nvidia-gsp.conf`
 
 ```text
@@ -285,18 +305,18 @@ sudo mkinitcpio -P
 ```
 
 :::note
-Los [módulos de kernel abiertos](https://github.com/NVIDIA/open-gpu-kernel-modules) de NVIDIA se basan en el firmware GSP. Debido a esto, GSP no puede ser deshabilitado y esta opción de modprobe será ignorada al usarlos. Usa `linux-cachyos-nvidia` o `nvidia-dkms`.
+Los [módulos de kernel abiertos](https://github.com/NVIDIA/open-gpu-kernel-modules) de NVIDIA están basados en el firmware GSP. Debido a esto, GSP no puede ser deshabilitado y esta opción de modprobe será ignorada al usarlos. Usa `linux-cachyos-nvidia` o `nvidia-dkms`.
 :::
 
-Generalmente se recomienda probar el firmware GSP después de cada nueva instalación del controlador de NVIDIA, ya que a menudo introduce características beneficiosas. Además, NVIDIA comenzó principalmente a realizar pruebas de control de calidad utilizando el firmware GSP.
+Generalmente se recomienda probar el firmware GSP después de cada nueva instalación del controlador NVIDIA, ya que a menudo introduce beneficiosas características. Además, NVIDIA comenzó principalmente a realizar pruebas de QA usando el firmware GSP.
 
 ## Mejoras de Audio y Software
 
 ### Mejorando el Sonido de los Altavoces del Portátil
 
-Los altavoces de los portátiles a menudo producen un sonido débil y decepcionante debido a su tamaño compacto y capacidades de hardware limitadas. [EasyEffects](https://wiki.archlinux.org/title/PipeWire#EasyEffects) puede mejorar significativamente la calidad del sonido de los altavoces integrados de tu portátil aplicando diversos efectos de audio y configuraciones personalizadas.
+Los altavoces de los portátiles a menudo producen un sonido delgado e insatisfactorio debido a su tamaño compacto y capacidades de hardware limitadas. [EasyEffects](https://wiki.archlinux.org/title/PipeWire#EasyEffects) puede mejorar significativamente la calidad de sonido de los altavoces integrados de tu portátil aplicando varios efectos de audio y configuraciones personalizadas.
 
-Para empezar, necesitas instalar EasyEffects y las dependencias requeridas:
+Para comenzar necesitas instalar EasyEffects y las dependencias requeridas:
 
 ```bash
 # Instalar EasyEffects
@@ -313,19 +333,19 @@ sudo pacman -S mda.lv2
 Sigue estos pasos para configurar EasyEffects:
 
 1. Inicia EasyEffects desde tu menú de aplicaciones o escribiendo `easyeffects` en la terminal.
-2. Navega a la pestaña **Output** para gestionar los efectos aplicados al audio de tus altavoces.
-3. Cambia a la pestaña **Effects** para añadir, modificar o ajustar los efectos de audio.
+2. Navega a la pestaña **Output** para gestionar efectos aplicados a tu audio de altavoces.
+3. Cambia a la pestaña **Effects** para añadir, modificar o ajustar efectos de audio.
 
 <ImageComponent imgsrc={import('~/assets/images/easyeffects.png')} />
 
-##### Usando Preajustes de la Comunidad
+##### Usando Presets de la Comunidad
 
-Para una configuración rápida y efectiva, comienza con los **preajustes creados por la comunidad** diseñados para diversos escenarios de audio:
+Para una configuración rápida y efectiva, comienza con **presets creados por la comunidad** adaptados para varios escenarios de audio:
 
-1. Descarga preajustes desde el repositorio de [Preajustes de la Comunidad de EasyEffects](https://github.com/wwmm/easyeffects/wiki/Community-presets).
+1. Descarga presets del repositorio [EasyEffects Community Presets](https://github.com/wwmm/easyeffects/wiki/Community-presets).
 2. En EasyEffects, haz clic en el botón **Presets** y elige **"Import preset from local storage"**.
-3. Localiza y selecciona el archivo de preajuste descargado.
-4. Una vez importado, el preajuste aparecerá en tu lista; haz clic en **"Load"** para aplicarlo a tu salida de audio.
+3. Localiza y selecciona el archivo de preset descargado.
+4. Una vez importado, el preset aparecerá en tu lista—haz clic en **"Load"** para aplicarlo a tu salida de audio.
 
 <ImageComponent imgsrc={import('~/assets/images/easyeffects-presets.png')} />
 
@@ -333,117 +353,127 @@ Para una configuración rápida y efectiva, comienza con los **preajustes creado
 
 Para una experiencia de audio más personalizada, crea un perfil personalizado adaptado a los altavoces de tu portátil:
 
-1. Haz clic en el botón **"+"** en el menú de Presets para crear un nuevo preajuste (p. ej., nómbralo **"Laptop Speakers"**).
-2. Selecciona **"Load"** para activar el nuevo preajuste.
-3. Añade y configura efectos en la pestaña **Output** > **Effects**, experimentando con opciones como ecualizadores, potenciadores de graves o ensanchadores estéreo.
+1. Haz clic en el botón **"+"** en el menú Presets para crear un nuevo preset (p. ej., llámalo **"Laptop Speakers"**).
+2. Selecciona **"Load"** para activar el nuevo preset.
+3. Añade y configura efectos en la pestaña **Output** > **Effects**, experimentando con opciones como ecualizadores, potenciadores de graves o ampliadores de estéreo.
 
-##### Usando el Efecto Convolver (Portátiles con Dolby Atmos)
+##### Usando el Efecto Convolver (Portátiles Dolby Atmos)
 
-El efecto **Convolver** puede mejorar drásticamente el sonido aplicando respuestas de impulso que simulan entornos de audio de alta calidad. Sin embargo, requiere una configuración precisa:
+El **efecto Convolver** puede mejorar drásticamente el sonido aplicando respuestas impulsionales que simulan entornos de audio de alta calidad. Sin embargo, requiere una configuración precisa:
 
 1. Añade el efecto **Convolver** a tu cadena de efectos en la pestaña **Effects**.
-2. Carga un archivo de respuesta de impulso (en formato `.wav`) específico para tu modelo de portátil, si está disponible. Puedes buscar estos archivos en línea en recursos como:
+2. Carga un archivo de respuesta impulsional (en formato `.wav`) específico para tu modelo de portátil, si está disponible. Puedes buscar estos archivos en línea en recursos como:
    - https://wiki.archlinux.org/title/Lenovo_ThinkPad_T14_(AMD)_Gen_4#Speakers
    - https://github.com/m4tx/thinkpad-p14s-g4-linux/#sound
    - https://github.com/shuhaowu/linux-thinkpad-speaker-improvements/
-3. **Prevenir el clipping**: El efecto Convolver puede aumentar significativamente el volumen. Añade un efecto **Limiter** después del Convolver en tu cadena de efectos para controlar los picos y evitar la distorsión.
+3. **Prevenir el recorte**: El efecto Convolver puede aumentar significativamente el volumen. Añade un efecto **Limiter** después del Convolver en tu cadena de efectos para controlar los picos y evitar distorsión.
 
 <ImageComponent imgsrc={import('~/assets/images/easyeffects-convolver.png')} />
 
 #### Consejos para Resultados Óptimos
 
-- **Experimenta** con diferentes preajustes para identificar el que mejor se adapte a tu modelo de portátil específico y a tus preferencias de sonido personales.
-- **Realiza ajustes incrementales** en los efectos individuales para evitar distorsión o un sonido poco natural.
-- **Compara activando y desactivando**: Activa y desactiva EasyEffects frecuentemente para evaluar las mejoras en comparación con el audio predeterminado.
-- Busca **preajustes específicos del dispositivo o respuestas de impulso de Convolver** para modelos de portátiles populares como **Framework Laptop 13** o **ThinkPad T14** para lograr resultados personalizados.
-- **Automatizar el inicio**: Configura EasyEffects para que se inicie automáticamente al arrancar a través de las preferencias de la aplicación para asegurar que tu perfil personalizado siempre se aplique.
-- **Autocargar preajustes para múltiples dispositivos**: Usa la pestaña **PipeWire** > **Presets Autoloading** para asociar preajustes específicos con diferentes dispositivos de salida (p. ej., Altavoces vs. Auriculares) para un cambio sin interrupciones. <ImageComponent imgsrc={import('~/assets/images/easyeffects-autoloading.png')} />
+- **Experimenta** con diferentes presets para identificar la mejor coincidencia para tu modelo específico de portátil y preferencias personales de sonido.
+- **Haz ajustes incrementales** a efectos individuales para prevenir distorsión o salida de sonido antinatural.
+- **Compara con alternancia**: Alterna frecuentemente EasyEffects **on/off** para evaluar las mejoras frente al audio predeterminado.
+- Busca **presets específicos del dispositivo o respuestas impulsionales de Convolver** para modelos populares de portátiles como **Framework Laptop 13** o **ThinkPad T14** para lograr resultados personalizados.
+- **Automatiza el inicio**: Configura EasyEffects para iniciarse automáticamente en el arranque a través de las preferencias de la app para asegurar que tu perfil personalizado esté siempre aplicado.
+- **Carga automática de presets para múltiples dispositivos**: Usa la pestaña **PipeWire** > **Presets Autoloading** para asociar presets específicos con diferentes dispositivos de salida (p. ej., Altavoces vs. Auriculares) para un cambio sin problemas. <ImageComponent imgsrc={import('~/assets/images/easyeffects-autoloading.png')} />
 
 #### Alternativa a EasyEffects
 
-Como alternativa, puedes probar a usar [JDSP4Linux](https://github.com/Audio4Linux/JDSP4Linux), que es un procesador de efectos de audio para clientes de PipeWire y PulseAudio.
+Como alternativa puedes probar usando [JDSP4Linux](https://github.com/Audio4Linux/JDSP4Linux), que es un procesador de efectos de audio para clientes PipeWire y PulseAudio.
 
 ### OBS Studio
 
-Proporcionamos un paquete personalizado obs-studio-browser en nuestro repositorio que se recomienda sobre el paquete estándar `obs-studio`. Contiene parches para solucionar algunos de los problemas comunes como errores de cuda y problemas con la cámara virtual.
+Proporcionamos un paquete personalizado obs-studio-browser en nuestro repositorio que es recomendado sobre el paquete estándar `obs-studio`. Contiene parches para corregir algunos de los problemas comunes como errores cuda y problemas de cámara virtual.
 
 ```sh title='Abre una terminal y ejecuta el siguiente comando'
 sudo pacman -S obs-studio-browser
-# Si tenías instalado previamente obs-studio, pacman te preguntará si
-# quieres reemplazarlo, en ese caso, introduce "Y".
+# Si previamente tenías el obs-studio instalado entonces pacman te preguntará si
+# quieres reemplazarlo, si es así ingresa "Y".
 ```
 
-## Configuración de la memoria de intercambio (Swap)
+## Configuración de Swap
 
 ### Cambiar de ZRam a Zswap
 
-Por defecto, CachyOS utiliza ZRam para la gestión de la memoria de intercambio. Sin embargo, si prefieres usar Zswap en su lugar, puedes cambiarlo fácilmente siguiendo estos pasos:
+Por defecto, CachyOS usa ZRam para la gestión de swap. Sin embargo, si prefieres usar Zswap en su lugar, puedes cambiar fácilmente siguiendo estos pasos:
 
 :::note
-Esta guía asume que tienes la configuración por defecto de CachyOS con ZRam activado y que no se creó ninguna partición o archivo de intercambio durante la instalación.
+Esta guía asume que tienes la configuración predeterminada de CachyOS con ZRam habilitado y no se creó una partición o archivo de swap durante la instalación.
 :::
 
 <Steps>
-    1. Deshabilita ZRam añadiendo un parámetro del kernel. [Edita la configuración de tu gestor de arranque](/es/configuration/boot_manager_configuration) y añade la siguiente línea:
+    1. Deshabilita ZRam añadiendo un parámetro del kernel. [Edita tu configuración del gestor de arranque](/es/configuration/boot_manager_configuration) y añade la siguiente línea:
         ```text
         systemd.zram=0
         ```
-    2. Crea un archivo de anulación vacío para deshabilitar la [regla udev de CachyOS](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/30-zram.rules) que deshabilita Zswap:
-        ```bash
-        sudo touch /etc/udev/rules.d/30-zram.rules
-        ```
-    3. Habilita Zswap añadiendo el siguiente parámetro del kernel:
+    2. Habilita Zswap añadiendo el siguiente parámetro del kernel:
         ```text
         zswap.enabled=1 zswap.shrinker_enabled=1 zswap.compressor=lz4 zswap.max_pool_percent=30
         ```
-    4. Crea un archivo de intercambio (swap) para Zswap.
+    3. Crea un archivo de override vacío para deshabilitar [la regla udev de CachyOS](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/30-zram.rules) que deshabilita Zswap:
+        ```bash
+        sudo touch /etc/udev/rules.d/30-zram.rules
+        ```
+    4. Crea un archivo de swap para Zswap.
         <details>
             <summary>Si estás usando Btrfs:</summary>
                 <Steps>
-                    1. Crea un subvolumen Btrfs para el archivo de intercambio:
+                    1. Crea un subvolumen Btrfs para el archivo de swap:
                         ```bash
                         sudo btrfs subvolume create /swap
                         ```
-                    2. Crea un archivo de intercambio con el tamaño que desees (p. ej., 8GB) cambiando el parámetro `--size`:
+                    2. Crea un archivo de swap con tu tamaño deseado (p. ej., 8GB) cambiando el parámetro `--size`:
                         ```bash "--size"
                         sudo btrfs filesystem mkswapfile --size 4g --uuid clear /swap/swapfile
                         ```
-                    3. Activa el archivo de intercambio:
+                    3. Activa el archivo de swap:
                         ```bash
                         sudo swapon /swap/swapfile
                         ```
-                    4. Añade el archivo de intercambio a `/etc/fstab` para que sea persistente entre reinicios:
+                    4. Añade el archivo de swap a `/etc/fstab` para hacerlo persistente entre reinicios:
                         ```bash
-                        sudo echo "/swap/swapfile none swap defaults 0 0" >> /etc/fstab
+                        echo "/swap/swapfile none swap defaults 0 0" | sudo tee -a /etc/fstab
                         ```
                 </Steps>
         </details>
         <details>
             <summary>Si no estás usando Btrfs:</summary>
             <Steps>
-                1. Crea un archivo de intercambio con el tamaño que desees (p. ej., 8GB) cambiando el parámetro `count=`:
+                1. Crea un archivo de swap con tu tamaño deseado (p. ej., 8GB) cambiando el parámetro `count=`:
                     ```bash "count=8"
                     sudo dd if=/dev/zero of=/swapfile bs=1G count=8
                     ```
-                2. Establece los permisos correctos para el archivo de intercambio:
+                2. Establece los permisos correctos para el archivo de swap:
                     ```bash
                     sudo chmod 0600 /swapfile
                     ```
-                3. Formatea el archivo de intercambio:
+                3. Formatea el archivo de swap:
                     ```bash
                     sudo mkswap /swapfile
                     ```
-                4. Añade el archivo de intercambio a `/etc/fstab` para que sea persistente entre reinicios:
+                4. Añade el archivo de swap a `/etc/fstab` para hacerlo persistente entre reinicios:
                     ```bash
-                    sudo echo "/swapfile none swap defaults 0 0" >> /etc/fstab
+                    echo "/swapfile none swap defaults 0 0" | sudo tee -a /etc/fstab
                     ```
-                5. Activa el archivo de intercambio:
+                5. Activa el archivo de swap:
                     ```
                     sudo swapon /swapfile
                     ```
             </Steps>
         </details>
-    5. Reconstruye tu initramfs para aplicar los cambios. El comando varía dependiendo de tu gestor de arranque:
+    5. Añade el módulo de compresión lz4 al archivo de configuración `mkinitcpio.conf`:
+        1. Abre el archivo con un editor de texto:
+            ```bash
+            sudo nano /etc/mkinitcpio.conf
+            ```
+        2. Busca el array `MODULES` y añade `lz4` a él. Debería verse algo como esto:
+            ```text
+            MODULES=(... lz4)
+            ```
+        3. Guarda el archivo presionando `Ctrl + O` y `Enter` para confirmar, luego sal del editor con `Ctrl + X`.
+    6. Reconstruye tu initramfs para aplicar los cambios. El comando varía dependiendo de tu gestor de arranque:
         <details>
             <summary>systemd-boot</summary>
             ```bash
@@ -462,5 +492,5 @@ Esta guía asume que tienes la configuración por defecto de CachyOS con ZRam ac
             sudo limine-mkinitcpio
             ```
         </details>
-    6. Reinicia tu sistema para aplicar todos los cambios.
+    7. Reinicia tu sistema para aplicar todos los cambios.
 </Steps>

--- a/src/content/docs/es/configuration/post_install_setup.mdx
+++ b/src/content/docs/es/configuration/post_install_setup.mdx
@@ -3,12 +3,16 @@ title: Postinstalación
 description: Pasos a configurar después de instalar CachyOS
 tableOfContents:
   minHeadingLevel: 1
-  maxHeadingLevel: 3
+  maxHeadingLevel: 4
+ai_translated: true
 ---
 
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, LinkButton, Icon } from '@astrojs/starlight/components';
+import ImageComponent from '~/components/image-component.astro';
 
-## Actualizando el sistema
+## Pasos Recomendados Después de la Instalación
+
+### Actualizando el Sistema
 
 :::tip
 Asegúrate de consultar nuestra sección de [Seguridad y Buenas Prácticas](/es/cachyos_basic/faq#seguridad-y-buenas-prácticas) para evitar errores comunes y mantener tu sistema seguro.
@@ -16,19 +20,79 @@ Asegúrate de consultar nuestra sección de [Seguridad y Buenas Prácticas](/es/
 
 <Tabs>
 
+<TabItem label="Shelly (GUI & CLI)">
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/overview/">Wiki de Shelly</LinkButton>
+    <LinkButton icon="external" href="https://www.seafoam-labs.org/shelly-alpm/docs/cli-reference/">CLI de Shelly</LinkButton>
+
+    [Shelly](https://github.com/Seafoam-Labs/Shelly-ALPM) es una reimaginación moderna del gestor de paquetes de Arch Linux, diseñado para ser una alternativa más intuitiva y amigable a pacman y octopi.
+
+    Desarrollado por: [Seafoam-Labs](https://github.com/Seafoam-Labs)
+
+    Permitiendo a los usuarios gestionar sus paquetes sin necesidad de usar la terminal.
+
+    Algunas de las características de Shelly incluyen:
+
+    Instalar/Desinstalar paquetes desde el AUR, repositorios oficiales, AppImages, Flatpaks y paquetes locales, ver detalles de paquetes, gestionar grupos de paquetes y más.
+
+    ¿Por qué elegir Shelly sobre Octopi?
+    - Tiene una interfaz más moderna y amigable.
+    - Desarrollo y actualizaciones continuas con nuevas características y mejoras.
+    - Soporta más formatos de paquetes (AUR, AppImages, Flatpaks, etc.)
+    - Características de seguridad como verificación de PKGBUILDs, consulta las [Comprobaciones de Seguridad](https://www.seafoam-labs.org/shelly-alpm/docs/security/) para más información.
+
+    <details>
+        <summary>Captura de pantalla de la página principal de Shelly</summary>
+        <ImageComponent imgsrc={import('~/assets/images/shelly-homepage.png')} />
+    </details>
+    <details>
+        <summary>Pestaña de Gestión de Paquetes</summary>
+        <ImageComponent imgsrc={import('~/assets/images/shelly-package-management.png')} />
+    </details>
+    Aquí hay algunos comandos útiles para comenzar con la CLI de Shelly:
+
+    <details>
+    <summary>Actualizar todos los paquetes (AUR, repositorios oficiales, Flatpak, etc.):</summary>
+    ```sh
+    shelly
+    ```
+    </details>
+    <details>
+    <summary>Actualizar paquetes estándar (derivados de Arch) + instalar paquete:</summary>
+    ```sh
+    shelly install --upgrade {pkg}
+    # Ejemplo:
+    shelly install --upgrade discord
+    ```
+    </details>
+    <details>
+    <summary>Eliminar paquete y dependencias:</summary>
+    ```sh
+    shelly remove {pkg}
+    # Ejemplo:
+    shelly remove discord
+    ```
+    </details>
+    <details>
+    <summary>Buscar paquete en AUR:</summary>
+    ```sh
+    shelly aur search {pkg}
+    ```
+    </details>
+</TabItem>
+
 <TabItem label="Usando Octopi (GUI)">
 
-Octopi es un gestor de paquetes gráfico para distribuciones basadas en Arch que proporciona una forma cómoda de gestionar paquetes y actualizaciones.
+Octopi es un gestor de paquetes gráfico para distribuciones basadas en Arch que proporciona una forma conveniente de gestionar paquetes y actualizaciones.
 Para actualizar tu sistema con Octopi, sigue estos pasos:
 
 <Steps>
 
 1. Inicia **Octopi** desde el menú de aplicaciones.
-2. En la ventana principal, haz clic en el botón **Check updates** (Comprobar actualizaciones) (arriba a la izquierda), y ahora al lado en **System upgrade.** (Actualización del sistema).
-3. Octopi buscará las actualizaciones disponibles y te pedirá que las instales en el propio Octopi o en una terminal.
-4. Para proceder con la actualización, haz clic en el botón **Apply** (Aplicar).
+2. En la ventana principal, haz clic en el botón **Check updates** (Esquina superior izquierda), ahora junto a él **System upgrade.**
+3. Octopi ahora buscará actualizaciones disponibles y te pedirá que las instales en Octopi mismo o en una terminal.
+4. Para proceder con la actualización, haz clic en el botón **Apply**.
 5. Octopi descargará e instalará las actualizaciones.
-6. Se recomienda reiniciar el ordenador después de una actualización grande **(especialmente si el kernel ha recibido una actualización)**.
+6. Se recomienda reiniciar tu computadora después de una gran actualización **(especialmente si el kernel recibió una actualización)**.
 
 </Steps>
 
@@ -38,28 +102,28 @@ Para actualizar tu sistema con Octopi, sigue estos pasos:
 
 <Steps>
 
-1. Abre un emulador de terminal (o presiona `ctrl + alt + t` - `mod + return` en un WM, por ejemplo, Qtile).
+1. Abre un emulador de terminal (o presiona `ctrl + alt + t` - `mod + return` en un WM p. ej. Qtile).
 2. Ejecuta el siguiente comando para actualizar el sistema:
 
    ```sh
    sudo pacman -Syu
    ```
-3. Se recomienda reiniciar el ordenador después de una actualización grande **(especialmente si el kernel ha recibido una actualización)**.
+3. Se recomienda reiniciar tu computadora después de una gran actualización **(especialmente si el kernel recibió una actualización)**.
 
 </Steps>
 
 </TabItem>
 
-<TabItem label="Actualización del sistema sin conexión">
+<TabItem label="Actualización del Sistema Offline">
 
-*CachyOS soporta actualizaciones del sistema sin conexión utilizando el script [`pacman-offline`](https://github.com/eworm-de/pacman-offline). Esto permite a tu sistema descargar actualizaciones de paquetes y aplicarlas en el siguiente reinicio. (Sí, como en Windows)*
+*CachyOS soporta actualizaciones del sistema offline usando el script [`pacman-offline`](https://github.com/eworm-de/pacman-offline). Esto permite que tu sistema descargue actualizaciones de paquetes y las aplique en el siguiente reinicio. (Sí, como en Windows)*
 
 :::note
-La herramienta `pacman-offline` se integra con la función de actualizaciones sin conexión de systemd. Gestiona automáticamente las actualizaciones del kernel y la carga de módulos.
+La herramienta `pacman-offline` se integra con la función de actualizaciones offline de systemd. Maneja automáticamente las actualizaciones del kernel y la carga de módulos.
 
-El archivo `/etc/pacman.d/offline.conf` es crucial para gestionar qué paquetes se actualizan durante las actualizaciones regulares y las sin conexión. Asegúrate de que está configurado correctamente para tu kernel deseado o añade los paquetes que quieras para que solo se actualicen durante la ejecución de pacman-offline y se ignoren en una actualización regular. Ejemplo: `pacman -Syu`.
+El archivo `/etc/pacman.d/offline.conf` es crucial para gestionar qué paquetes se actualizan durante las actualizaciones regulares y offline. Asegúrate de que esté configurado correctamente para tu kernel deseado o añade los paquetes que quieras para que solo se actualicen durante la ejecución de pacman-offline y se ignoren en una actualización regular. Ejemplo: `pacman -Syu`.
 
-**Si habilitas el temporizador de actualización automática, ya no necesitarás actualizar tu sistema manualmente.**
+**Si habilitas el temporizador de actualización automática, ya no necesitas actualizar manualmente tu sistema.**
 :::
 
 <Steps>
@@ -70,9 +134,9 @@ El archivo `/etc/pacman.d/offline.conf` es crucial para gestionar qué paquetes 
    sudo pacman -S pacman-offline
    ```
 
-2. **Indicando a Pacman que lea desde la lista de paquetes a ignorar separada.**
+2. **Decirle a Pacman que lea desde la lista de ignorados de paquetes separada.**
 
-   :::note[Añade la línea después de la sección [options]. Comprueba el ejemplo de abajo como referencia.]
+   :::note[Añade la línea después de la sección [options]. Consulta el ejemplo a continuación como referencia.]
    :::
 
    ```bash title='Añade la siguiente línea al archivo /etc/pacman.conf'
@@ -105,7 +169,7 @@ El archivo `/etc/pacman.d/offline.conf` es crucial para gestionar qué paquetes 
    ```
 3. **Añadiendo los kernels de CachyOS para que pacman los ignore durante las actualizaciones regulares**
 
-   La herramienta `pacman-offline` utiliza este archivo para determinar qué paquetes ignorar durante las actualizaciones tradicionales de pacman.
+   La herramienta `pacman-offline` usa este archivo para determinar qué paquetes ignorar durante las actualizaciones tradicionales de pacman.
 
    Ejemplo: cuando ejecutas `sudo pacman -Syu`
 
@@ -132,24 +196,24 @@ El archivo `/etc/pacman.d/offline.conf` es crucial para gestionar qué paquetes 
    IgnorePkg = linux-cachyos-server linux-cachyos-server-headers linux-cachyos-server-nvidia-open linux-cachyos-server-zfs
    ```
 
-   *Ahora todos esos paquetes serán ignorados en las actualizaciones regulares pero se comprobarán durante la preparación sin conexión.*
+   *Ahora todos esos paquetes se van a ignorar en las actualizaciones regulares pero se comprobarán durante la preparación offline.*
 
-3. **Inicia la preparación para la actualización sin conexión solo una vez**
+3. **Inicia la preparación para la actualización offline solo una vez**
 
    ```bash title='Ejecuta el siguiente comando'
    sudo systemctl start pacman-offline-prepare.service
    ```
-   Este comando hará que pacman-offline se ejecute una vez y sincronice las bases de datos de paquetes y proceda a descargar las actualizaciones, pero no las instalará.
+   Este comando hará que pacman-offline se ejecute una vez y sincronice las bases de datos de paquetes y proceda a descargar actualizaciones pero no las instala.
 
 </Steps>
 
-*Si quieres que este script se automatice. Sigue los siguientes pasos:*
+*Si quieres que este script sea automatizado. Sigue los siguientes pasos:*
 
 <Steps>
 
 1. **Habilita el temporizador de preparación**
 
-   Al habilitar `pacman-offline-prepare.timer`, permitirás que systemd active este script para descargar actualizaciones diariamente unos minutos después de cada inicio del sistema.
+   El `pacman-offline-prepare.timer` habilitado permitirá a systemd activar este script para descargar actualizaciones a diario después de unos minutos de cada inicio del sistema.
 
    ```bash
    sudo systemctl enable pacman-offline-prepare.timer
@@ -157,18 +221,18 @@ El archivo `/etc/pacman.d/offline.conf` es crucial para gestionar qué paquetes 
 
 2. **Reinicia tu sistema:**
 
-   Las actualizaciones se instalarán durante el próximo reinicio del sistema.
+   Las actualizaciones se instalarán durante el siguiente reinicio del sistema.
 
-3. **(Opcional) Reinicios automáticos del sistema:**
+3. **(Opcional) Reinicios Automáticos del Sistema:**
 
-    Habilita `pacman-offline-reboot.timer` para reiniciar automáticamente tu sistema por defecto a las **3am** (tu zona horaria) si hay actualizaciones pendientes. Ten en cuenta que no siempre es a la misma hora debido a la inclusión de `RandomizedDelaySec` que está configurado a 2 horas por defecto.
+    Habilita el `pacman-offline-reboot.timer` para reiniciar automáticamente tu sistema por defecto a las **3am** (Tu zona horaria) si hay actualizaciones pendientes. Ten en cuenta que no es siempre a la misma hora debido a la inclusión de `RandomizedDelaySec` que está establecido en 2 horas por defecto.
 
     ```bash
     sudo systemctl enable pacman-offline-reboot.timer
     ```
 
     :::tip
-    Puedes editar el archivo `pacman-offline-reboot.timer` para modificar la hora a la que quieres que tu sistema se reinicie si hay alguna actualización pendiente o para desactivar la programación aleatoria.
+    Puedes editar el archivo `pacman-offline-reboot.timer` para modificar a qué hora quieres que tu sistema se reinicie si hay alguna actualización pendiente o deshabilitar el horario aleatorio.
     :::
 
 </Steps>
@@ -179,39 +243,60 @@ El archivo `/etc/pacman.d/offline.conf` es crucial para gestionar qué paquetes 
 
 Fork de [Arch-Update](https://github.com/Antiz96/arch-update)
 
-Un notificador y aplicador de actualizaciones para Arch Linux que te ayuda con tareas importantes antes y después de la actualización.
-Incluye un applet dinámico y clicable en la bandeja del sistema para una fácil integración con cualquier Entorno de Escritorio / Gestor de Ventanas.
+Un notificador y aplicador de actualizaciones para Arch Linux que te asiste con tareas importantes previas / posteriores a la actualización.
+Incluye un applet de bandeja del sistema dinámico y clicable para una fácil integración con cualquier Entorno de Escritorio / Gestor de Ventanas.
 
-Habilita Cachy-Update en CachyOS Hello > Apps/Tweaks > Cachy Update enabled
+<details>
+    <summary>Cómo habilitar Cachy-Update</summary>
+    Habilita Cachy-Update en `CachyOS Hello > Apps/Tweaks > Cachy Update enabled`
+</details>
+<details>
+    <summary>Cómo deshabilitar Cachy-Update</summary>
+        Deshabilita Cachy-Update en `CachyOS Hello > Apps/Tweaks > Cachy Update disabled`
+            :::tip
+            Si quieres mantener Cachy-Update y solo deshabilitar el applet de la bandeja del sistema, abre una terminal y ejecuta los siguientes comandos:
+            ```bash
+            mkdir -p ~/.config/autostart
+            echo -e "[Desktop Entry]\nHidden=true" > ~/.config/autostart/arch-update-tray.desktop"
+            ```
+            Si quieres mantener el applet de la bandeja del sistema habilitado y simplemente deshabilitar la comprobación automática de actualizaciones, ejecuta el siguiente comando:
+            ```bash
+            sudo systemctl --global disable --now arch-update.timer
+            ```
+            :::
+</details>
 
 - Características:
-  - Comprobación y listado automáticos de las actualizaciones disponibles.
-  - Comprobación de noticias recientes de Arch Linux (y ofrece mostrarlas si las hay).
-  - Comprobación de paquetes huérfanos (y ofrece eliminarlos si los hay).
-  - Comprobación de paquetes antiguos y desinstalados en la caché (y ofrece eliminarlos si los hay).
-  - Comprobación de actualizaciones de kernel pendientes que requieran un reinicio (y ofrece hacerlo si hay alguna).
-  - Comprobación de servicios que requieren un reinicio después de la actualización (y ofrece hacerlo si los hay).
-  - Soporte para `sudo`, `sudo-rs`, `doas` y `run0`.
+  - Comprobación y listado automáticos de actualizaciones disponibles.
+  - Comprobar noticias recientes de Arch Linux (y ofrece mostrarlas si las hay).
+  - Comprobar paquetes huérfanos (y ofrece eliminarlos si los hay).
+  - Comprobar paquetes antiguos y desinstalados en caché (y ofrece eliminarlos si los hay).
+  - Comprobar si hay actualización pendiente del kernel que requiere un reinicio (y ofrece hacerlo si la hay).
+  - Comprobar servicios que requieren un reinicio posterior a la actualización (y ofrece hacerlo si los hay).
+  - Soporte para `sudo`, `sudo-rs`, `doas` & `run0`.
 
-**Intervalo de comprobación de actualizaciones:** `Una vez 15 segundos después del arranque y luego cada hora.`
+**Intervalo de comprobación de actualizaciones:** `Una vez dos minutos después del arranque y luego una vez al día con un retraso aleatorio de una hora.`
 
 - Cómo cambiar el intervalo de comprobación de actualizaciones:
 
 ```sh title='Ejecuta el siguiente comando'
 systemctl --user edit --full arch-update.timer
 # Consejo: También puedes usar cualquier editor de texto de tu elección en lugar de `nano`
-# ej. EDITOR=micro systemctl --user edit --full arch-update.timer
+# p. ej EDITOR=micro systemctl --user edit --full arch-update.timer
 ```
-Contenido predeterminado del archivo:
+
+<details>
+<summary>Contenido predeterminado del archivo:</summary>
 ```systemd
 [Timer]
-OnStartupSec=15 # Comprobar actualizaciones 15 segundos después del arranque
-OnUnitActiveSec=1h # Comprobar actualizaciones cada hora
+    OnStartupSec=2min # Buscar actualizaciones dos minutos después del arranque
+    RandomizedDelaySec=1h # Retraso aleatorio de una hora
+    OnUnitActiveSec=1d # Buscar actualizaciones una vez al día
 ```
+</details>
+Básicamente puedes cambiar el valor de `OnUnitActiveSec` a lo que quieras. Por ejemplo, si quieres comprobar actualizaciones cada 30 minutos, cámbialo a `30m`. o cada 6 horas, cámbialo a `6h`. Consulta este [documento](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans) para más detalles sobre cómo establecer el intervalo de tiempo.
 
-Básicamente, puedes cambiar el valor de `OnUnitActiveSec` a lo que quieras. Por ejemplo, si quieres comprobar si hay actualizaciones cada 30 minutos, cámbialo a `30m`. o cada 6 horas, cámbialo a `6h`. Consulta este [documento](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans) para más detalles sobre cómo establecer el intervalo de tiempo.
-
-En caso de que quieras que Cachy-Update busque nuevas actualizaciones solo una vez al arrancar, puedes simplemente eliminar la línea `OnUnitActiveSec` por completo.
+En caso de que quieras que Cachy-Update compruebe nuevas actualizaciones solo una vez al arranque, simplemente puedes eliminar la línea `OnUnitActiveSec` por completo.
 
 Gracias a [Antiz](https://github.com/Antiz96) por mantener el proyecto upstream Arch-Update y por la implementación de Cachy-Update
 
@@ -219,7 +304,7 @@ Gracias a [Antiz](https://github.com/Antiz96) por mantener el proyecto upstream 
 
 </Tabs>
 
-## Configurando el Firewall (ufw)
+### Configurando el Firewall (ufw)
 :::note
 UFW está habilitado por defecto después de la instalación.
 :::
@@ -245,20 +330,30 @@ sudo ufw disable
 
 <TabItem label="Permitir">
 
-Por defecto, ufw ignora el tráfico entrante y permite el saliente; puedes añadir reglas específicas al cortafuegos para bloquear o permitir conexiones concretas.
+Por defecto, ufw ignora el tráfico entrante y permite el saliente; puedes añadir reglas específicas al firewall para bloquear o permitir conexiones específicas.
 
 ```bash
-# Por ejemplo:
+# Ejemplo 1, permitir tráfico ssh:
 sudo ufw allow ssh
+# Ejemplo 2, abrir puerto 12345 para tráfico TCP & UDP:
+sudo ufw allow 12345
+
+# El texto o número de puerto se puede ajustar según sea necesario, como 12345/udp para permitir solo tráfico UDP o reemplazando ssh con un nombre de programa
 ```
 
 </TabItem>
 
 <TabItem label="Denegar">
 
+Por defecto, ufw ignora el tráfico entrante y permite el saliente; puedes añadir reglas específicas al firewall para bloquear o permitir conexiones específicas.
+
 ```bash
-# Para denegar un puerto específico, mira el siguiente ejemplo:
-sudo ufw deny 80
+# Ejemplo 1, denegar tráfico ssh:
+sudo ufw deny ssh
+# Ejemplo 2, cerrar puerto 12345 para tráfico TCP & UDP:
+sudo ufw deny 12345
+
+# El texto o número de puerto se puede ajustar según sea necesario, como 12345/udp para denegar solo tráfico UDP o reemplazando ssh con un nombre de programa
 ```
 
 </TabItem>
@@ -268,33 +363,55 @@ sudo ufw deny 80
 ```bash
 sudo ufw status verbose
 ```
-
+:::tip
+Si no quieres olvidar por qué abriste/cerraste un puerto, añade un comentario a la regla.
+```bash
+# Ejemplo 1, abrir puerto 12345 para tráfico TCP & UDP con un comentario:
+sudo ufw allow 12345 comment 'Ejemplo'
+# Ejemplo 2, cerrar puerto 6789 para TCP con un comentario:
+sudo ufw deny 6789/tcp comment 'Los comentarios pueden tener espacios'
+```
+:::
 </TabItem>
 
 </Tabs>
 
 :::note
-Ten cuidado al configurar las reglas del cortafuegos, ya que reglas mal configuradas pueden dejarte fuera de tu propio sistema.
+Ten cuidado al configurar reglas del firewall, ya que las reglas configuradas incorrectamente pueden bloquearte de tu propio sistema.
 :::
 
 :::note
 También puedes configurarlo gráficamente usando la sección "Firewall" en la configuración de KDE Plasma.
 :::
 
-## Cambiando el Shell Predeterminado
+:::note
+Los cambios en permitir/denegar surten efecto después de que ufw se haya reiniciado. Deshabilita y luego habilita ufw de nuevo para un resultado inmediato.
+:::
 
-Actualmente, CachyOS usa [fish](https://fishshell.com/) como el shell de inicio de sesión predeterminado del usuario. Sin embargo, puedes cambiar
-el shell predeterminado por el que prefieras.
+### Habilitando el Menú Global
+Para algunas aplicaciones como Visual Studio Code, el menú global puede no funcionar o puede estar adjunto a la aplicación padre en lugar del panel.
+
+```sh
+# Para habilitar el soporte de menú global, ejecuta el comando y reinicia la aplicación.
+sudo pacman -S appmenu-gtk-module libdbusmenu-glib
+```
+
+## Configuraciones Opcionales
+
+### Cambiando el Shell Predeterminado
+
+Actualmente, CachyOS usa [fish](https://fishshell.com/) como el shell de inicio predeterminado del usuario. Sin embargo, puedes cambiar
+el shell predeterminado a lo que quieras.
 
 <Tabs>
    <TabItem label='bash'>
 
-      Este es el shell predeterminado en casi todas las distribuciones de Linux. También se sigue usando como el shell de inicio de sesión del usuario root. bash
-      tiene una funcionalidad de autocompletado básica y una gestión de historial sencilla. Se diferencia de zsh y fish en que no tiene
-      el ecosistema de personalización y plugins sofisticado que tienen tanto fish como zsh.
+      Este es el shell predeterminado en casi todas las distribuciones Linux. También se usa como el shell de inicio del usuario root. bash
+      tiene funcionalidad básica de autocompletado y gestión de historial fácil. Se diferencia de zsh y fish en que no tiene
+      el ecosistema de personalización y plugins que tanto fish como zsh tienen.
 
 
-      ```sh title='Cambiando tu shell predeterminado a bash'
+      ```sh title='Cambiar tu shell predeterminado a bash'
       chsh -s /usr/bin/bash
       ```
 
@@ -302,21 +419,21 @@ el shell predeterminado por el que prefieras.
 
    <TabItem label='zsh'>
 
-      Proporcionamos una [configuración de zsh](https://github.com/CachyOS/cachyos-zsh-config) con plugins y configuraciones de uso común.
-      Su objetivo es tener una funcionalidad 1:1 con nuestra [configuración de fish](https://github.com/CachyOS/cachyos-fish-config).
-      Este es también el shell predeterminado utilizado en MacOS.
+      Proporcionamos una [configuración de zsh](https://github.com/CachyOS/cachyos-zsh-config) con plugins y configuraciones comúnmente usadas.
+      Su objetivo es tener funcionalidad 1:1 con nuestra [configuración de fish](https://github.com/CachyOS/cachyos-fish-config).
+      Este también es el shell predeterminado usado en MacOS.
 
-      ```sh title='Cambiando el shell predeterminado a zsh'
+      ```sh title='Cambiar el shell predeterminado a zsh'
       chsh -s /usr/bin/zsh
       ```
 
    </TabItem>
 </Tabs>
 
-## Actualizando/usando [tldr](https://github.com/tldr-pages/tldr)
+### Actualizando/usando [tldr](https://github.com/tldr-pages/tldr)
 
 :::note
-CachyOS usa [tealdeer](https://github.com/tealdeer-rs/tealdeer) que es una implementación más rápida basada en Rust del tldr original.
+CachyOS usa [tealdeer](https://github.com/tealdeer-rs/tealdeer) que es una implementación más rápida basada en Rust del tldr original
 :::
 
 Esta herramienta es extremadamente útil para aquellos que no quieren leer mucho o perder tiempo leyendo una página de ayuda/man.
@@ -338,9 +455,9 @@ Esta herramienta es extremadamente útil para aquellos que no quieren leer mucho
 
 </Steps>
 
-## Gestionando AppImages
+### Gestionando AppImages
 
-Las AppImages son aplicaciones portátiles que se ejecutan en la mayoría de las distribuciones de Linux sin necesidad de instalación o permisos de root.
+AppImages son aplicaciones portátiles que se ejecutan en la mayoría de distribuciones Linux sin necesidad de instalación o permisos de root.
 
 :::note[Todas las AppImages requieren permisos de ejecución para funcionar.]
 Puedes establecer el permiso de ejecución usando el siguiente comando:
@@ -350,56 +467,99 @@ chmod +x /ruta/a/tu/appimage
 O haz clic derecho en el archivo AppImage, ve a `Propiedades` > `Permisos`, y marca la casilla que dice `Permitir ejecutar el archivo como un programa.`
 :::
 
-:::note[Antes de ejecutar AppImages, asegúrate de que FUSE (Filesystem in Userspace) esté instalado en tu sistema.]
+:::note[Antes de ejecutar AppImages, asegúrate de que FUSE (Filesystem in Userspace) está instalado en tu sistema.]
 ```sh
 sudo pacman -S fuse2
 ```
 :::
 
-Para gestionar AppImages, puedes usar [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher), que proporciona una forma fácil de integrar AppImages en tu sistema.
-<Tabs>
-  <TabItem label='Usando AppImageLauncher (GUI)'>
-    AppImageLauncher es una herramienta gráfica que simplifica la gestión de AppImages en tu sistema. Se integra con tu entorno de escritorio, facilitando la ejecución y gestión de AppImages.
+Para gestionar AppImages, puedes usar [gearlever](https://github.com/mijorus/gearlever), que proporciona una forma fácil de integrar AppImages en tu sistema.
+
+`gearlever` es una herramienta gráfica que simplifica la gestión de AppImages en tu sistema. Se integra con tu entorno de escritorio, haciendo fácil ejecutar y gestionar AppImages.
+
+Para instalar gearlever, sigue estos pasos:
+
         <Steps>
-        1. Instala AppImageLauncher:
+    1. Instala flatpak si aún no lo has hecho:
+        ```sh
+        sudo pacman -S flatpak
+        ```
+    2. Reinicia tu sistema.
+    3. Instala gearlever usando flatpak:
               ```sh
-              paru appimagelauncher
-              ```
-        2. Descarga una AppImage de tu elección de una fuente confiable.
-
-        3. Haz doble clic en el archivo AppImage descargado. AppImageLauncher te pedirá que integres la aplicación en tu sistema.
-
-        4. Sigue las indicaciones para completar el proceso de integración.
-
-        5. Una vez integrada, puedes lanzar la aplicación desde tu menú de aplicaciones o haciendo doble clic en el archivo AppImage.
+        flatpak install flathub it.mijorus.gearlever
+        ```
+    4. Después de la instalación. Cierra sesión y vuelve a iniciar sesión para ver gearlever en tu menú de aplicaciones.
         </Steps>
-    </TabItem>
-</Tabs>
 
-## Configurando el acceso a recursos compartidos de Samba
+### Configurando el Acceso a Comparticiones Samba
 
-Samba es una reimplementación de software libre del protocolo de red SMB. Para conectarte a tu servidor Samba, se ha puesto a disposición de los usuarios de CachyOS una configuración útil, pero requiere cambiar la configuración de tu servidor Samba.
+Samba es una reimplementación gratuita del protocolo de red SMB. Para conectarte a tu servidor samba, se ha hecho disponible una configuración útil para los usuarios de CachyOS, pero requiere cambiar la configuración de tu servidor samba.
 
-### Instalando y usando el archivo smb.conf de CachyOS
+#### Instalando y usando el archivo smb.conf de CachyOS
 
-Para usar el práctico archivo smb.conf, primero instala un paquete específico que proporciona el archivo smb.conf requerido. Luego, reemplaza el smb.conf existente de tu servidor con este archivo y reconfigura tus volúmenes compartidos.
+Para usar el archivo smb.conf conveniente, primero instala un paquete específico que proporciona el archivo smb.conf requerido. Luego, reemplaza el smb.conf existente de tu servidor con este archivo y reconfigura tus volúmenes compartidos.
 
 :::note[Esta guía asume que ya tienes un servidor Samba funcionando]
 :::
 
 <Steps>
-    1. Crea una copia de seguridad de tu archivo `smb.conf` original, generalmente ubicado en `/etc/samba/smb.conf` en sistemas Linux.
-    2. Instala el paquete de configuración de Samba de CachyOS en tu máquina cliente:
+    1. Crea una copia de seguridad de tu archivo `smb.conf` original, típicamente ubicado en `/etc/samba/smb.conf` en sistemas Linux.
+    2. Instala el paquete de configuraciones Samba de CachyOS en tu máquina cliente:
         ```sh
         sudo pacman -S cachyos-samba-settings
         ```
-    3. Copia el `smb.conf` de tu máquina cliente al servidor Samba.
+    3. Copia el `smb.conf` desde tu máquina cliente al servidor Samba.
     4. Abre y edita el archivo para añadir tus directorios compartidos, impresoras, etc.
-    5. Reinicia el servicio de Samba en tu servidor:
+    5. Reinicia el servicio Samba en tu servidor:
         ```sh
         sudo systemctl restart --now samba
         ```
-    6. En la máquina cliente, accede a tus recursos compartidos a través de tu gestor de archivos (p. ej., `smb://<ip_de_tu_servidor>/<nombre_del_recurso>`).
+    6. En la máquina cliente, accede a tus recursos compartidos a través de tu gestor de archivos (p. ej., `smb://<tu_ip_servidor>/<nombre_comparticion>`).
 
-        Si está configurado correctamente, se te pedirán las credenciales de inicio de sesión. Recuerda seleccionar la opción de guardar tu información de inicio de sesión si lo deseas.
+        Si está configurado correctamente, se te pedirá las credenciales de inicio de sesión. Recuerda seleccionar la opción para guardar tu información de inicio de sesión si lo deseas.
+</Steps>
+
+### Soporte AppArmor usando perfiles AppArmor.d
+
+Cita de Wikipedia:
+
+*AppArmor ("Application Armor") es un módulo de seguridad del kernel Linux que permite al administrador del sistema restringir las capacidades de los programas con perfiles por programa. Los perfiles pueden permitir capacidades como acceso a red, acceso a sockets crudos y el permiso de leer, escribir o ejecutar archivos en rutas coincidentes.*
+
+Esto es solo una introducción sobre cómo instalar una configuración básica de AppArmor, si no estás familiarizado con AppArmor. Por favor no continúes sin entender las implicaciones.
+
+Para información más detallada sobre AppArmor.d y cómo crear tus propios perfiles, consulta la [documentación de AppArmor.d](https://github.com/roddhjav/apparmor.d?tab=readme-ov-file#configuration).
+
+:::caution[Procede con precaución. Una configuración de AppArmor mal hecha puede causar problemas.]
+:::
+
+<Steps>
+
+1. Añade los siguientes parámetros del kernel a tu Gestor de Arranque, consulta [Configuración del Gestor de Arranque](/es/configuration/boot_manager_configuration) como referencia
+
+   ```text
+   lsm=landlock,lockdown,yama,integrity,apparmor,bpf
+   ```
+
+2. Instala los paquetes apparmor y apparmord **(Set de más de +1500 perfiles)**
+   ```bash
+   sudo pacman -S apparmor apparmor.d
+   ```
+
+3. Habilita/Inicia el servicio AppArmor
+
+   ```bash
+   systemctl enable --now apparmor.service
+   ```
+
+4. Habilita la caché para los perfiles AppArmor
+
+   ```shell
+   # /etc/apparmor/parser.conf
+   ## Añade las siguientes líneas:
+   write-cache
+   Optimize=compress-fast
+   cache-loc /etc/apparmor/earlypolicy/
+   ```
+   Guarda el archivo y reinicia.
 </Steps>

--- a/src/content/docs/es/configuration/sched-ext.mdx
+++ b/src/content/docs/es/configuration/sched-ext.mdx
@@ -4,15 +4,21 @@ description: Tutorial sobre cómo usar el framework e información variada
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 5
+ai_translated: true
 ---
 
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Icon } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem, Icon } from '@astrojs/starlight/components';
 import ImageComponent from '~/components/image-component.astro';
 
 La Clase de Planificador Extensible (más conocida como `sched-ext`) es una característica del kernel de Linux que permite implementar planificadores de hilos del kernel en
 BPF (Berkeley Packet Filter) y cargarlos dinámicamente. Esencialmente, esto permite a los usuarios finales cambiar sus planificadores en el espacio de usuario sin
 la necesidad de compilar otro kernel solo para tener un planificador diferente.
+
+:::note
+El uso de cualquier planificador sched-ext desvinculará temporalmente el planificador por defecto del kernel. Cuando se detenga un planificador sched-ext, el planificador por defecto del kernel retomará el control.
+
+Ejemplo: EEVDF o BORE.
+:::
 
 :::tip[Ponte en contacto con los desarrolladores en su [servidor de Discord](https://discord.gg/b2J8DrWa7t)]
 :::
@@ -51,7 +57,7 @@ Sin `sudo`, scxctl/scx_loader pedirá autenticación a través de un agente de p
 
 *Esto lanzará el planificador rusty y desvinculará el planificador por defecto.*
 
-Para detener el planificador. Presiona `CTRL + C` y el planificador se detendrá, y el planificador por defecto del kernel tomará el control de nuevo.
+Para detener el planificador. Presiona `CTRL + C` y el planificador se detendrá y el planificador por defecto del kernel retomará el control.
 
 </TabItem>
 
@@ -61,7 +67,7 @@ Para detener el planificador. Presiona `CTRL + C` y el planificador se detendrá
 :::
 
 :::caution[Requiere un agente de polkit funcional para operar correctamente.]
-Consulte la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
+Consulta la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
 :::
 
 `scxctl` es un cliente CLI de DBUS para interactuar con `scx_loader`.
@@ -132,12 +138,12 @@ Options:
 <TabItem label='scx_loader (DBus)'>
 
 :::caution[Requiere un agente de polkit funcional para operar correctamente.]
-Consulte la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
+Consulta la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
 :::
 
 *Como su nombre indica, es una utilidad que funciona como cargador y gestor para el framework sched-ext usando la interfaz D-Bus.*
 
-*Aunque no requiere systemd, puede utilizarse junto con él.* [Consulta la guía de transición como referencia](/configuration/sched-ext#transitioning-from-scxservice-to-scx_loader-a-comprehensive-guide).
+*Aunque no requiere systemd, puede utilizarse junto con él.* [Consulta la guía de transición como referencia](/es/configuration/sched-ext#transicion-de-scxservice-a-scx_loader-una-guia-completa).
 
 - Tiene la capacidad de detener, iniciar, reiniciar, leer información sobre un planificador scx y más.
   - *Puedes usar herramientas como `dbus-send` o `gdbus` para comunicarte con él.*
@@ -182,7 +188,7 @@ Ejemplo: LAVD ejecutándose en Modo 1 es el equivalente a `scx_lavd --performanc
 
 *En resumen: cada modo es un conjunto de diferentes flags destinados a mejorar el caso de uso previsto.*
 
-[Para una visión más detallada de lo que estos Modos cambian en cada planificador](<https://github.com/sched-ext/scx-loader/blob/122cdb289d09fc960ba7e24dc6bec10326b424e9/crates/scx_loader/src/config.rs#L193>)
+[Para una visión más detallada de lo que estos Modos cambian en cada planificador](<https://github.com/sched-ext/scx-loader/blob/main/crates/scx_loader/src/config.rs#L193>)
 :::
 
 </TabItem>
@@ -190,7 +196,7 @@ Ejemplo: LAVD ejecutándose en Modo 1 es el equivalente a `scx_lavd --performanc
 <TabItem label='CachyOS Kernel Manager'>
 
 :::caution[Requiere un agente de polkit funcional para operar correctamente.]
-Consulte la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
+Consulta la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
 :::
 
 Puedes acceder y configurarlos a través del botón `sched-ext scheduler config`.
@@ -200,7 +206,7 @@ Puedes acceder y configurarlos a través del botón `sched-ext scheduler config`
 <TabItem label='SCX Manager'>
 
 :::caution[Requiere un agente de polkit funcional para operar correctamente.]
-Consulte la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
+Consulta la siguiente **[página de la Arch Wiki como referencia.](https://wiki.archlinux.org/title/Polkit#Authentication_agents)**
 :::
 
 SCX Manager es una herramienta gráfica independiente derivada del CachyOS Kernel Manager. Permite a los usuarios gestionar el framework sched-ext y sus planificadores a través de `scx_loader`.
@@ -227,16 +233,37 @@ Características:
 Dado que hay muchos planificadores para elegir, queremos dar una pequeña introducción sobre los planificadores disponibles.
 
 :::note
-Estos planificadores están en constante desarrollo mientras se prueban, así que espera que algunas de sus características/opciones puedan cambiar.
+Estos planificadores están en constante desarrollo mientras se prueban, así que espera que algunas de sus características/flags puedan cambiar.
 :::
 
 No dudes en reportar cualquier problema o dar tu opinión en el repositorio de cada planificador.
 
-Usa `scx_nombredelplanificador --help` para ver las opciones disponibles y una breve descripción de lo que hacen.
+Usa `scx_nombredelplanificador --help` para ver las flags disponibles y una breve descripción de lo que hacen.
 
 ```sh title='Ejemplo de cómo obtener ayuda para scx_rusty'
 scx_rusty --help
 ```
+
+### [scx_beerland](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_beerland)
+
+**Desarrollado por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
+
+¿Listo para producción? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
+
+scx_beerland es un planificador diseñado para priorizar la localidad y la escalabilidad.
+
+Prioriza mantener las tareas en la misma CPU para conservar la localidad de la caché, al mismo tiempo que asegura una buena escalabilidad en muchos CPUs mediante el uso de DSQs locales (colas de ejecución por CPU) cuando el sistema no está saturado.
+
+- Casos de uso:
+  - Cargas de trabajo intensivas en caché
+  - Sistemas con una gran cantidad de CPUs
+  - Videojuegos: Funciona sorprendentemente bien en ciertos juegos, aunque los resultados pueden variar.
+  - Servidor: Bueno para cargas de trabajo de servidor de propósito general debido a sus optimizaciones de escalabilidad y localidad.
+  - También se puede usar para escritorio.
+
+#### Modos del Planificador
+
+Ninguno por el momento.
 
 ### [scx_bpfland](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_bpfland>)
 
@@ -260,59 +287,149 @@ Al tomar decisiones sobre qué núcleos usar, Bpfland tiene en cuenta su diseño
 
 ##### Baja Latencia
 
-* **Opciones de línea de comandos:** `-m performance -w`
-* **Descripción:** Diseñado para reducir la latencia a costa del rendimiento (throughput). Adecuado para aplicaciones de tiempo real flexible como el procesamiento de audio y multimedia.
+* **Flags de línea de comandos:** `-m performance -w`
+* **Descripción:** Diseñado para reducir la latencia a costa del throughput. Adecuado para aplicaciones de tiempo real flexible como el procesamiento de audio y multimedia.
 
 ##### Ahorro de Energía
 
-* **Opciones de línea de comandos:** `-s 20000 -m powersave -I 100 -t 100`
+* **Flags de línea de comandos:** `-s 20000 -m powersave -I 100 -t 100`
 * **Descripción:** Prioriza la eficiencia energética. Favorece los núcleos menos potentes (por ejemplo, los E-cores en Intel).
 
 ##### Servidor
 
-* **Opciones de línea de comandos:** `-s 20000 -S`
-* **Descripción:** Prioriza tareas con afinidad estricta. Esta opción puede aumentar el rendimiento a costa de la latencia y es más adecuada para cargas de trabajo de servidor.
+* **Flags de línea de comandos:** `-s 20000 -S`
+* **Descripción:** Prioriza tareas con afinidad estricta. Esta opción puede aumentar el throughput a costa de la latencia y es más adecuada para cargas de trabajo de servidor.
 
-### [scx_beerland](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_beerland)
+### [scx_cake](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_cake)
+
+**Desarrollado por: RitzDaCat (RitzDaCat [GitHub](<https://github.com/RitzDaCat>))**
+
+- ¿Listo para producción? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
+
+`scx_cake` es un planificador de CPU BPF experimental que adapta el algoritmo DRR++ (Deficit Round Robin++) de la red [CAKE](https://www.bufferbloat.net/projects/codel/wiki/Cake/) para la planificación de la CPU.
+- Clasificación de 4 niveles — Tareas ordenadas por avg_runtime EWMA en Crítico / Interactivo / Frame / Bulk
+- Sin atómicos globales — Matrices BSS por CPU con escrituras protegidas por MESI eliminan el bloqueo de bus
+- Selección de reposo delegada al kernel — scx_bpf_select_cpu_dfl() para selección de CPU autoritativa y sin datos obsoletos
+- Fragmentación de DSQ por LLC — Elimina la contención de bloqueo entre CCD en CPUs multi-chiplet
+- Seguimiento de déficit DRR++ — Algoritmo de equidad de flujo de la red CAKE adaptado para la planificación de tareas de la CPU
+
+Diseñado para cargas de trabajo de videojuegos en hardware moderno de AMD e Intel.
+
+- Casos de uso:
+  - Videojuegos
+
+#### Sistema de 4 Niveles
+
+`scx_cake` clasifica cada tarea en uno de cuatro niveles según su tiempo de ejecución **EWMA** (Exponential Weighted Moving Average). La clasificación es automática y continua — las tareas se mueven entre niveles a medida que cambia su comportamiento.
+
+##### Umbrales de Nivel
+
+| Nivel   | Nombre        | avg_runtime | Carga de Trabajo Típica                                       | Quantum | Privación |
+| :----- | :---------- | :---------- | :----------------------------------------------------- | :------ | :--------- |
+| **T0** | Crítico    | < 100µs     | Manejadores IRQ, controladores de entrada, audio (PipeWire), red | 0.5ms   | 3ms        |
+| **T1** | Interactivo | < 2ms       | Compositores, física de juegos, IA de juegos, workers cortos      | 2.0ms   | 8ms        |
+| **T2** | Frame       | < 8ms       | Hilos de renderizado de juegos, codificación de video                    | 4.0ms   | 40ms       |
+| **T3** | Bulk        | ≥ 8ms       | Compilación, indexación en segundo plano, trabajos por lotes           | 8.0ms   | 100ms      |
+
+:::tip
+**Ninguna tarea de juego debería estar en T3**. Los hilos de renderizado de juegos ejecutan 2-8ms por frame → T2. Física/IA ejecutan 0.5-2ms → T1. Manejadores de entrada ejecutan < 100µs → T0. Solo las tareas que realizan 8ms+ de trabajo de CPU ininterrumpido (compilación de shaders, pantallas de carga) aterrizan en T3.
+:::
+
+##### Cómo Funciona la Clasificación
+
+1. **Colocación inicial:** Basada en el valor `nice` — `nice < 0` → T0, `nice 0-10` → T1, `nice > 10` → T3
+2. **Autoridad de tiempo de ejecución:** Después de ~3 paradas, el avg_runtime EWMA se vuelve autoritativo. Una tarea nice -5 que ejecuta ráfagas de 50ms se reclasificará a T3 independientemente del valor nice.
+3. **Histéresis:** Un margen muerto del 10% evita oscilaciones en los límites de nivel. La promoción requiere avg_runtime claramente por debajo del umbral; la degradación es inmediata.
+4. **Retroceso gradual:** Una vez que un nivel es estable durante 3+ paradas consecutivas, la frecuencia de reclasificación disminuye por nivel: T0 vuelve a verificar cada 1024ª parada, T3 cada 16ª. La inestabilidad se restablece a verificación a frecuencia completa.
+
+##### Seguimiento de Déficit DRR++
+
+Adaptado de la equidad de flujo de la red CAKE:
+
+- Cada tarea comienza con un **déficit** (quantum + bono de nuevo flujo ≈ 10ms de crédito)
+- Cada ejecución consume déficit proporcional al tiempo de ejecución
+- Cuando el déficit se agota → se elimina el bono de nuevo flujo → la tarea compite normalmente
+- Esto da a los hilos recién creados (un juego que lanza un worker) capacidad de respuesta instantánea que decae naturalmente
+
+##### DVFS (Escalado de Frecuencia de CPU)
+
+Cada nivel se mapea a un objetivo de rendimiento de CPU a través de una tabla de búsqueda RODATA:
+
+| Nivel  | Objetivo               | Razón                                             |
+| :---- | :------------------- | :---------------------------------------------------- |
+| T0-T2 | 100% (frecuencia máxima) | Las cargas de trabajo de juegos necesitan rendimiento completo                |
+| T3    | 75%                  | El trabajo en segundo plano puede ejecutarse un poco más lento para ahorrar energía |
+
+En CPUs híbridas de Intel (`has_hybrid = true`), los objetivos se escalan según el `cpuperf_cap` de cada núcleo para evitar solicitar demasiada frecuencia en los E-cores.
+
+#### Perfiles (`--profile, -p`)
+
+| Perfil     | Quantum | Privación | Caso de Uso                              |
+| :---------- | :------ | :--------- | :------------------------------------ |
+| **gaming**  | 2ms     | 100ms      | **(Por defecto)** Equilibrado para la mayoría de juegos |
+| **esports** | 1ms     | 50ms       | FPS competitivo, latencia ultra baja    |
+| **legacy**  | 4ms     | 200ms      | CPUs antiguas, ahorro de batería            |
+| **default** | 2ms     | 100ms      | Alias para gaming                      |
+
+#### Argumentos CLI
+
+| Argumento                  | Por Defecto  | Descripción                           |
+| :------------------------ | :------- | :------------------------------------ |
+| `--profile, -p <PROFILE>` | `gaming` | Seleccionar perfil preestablecido                 |
+| `--quantum <µs>`          | perfil  | Tiempo de rebanada base en microsegundos       |
+| `--new-flow-bonus <µs>`   | perfil  | Déficit extra para tareas recién despertadas   |
+| `--starvation <µs>`       | perfil  | Tiempo máximo de ejecución antes de la interrupción forzada |
+| `--verbose, -v`           | `false`  | Activar visualización de estadísticas TUI en vivo         |
+| `--interval <secs>`       | `1`      | Intervalo de actualización de TUI                  |
+
+#### Ajuste por Nivel (Perfil Gaming)
+
+| Nivel           | Multiplicador de Quantum | Rebanada Efectiva | Límite de Privación |
+| :------------- | :----------------- | :-------------- | :--------------- |
+| T0 Crítico    | 0.75x              | 1.5ms           | 3ms              |
+| T1 Interactivo | 1.0x               | 2.0ms           | 8ms              |
+| T2 Frame       | 1.2x               | 2.4ms           | 40ms             |
+| T3 Bulk        | 1.4x               | 2.8ms           | 100ms            |
+
+### [scx_cosmos](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_cosmos)
 
 **Desarrollado por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
 
-¿Listo para producción? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
+- ¿Listo para producción? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
 
-scx_beerland es un planificador diseñado para priorizar la localidad y la escalabilidad.
+Planificador ligero optimizado para preservar la localidad tarea-CPU.
 
-Prioriza mantener las tareas en la misma CPU para conservar la localidad de la caché, al mismo tiempo que asegura una buena escalabilidad en muchos CPUs mediante el uso de DSQs locales (colas de ejecución por CPU) cuando el sistema no está saturado.
+Cuando el sistema no está saturado, el planificador prioriza mantener las tareas en la misma CPU usando DSQs locales. Esto no solo mantiene la localidad, sino que también reduce la contención de bloqueos en comparación con los DSQs compartidos, permitiendo una buena escalabilidad en muchos CPUs.
 
 - Casos de uso:
-  - Cargas de trabajo intensivas en caché
-  - Sistemas con una gran cantidad de CPUs
-  - Videojuegos: Se sabe que funciona sorprendentemente bien en ciertos juegos, aunque los resultados pueden variar
-  - Servidor: Bueno para cargas de trabajo de servidor de propósito general debido a sus optimizaciones de escalabilidad y localidad.
-  - También se puede usar para escritorio.
+  - Planificador de propósito general: el planificador debería adaptarse tanto a cargas de trabajo de servidor como de escritorio.
 
 #### Modos del Planificador
 
-Ninguno por el momento.
+##### Auto
 
-### [scx_rustland](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rustland>)
+* **Flags de línea de comandos:** Ninguna.
+* **Descripción:**
 
-**Desarrollado por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
+##### Gaming
 
-¿Listo para producción? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
+* **Flags de línea de comandos:** `-s 700 -S`
+* **Descripción:** Sacrifica throughput para una mejor consistencia en el rendimiento de Gaming reduciendo la contención en núcleos SMT compartidos.
 
-Para escenarios de producción críticos en cuanto a rendimiento, es probable que otros planificadores muestren un mejor desempeño, ya que delegar todas las decisiones de planificación al espacio de usuario tiene un cierto costo (incluso si es mínimo).
+##### Ahorro de Energía
 
-Sin embargo, un planificador implementado completamente en el espacio de usuario tiene el potencial de integrarse sin problemas con bibliotecas sofisticadas, herramientas de trazado, servicios externos (por ejemplo, IA), etc.
+* **Flags de línea de comandos:** `-m powersave`
+* **Descripción:** Prioriza la eficiencia energética. Favorece núcleos menos potentes (por ejemplo, E-cores en Intel).
 
-Por lo tanto, podría haber situaciones en las que los beneficios superen la sobrecarga, justificando el uso de este planificador en un entorno de producción.
+##### Baja Latencia
 
-Comparte similitudes con bpfland, hecho con la intención de ser fácil de leer y entender cómo funciona debido a su implementación en el espacio de usuario.
+* **Flags de línea de comandos:** `-s 700 -S -m performance -w`
+* **Descripción:** Diseñado para reducir la latencia a costa del throughput. Adecuado para aplicaciones de tiempo real flexible como el procesamiento de audio y multimedia. Otorga una distribución de carga más uniforme en los núcleos disponibles sacrificando eficiencia.
 
-Ten en cuenta que hay una ligera desventaja en el rendimiento (throughput) al usar un planificador en el espacio de usuario.
+##### Servidor
 
-- Casos de uso:
-  - Cargas de trabajo de baja latencia (Videojuegos, videoconferencias y transmisiones en vivo)
-  - Uso de escritorio
+* **Flags de línea de comandos:** `-s 20000 -c 75 -p 250`
+* **Descripción:** Habilita la afinidad del espacio de direcciones para mejorar la localidad y el rendimiento en ciertas cargas de trabajo sensibles a la caché. La duración de la rebanada se establece en 20ms y el sondeo que monitorea con qué frecuencia el planificador compara la utilización de la CPU con el umbral de ocupación de la CPU para decidir cuándo el sistema está ocupado.
 
 ### [scx_flash](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_flash>)
 
@@ -337,63 +454,126 @@ A las tareas que liberan la CPU antes de tiempo se les da un mayor peso de laten
 
 ##### Baja Latencia
 
-* **Opciones de línea de comandos:** `-m performance -w -C 0`
-* **Descripción:** Diseñado para reducir la latencia a costa del rendimiento (throughput). Adecuado para aplicaciones de tiempo real flexible como el procesamiento de audio y multimedia.
+* **Flags de línea de comandos:** `-m performance -w -C 0`
+* **Descripción:** Diseñado para reducir la latencia a costa del throughput. Adecuado para aplicaciones de tiempo real flexible como el procesamiento de audio y multimedia.
 
-##### Videojuegos
+##### Gaming
 
-* **Opciones de línea de comandos:** `-m all`
-* **Descripción:** Optimiza para un alto rendimiento en juegos.
+* **Flags de línea de comandos:** `-m all`
+* **Descripción:** Optimiza para alto rendimiento en juegos.
 
 ##### Ahorro de Energía
 
-* **Opciones de línea de comandos:** `-m powersave -I 10000 -t 10000 -s 10000 -S 1000`
-* **Descripción:** Prioriza la eficiencia energética. Favorece los núcleos menos potentes (por ejemplo, E-cores en Intel) e introduce un ciclo de inactividad forzada cada 10 ms para aumentar el ahorro de energía.
+* **Flags de línea de comandos:** `-m powersave -I 10000 -t 10000 -s 10000 -S 1000`
+* **Descripción:** Prioriza la eficiencia energética. Favorece núcleos menos potentes (por ejemplo, E-cores en Intel) e introduce un ciclo de inactividad forzada cada 10ms para aumentar el ahorro de energía.
 
 ##### Servidor
 
-* **Opciones de línea de comandos:** `-m all -s 20000 -S 1000 -I -1 -D -L`
-* **Descripción:** Ajustado para cargas de trabajo de servidor. Intercambia capacidad de respuesta por rendimiento (throughput).
+* **Flags de línea de comandos:** `-m all -s 20000 -S 1000 -I -1 -D -L`
+* **Descripción:** Ajustado para cargas de trabajo de servidor. Intercambia capacidad de respuesta por throughput.
 
-### [scx_cosmos](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_cosmos)
+### [scx_flow](https://github.com/sched-ext/scx/tree/main/scheds/experimental/scx_flow)
+
+**Desarrollado por: Galih Tama (galpt [GitHub](https://github.com/galpt))**
+
+¿Listo para producción? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
+
+scx_flow es un planificador basado en presupuesto que clasifica las tareas en uno de cuatro niveles FIFO O(1) según cuánto presupuesto les queda. Sin heurísticas, sin algoritmos de puntuación, sin ajuste adaptativo — cada decisión proviene de un solo número: *presupuesto restante*.
+
+- Casos de uso:
+  - Multitarea de propósito general en escritorio y estación de trabajo
+  - Videojuegos con aplicaciones de fondo abiertas
+  - Trabajo de desarrollo con compilaciones, pruebas o contenedores ejecutándose
+  - Cualquier escenario donde la capacidad de respuesta interactiva bajo carga mixta importe
+  - Sistemas que necesitan planificación determinista y explicable (control embebido, robótica, aviónica)
+
+#### Cómo funciona — el presupuesto
+
+Piensa en cada tarea como si tuviera un "presupuesto de capacidad de respuesta". Mientras una tarea duerme (esperando algo que hacer), acumula presupuesto. Cuando se despierta y se ejecuta, lo gasta. Las tareas que se despiertan aún con presupuesto son señal de interactividad — se despachan inmediatamente a la CPU donde se ejecutaron por última vez, saltándose el sistema de niveles por completo. Las tareas que agotan su presupuesto se vuelven a encolar en uno de los cuatro niveles FIFO.
+
+##### Los cuatro niveles de despacho
+
+Cuando una tarea se vuelve a encolar (no un despertar), su presupuesto restante decide en qué nivel aterriza:
+
+| Nivel | Umbral de presupuesto | Qué tipo de tareas terminan aquí |
+|---|---|---|
+| **Priority** | ≥ 1.5ms | Tareas interactivas que duermen a menudo y se ejecutan brevemente |
+| **Normal** | ≥ 1ms | Tareas típicas con presupuesto decente restante |
+| **Low** | ≥ 0.5ms | Tareas con poco presupuesto restante |
+| **Deficit** | < 0.5ms | Workers bulk, consumidores de CPU, trabajos en segundo plano |
+
+Cada nivel es una cola FIFO simple — O(1) encolar, O(1) desencolar. Sin recorridos de árbol, sin recálculos de prioridad.
+
+##### Sin privación, sin inversión de prioridad
+
+La función de despacho no solo vacía Priority primero cada vez. Rota el nivel de inicio en cada llamada — `gen & 3` decide dónde empezar. Así que el nivel Deficit nunca espera más de 3 ciclos de despacho antes de ser atendido primero. Esto significa que los workers bulk progresan incluso bajo carga interactiva pesada, y no hay inversión de prioridad porque ningún nivel único puede monopolizar la CPU.
+
+##### Los despertares saltan la fila por completo
+
+Cuando una tarea se despierta (estaba durmiendo y ahora tiene algo que hacer), no espera en ninguna cola de nivel. Va directamente a la CPU donde se ejecutó por última vez vía `SCX_DSQ_LOCAL_ON` — caché caliente e inmediato. Esto es lo que mantiene las tareas interactivas rápidas: una pestaña de Discord o navegador durmiendo se despierta con presupuesto y se despacha en microsegundos, no milisegundos.
+
+##### Las tareas fijas siempre van primero
+
+Las tareas que no pueden migrar entre CPUs (setaffinity) tienen su propia cola FIFO por CPU que tiene prioridad absoluta sobre cualquier nivel. Se despachan antes de que cualquier cosa del sistema de niveles se ejecute en esa CPU.
+
+##### El resultado
+
+Las tareas interactivas (entrada de teclado, actualizaciones de UI, hilos de audio, sondeo de red) casi siempre se despiertan con presupuesto y obtienen el carril rápido. El trabajo batch pesado en CPU (compilación, descargas, indexación en segundo plano) agota su presupuesto y se asienta en el nivel Deficit, donde aún progresa gracias al despacho rotativo. Sin ajuste necesario.
+
+##### Sin perfiles, sin autotuning, sin modos
+
+scx_flow **no** tiene modos Gaming, Power Save, o Low Latency — y a diferencia de versiones anteriores, tampoco tiene un bucle de control adaptativo. El despacho de nivel rotativo y los umbrales de presupuesto son constantes en tiempo de compilación. Lo que obtienes es lo que se ejecuta: determinista, explicable e idéntico en cada sistema. Si una tarea tiene presupuesto, obtiene prioridad. Si no, comparte el nivel Deficit de forma justa. Esa es toda la política.
+
+#### Interfaz Web
+
+Cuando scx_flow se inicia, sirve automáticamente un panel de métricas en vivo en **[http://localhost:50005](http://localhost:50005)**.
+
+El panel muestra:
+- Cuántos despachos han pasado por cada nivel (Priority / Normal / Low / Deficit)
+- Información del sistema: tareas en ejecución, tiempo de actividad, conteo total de despachos
+- Una barra de distribución de niveles para ver de un vistazo si el trabajo interactivo o bulk domina
+- Cada tarjeta de métrica es clicable — abre un modal de historial con sparklines y un gráfico de barras
+- Todos los valores se actualizan cada segundo vía sondeo — sin necesidad de actualizar la página
+
+Si la página no carga, el planificador puede haber dejado de ejecutarse (el kernel vuelve al EEVDF integrado).
+
+```sh
+# Deshabilita la interfaz web si no la necesitas:
+sudo scx_flow --no-webui
+```
+
+Cuando `scx_loader` se ejecuta con endurecimiento de systemd que restringe familias de sockets (`RestrictAddressFamilies`, `SocketBindDeny`), la vinculación TCP está bloqueada y scx_flow vuelve a un socket Unix en `/tmp/scx_flow.sock`. En ese caso, el navegador no puede acceder al panel directamente — ejecuta temporalmente `sudo scx_flow --no-webui` para silenciar errores si no necesitas la interfaz.
+
+#### Argumentos CLI
+
+| Argumento | Descripción |
+|---|---|
+| `--no-webui` | Deshabilitar la interfaz web integrada |
+| `-d, --debug` | Activar registro de nivel de depuración |
+| `-V, --version` | Imprimir versión del planificador y salir |
+
+:::note
+scx_flow **no** tiene modos de perfil de scx_loader (Gaming, Power Save, Low Latency, Server). Cada decisión de planificación se deriva directamente del presupuesto de la tarea — sin perfiles necesarios.
+:::
+
+### [scx_forge](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_forge>)
 
 **Desarrollado por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
 
-- ¿Listo para producción? <Icon name="approve-check" color="var(--sl-color-text-accent)" size="2rem" />
+- ¿Listo para producción? <Icon name="close" color="var(--sl-color-text-accent)" size="2rem" />
 
-Planificador ligero optimizado para preservar la localidad tarea-CPU.
+scx_forge contiene dos partes:
 
-Cuando el sistema no está saturado, el planificador prioriza mantener las tareas en la misma CPU usando DSQs locales. Esto no solo mantiene la localidad, sino que también reduce la contención de bloqueos en comparación con los DSQs compartidos, permitiendo una buena escalabilidad en muchos CPUs.
+1. Un planificador base orientado a IA diseñado para usarse junto con la segunda parte.
+2. Un agente destinado a usarse con el planificador base para proporcionar una experiencia de planificación más orientada a la IA, más optimización en el lugar por parte del agente mismo.
 
-- Casos de uso:
-  - Planificador de propósito general: el planificador debería adaptarse tanto a cargas de trabajo de servidor como de escritorio.
+El agente permite configurar tu modelo de IA, la carga de trabajo que quieres optimizar y el objetivo general que quieres lograr. El agente entonces intentará optimizar el planificador para tu carga de trabajo y objetivo específicos.
 
-#### Modos del Planificador
+¿Cómo? A través del [archivo spec.toml](https://github.com/sched-ext/scx/blob/main/tools/scx_forge_agent/spec.toml) que se usa para iniciar el bucle de optimización.
 
-##### Automático
+Básicamente, este planificador es perfecto para quienes quieran optimizar una carga de trabajo específica mediante un agente de IA.
 
-* **Opciones de línea de comandos:** `-d`
-* **Descripción:** Deshabilita las activaciones diferidas (deferred wakeups). Reduce el rendimiento (throughput) y el desempeño para ciertas cargas de trabajo mientras disminuye el consumo de energía.
-
-##### Videojuegos
-
-* **Opciones de línea de comandos:** `-c 0 -p 0`
-* **Descripción:** Desactiva el seguimiento de la carga de la CPU e impone siempre una planificación basada en plazos para mejorar la capacidad de respuesta.
-
-##### Ahorro de Energía
-
-* **Opciones de línea de comandos:** `-m powersave -d -p 5000`
-* **Descripción:** Prioriza la eficiencia energética. Favorece los núcleos menos potentes (por ejemplo, E-cores en Intel) y deshabilita las activaciones diferidas, reduciendo el rendimiento (throughput) mientras aumenta la eficiencia energética. El sondeo de la carga de la CPU se aumenta a 5 ms.
-
-##### Baja Latencia
-
-* **Opciones de línea de comandos:** `-m performance -c 0 -p 0 -w`
-* **Descripción:** Diseñado para reducir la latencia a costa del rendimiento (throughput). Adecuado para aplicaciones de tiempo real flexible como el procesamiento de audio y multimedia. Impone siempre una planificación basada en plazos y optimizaciones de activación síncrona para mejorar la predictibilidad del rendimiento.
-
-##### Servidor
-
-* **Opciones de línea de comandos:** `-s 20000`
-* **Descripción:** Habilita la afinidad del espacio de direcciones para mejorar la localidad y el rendimiento en ciertas cargas de trabajo sensibles a la caché. El sondeo se aumenta a 20 ms.
+Para saber más al respecto, consulta el [README de scx_forge_agent](https://github.com/sched-ext/scx/tree/main/tools/scx_forge_agent).
 
 ### [scx_lavd](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_lavd>)
 
@@ -406,7 +586,7 @@ Breve introducción a LAVD de Changwoo:
 *LAVD es un nuevo algoritmo de planificación que todavía está en desarrollo. Está
 motivado por las cargas de trabajo de los videojuegos, que son críticas en latencia y
 con mucha comunicación. Su objetivo es minimizar los picos de latencia mientras se mantiene
-un buen rendimiento (throughput) general y un uso justo del tiempo de CPU entre las tareas.*
+un buen rendimiento general y un uso justo del tiempo de CPU entre las tareas.*
 
 - Casos de uso:
   - Videojuegos
@@ -420,33 +600,44 @@ Una de las capacidades principales e increíbles que incluye LAVD es la **Compac
 
 ##### Modos del Planificador
 
-##### Videojuegos y Baja Latencia
+##### Gaming y Baja Latencia
 
-* **Opciones de línea de comandos:** `--performance`
+* **Flags de línea de comandos:** `--performance`
 * **Descripción:** Maximiza el rendimiento utilizando todos los núcleos disponibles, priorizando los núcleos físicos.
 
 ##### Ahorro de Energía
 
-* **Opciones de línea de comandos:** `--powersave`
+* **Flags de línea de comandos:** `--powersave`
 * **Descripción:** Minimiza el consumo de energía mientras mantiene un rendimiento razonable. Prioriza los núcleos e hilos eficientes sobre los núcleos físicos.
 
-### [scx_rusty](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rusty>)
+### [scx_pandemonium](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_pandemonium)
 
-**Desarrollado por: David Vernet (Byte-Lab [GitHub](<https://github.com/Byte-Lab>))**
+**Desarrollado por: Will Clingan (willclngn [GitHub](https://github.com/wllclngn/))**
 
-- ¿Listo para producción? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
-  - Sí. Si se ajusta correctamente.
-
-Rusty ofrece una amplia gama de características que mejoran sus capacidades, proporcionando una mayor flexibilidad para diversos casos de uso.
-Una de estas características es la capacidad de ajuste, que te permite personalizar Rusty para que se adapte a tus preferencias y requisitos específicos.
+*Un planificador de clasificación por comportamiento con colocación consciente de la topología. Puntuación impulsada por EWMA (frecuencia de despertar, tasa de cambio de contexto, varianza de tiempo de ejecución) que clasifica tareas en tres niveles — LAT_CRITICAL, INTERACTIVE, BATCH — cada uno con su propia rebanada, reglas de interrupción y enrutamiento DSQ. La colocación está impulsada por resistencia efectiva (R_eff) en el gráfico de topología de la CPU, derivada de una pseudoinversa Laplaciana; los DSQs por CPU son robados por trabajo en orden R_eff para mantener el trabajo caliente en caché caliente. Cada constante de tiempo — rescate de estancia, objetivo CoDel, techo vtime, umbral longrun — se deriva de un único valor tau (el recíproco del autovalor de Fiedler), por lo que el planificador se autocalibra desde laptops 2C hasta servidores 32C+ sin ajuste. Un oscilador armónico amortiguado adapta el objetivo de detención CoDel desde la presión de rescate cada tick. Un bucle de control adaptativo Rust de 1Hz (actualización de pesos multiplicativos sobre seis perfiles expertos) ajusta los parámetros de planificación desde telemetría de histograma BPF, sincronizado con el estado del oscilador BPF para evitar doble corrección. Una base de datos persistente de procesos aprende clasificaciones de tareas entre reinicios. Consciente de NUMA, correcto en hotplug.*
 
 - Casos de uso:
   - Videojuegos
-  - Cargas de trabajo sensibles a la latencia
   - Uso de escritorio
   - Producción multimedia/audio
-  - Gran interactividad bajo cargas de trabajo intensivas
-  - Ahorro de energía
+    - Compilación de código fuente
+    - Cargas de trabajo intensivas en ZFS / almacenamiento
+    - Cargas de trabajo mixtas
+    - Interactividad bajo saturación sostenida de CPU
+
+##### Modos del Planificador
+Default (Adaptativo)
+- **Flags de línea de comandos:** (ninguna — se ejecuta en modo adaptativo por defecto)
+- **Descripción:** Modo adaptativo completo. El bucle de control Rust detecta el régimen de carga de trabajo (LIGHT / MIXED / HEAVY) y ajusta los parámetros de planificación en tiempo real. Mejor para uso general de escritorio y videojuegos.
+
+###### Solo BPF
+- **Flags de línea de comandos:** `--no-adaptive`
+- **Descripción:** Deshabilita el bucle de control adaptativo Rust. El planificador BPF se ejecuta con parámetros de ajuste estáticos. Menor sobrecarga, útil para benchmarks o si la capa adaptativa está sobre-corrigiendo en tu carga de trabajo.
+
+###### Verbose / Debug
+- **Flags de línea de comandos:** `-v` o `--verbose`
+- **Descripción:** Habilita salida de telemetría detallada incluyendo conteos de despacho por nivel, tiempos de estancia y estadísticas de clasificación por comportamiento. Útil para diagnosticar el comportamiento de planificación.
+
 
 ### [scx_p2dq](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_p2dq>)
 
@@ -456,7 +647,7 @@ Una de estas características es la capacidad de ajuste, que te permite personal
 **Desarrollado por: Daniel Hodges (hodgesds [GitHub](<https://github.com/hodgesds>))**
 
 Un planificador de propósito general que se centra en el balanceo de carga "pick two" (elegir dos) entre
-cachés LLC. Mantiene una alta localidad de caché y conservación del trabajo mientras proporciona
+LLCs. Mantiene una alta localidad de caché y conservación del trabajo mientras proporciona
 una latencia razonable.
 
 - Casos de uso:
@@ -466,25 +657,25 @@ una latencia razonable.
 
 #### Modos del Planificador
 
-##### Videojuegos
+##### Gaming
 
-* **Opciones de línea de comandos:** `--task-slice true -f --sched-mode performance`
+* **Flags de línea de comandos:** `--task-slice true -f --sched-mode performance`
 * **Descripción:** Mejora la consistencia en el rendimiento de los videojuegos y aumenta la preferencia por planificar en núcleos de mayor rendimiento.
 
 ##### Baja Latencia
 
-* **Opciones de línea de comandos:** `-y -f --task-slice true`
-* **Descripción:** Reduce la latencia haciendo que las tareas interactivas se adhieran más a la CPU a la que fueron asignadas y aumentando la estabilidad en la porción de tiempo.
+* **Flags de línea de comandos:** `-y -f --task-slice true`
+* **Descripción:** Reduce la latencia haciendo que las tareas interactivas se adhieran más a la CPU a la que fueron asignadas y aumentando la estabilidad en la rebanada de tiempo.
 
 ##### Ahorro de Energía
 
-* **Opciones de línea de comandos:** `--sched-mode efficiency`
+* **Flags de línea de comandos:** `--sched-mode efficiency`
 * **Descripción:** Mejora la eficiencia energética al priorizar los núcleos de bajo consumo.
 
 ##### Servidor
 
-* **Opciones de línea de comandos:** `--keep-running`
-* **Descripción:** Mejora las cargas de trabajo del servidor al permitir que las tareas se ejecuten más allá de su porción de tiempo si la CPU está inactiva.
+* **Flags de línea de comandos:** `--keep-running`
+* **Descripción:** Mejora las cargas de trabajo del servidor al permitir que las tareas se ejecuten más allá de su rebanada de tiempo si la CPU está inactiva.
 
 ### [scx_tickless](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_tickless>)
 
@@ -509,36 +700,74 @@ El planificador funciona enrutando todos los eventos de planificación a través
 
 #### Modos del Planificador
 
-##### Videojuegos
+##### Gaming
 
-* **Opciones de línea de comandos:** `-f 5000 -s 5000`
-* **Descripción:** Aumenta el rendimiento en videojuegos al incrementar la frecuencia con la que el planificador detecta la contención de la CPU y activa cambios de contexto con una porción de tiempo más corta.
+* **Flags de línea de comandos:** `-f 5000 -s 5000`
+* **Descripción:** Aumenta el rendimiento en videojuegos al incrementar la frecuencia con la que el planificador detecta la contención de la CPU y activa cambios de contexto con una rebanada de tiempo más corta.
 
 ##### Ahorro de Energía
 
-* **Opciones de línea de comandos:** `-f 50`
+* **Flags de línea de comandos:** `-f 50`
 * **Descripción:** Mejora la eficiencia energética al reducir las comprobaciones de contención.
 
 ##### Baja Latencia
-* **Opciones de línea de comandos:** `-f 5000 -s 1000`
-* **Descripción:** Similar al perfil de videojuegos pero con una porción de tiempo aún más reducida.
+* **Flags de línea de comandos:** `-f 5000 -s 1000`
+* **Descripción:** Similar al perfil de videojuegos pero con una rebanada aún más reducida.
 
 ##### Servidor
 
-* **Opciones de línea de comandos:** `-f 100`
-* **Descripción:** Reduce la frecuencia con la que el planificador comprueba la contención de la CPU para mejorar el rendimiento (throughput) a costa de la capacidad de respuesta.
+* **Flags de línea de comandos:** `-f 100`
+* **Descripción:** Reduce la frecuencia con la que el planificador comprueba la contención de la CPU para mejorar el throughput a costa de la capacidad de respuesta.
 
-## Pruebas de configuración y rendimiento
+### [scx_rustland](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rustland>)
 
-### Piloto automático y energía automática de LAVD
+**Desarrollado por: Andrea Righi (arighi [GitHub](<https://github.com/arighi>))**
+
+¿Listo para producción? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
+
+Para escenarios de producción críticos en cuanto a rendimiento, es probable que otros planificadores muestren un mejor desempeño, ya que delegar todas las decisiones de planificación al espacio de usuario tiene un cierto costo (incluso si es mínimo).
+
+Sin embargo, un planificador implementado completamente en el espacio de usuario tiene el potencial de integrarse sin problemas con bibliotecas sofisticadas, herramientas de trazado, servicios externos (por ejemplo, IA), etc.
+
+Por lo tanto, podría haber situaciones en las que los beneficios superen la sobrecarga, justificando el uso de este planificador en un entorno de producción.
+
+Comparte similitudes con bpfland, hecho con la intención de ser fácil de leer y entender cómo funciona debido a su implementación en el espacio de usuario.
+
+Ten en cuenta que hay una ligera desventaja en el throughput al usar un planificador en el espacio de usuario.
+
+- Casos de uso:
+  - Cargas de trabajo de baja latencia (Videojuegos, videoconferencias y transmisiones en vivo)
+  - Uso de escritorio
+
+### [scx_rusty](<https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rusty>)
+
+**Desarrollado por: David Vernet (Byte-Lab [GitHub](<https://github.com/Byte-Lab>))**
+
+- ¿Listo para producción? <Icon name="information" color="var(--sl-color-text-accent)" size="2rem" />
+  - Sí. Si se ajusta correctamente.
+
+Rusty ofrece una amplia gama de características que mejoran sus capacidades, proporcionando una mayor flexibilidad para diversos casos de uso.
+Una de estas características es la capacidad de ajuste, que te permite personalizar Rusty para que se adapte a tus preferencias y requisitos específicos.
+
+- Casos de uso:
+  - Videojuegos
+  - Cargas de trabajo sensibles a la latencia
+  - Uso de escritorio
+  - Producción multimedia/audio
+  - Gran interactividad bajo cargas de trabajo intensivas
+  - Ahorro de energía
+
+## Configuración y pruebas de rendimiento
+
+### LAVD Autopilot y Autopower
 
 *Citas de Changwoo Min:*
-- En modo de piloto automático, el planificador ajusta su modo de energía `Powersave, Balanced, o Performance` según la carga del sistema, específicamente la utilización de la CPU.
+- En modo autopilot, el planificador ajusta su modo de energía `Powersave, Balanced, o Performance` según la carga del sistema, específicamente la utilización de la CPU.
 
-- Energía automática: Decide automáticamente el modo de energía del planificador basándose en el perfil de energía del sistema, también conocido como EPP (Energy Performance Preference).
+- Autopower: Decide automáticamente el modo de energía del planificador basándose en el perfil de energía del sistema, también conocido como EPP (Energy Performance Preference).
 
 ```sh
-# La energía automática se puede activar con la siguiente bandera:
+# Autopower se puede activar con la siguiente flag:
 --autopower
 # ej:
 scx_lavd --autopower
@@ -560,10 +789,10 @@ systemctl disable --now ananicy-cpp
 
 Implementado en el paquete `power-profiles-daemon` proporcionado por CachyOS, que incluye un [parche personalizado](https://github.com/CachyOS/CachyOS-PKGBUILDS/blob/master/power-profiles-daemon/0001-Add-support-for-scx_loader-modes-switching.patch) para admitir el cambio de perfiles de energía de `scx_loader`.
 
-- Si `scx_loader` se está ejecutando, al usar el modo [game-performance](/es/configuration/gaming#cambio-de-perfil-de-energía-bajo-demanda), cambiará automáticamente el planificador activo al perfil `Gaming` cuando se inicie un juego y volverá al perfil predeterminado cuando el juego se cierre.
+- Si `scx_loader` se está ejecutando, al usar [game-performance](/es/configuration/gaming#cambio-de-perfil-de-energia-bajo-demanda), cambiará automáticamente el planificador activo al perfil `Gaming` cuando se inicie un juego y volverá al perfil predeterminado cuando el juego se cierre.
 - Al cambiar entre perfiles de energía, por ejemplo, en KDE Plasma o GNOME usando el selector de perfiles de energía, `scx_loader` cambiará automáticamente al perfil de planificador correspondiente:
 
-| Power Profile       | Scheduler Profile  |
+| Perfil de Energía       | Perfil del Planificador  |
 | ------------------- | ------------------ |
 | Power Saver         | Power Save         |
 | Balanced            | Auto               |
@@ -606,7 +835,7 @@ Se incluyen los siguientes benchmarks:
 - **Medir el efecto de las actualizaciones del kernel o del planificador**
   - Comparar ejecuciones antes y después de aplicar parches o cambios de versión para verificar regresiones o mejoras de rendimiento.
 - **Probar ajustes de configuración**
-  - Evaluar el impacto de cambios como la configuración del gobernador de la CPU, la activación/desactivación de SMT o las banderas modificadas del planificador.
+  - Evaluar el impacto de cambios como la configuración del gobernador de la CPU, la activación/desactivación de SMT o las flags modificadas del planificador.
 
 #### Requisitos
 - 4 GB de RAM o más
@@ -794,7 +1023,7 @@ Después de cada ejecución, `schbench` imprime los percentiles de latencia de e
   - Representa el tiempo que se tarda en completar solicitudes entre hilos.
     - Una latencia más baja indica una mejor comunicación entre hilos y eficiencia en la planificación.
 - **RPS (Solicitudes por segundo):**
-  - Muestra el rendimiento sostenido:
+  - Muestra el throughput sostenido:
     - Un **RPS promedio** más alto indica que el planificador puede manejar más trabajo por segundo bajo la configuración dada.
 
 En conclusión:
@@ -818,8 +1047,8 @@ Si tu deseo es hacer benchmarks en juegos para comparar el rendimiento de difere
 - **Múltiples ejecuciones:** Realiza varias ejecuciones del benchmark y saca el promedio para tener en cuenta la variabilidad.
 - **Usa herramientas de monitoreo de rendimiento:** Herramientas como MangoHud o GOverlay pueden proporcionar métricas de rendimiento en tiempo real como FPS, tiempos de fotograma y uso de CPU/GPU.
 - **Aprovecha los atajos de teclado o macros:**
-  - Un ejemplo es crear una combinación de teclas con la que puedas cambiar entre diferentes planificadores o sus modos sobre la marcha mientras estás en el juego.
-    - Esto se puede hacer usando una herramienta como [scxctl](/es/configuration/sched-ext#cómo-lanzar-y-gestionar-el-planificador) o creando scripts personalizados que cambien el planificador activo y su modo.
+  - Un ejemplo es crear una combinación de teclas con la que puedas cambiar entre diferentes planificadores o cambiar sus modos sobre la marcha mientras estás en el juego.
+    - Esto se puede hacer usando una herramienta como [scxctl](/es/configuration/sched-ext#como-lanzar-y-gestionar-el-planificador) o creando scripts personalizados que cambien el planificador activo y su modo.
 
 #### Subir y compartir tus benchmarks
 
@@ -833,16 +1062,64 @@ Luego haz clic en el botón `New benchmark` y completa la información requerida
 - Acepta registros tanto de MangoHud como de Afterburner.
 - Permite buscar por título o descripción.
 
+## Configuración de scx_loader
+
+### Establecer un planificador como predeterminado (en el arranque)
+
+Para establecer un planificador que se inicie automáticamente cuando `scx_loader` se inicie (por ejemplo, en el arranque), sigue estos pasos:
+
+<Steps>
+1. **Copia el archivo de configuración de ejemplo** al directorio de configuración:
+   ```sh
+   sudo mkdir -p /etc/scx_loader
+   sudo cp /usr/share/scx_loader/config.toml /etc/scx_loader/config.toml
+   ```
+
+2. **Edita el archivo de configuración** con tu editor preferido:
+   ```sh
+   sudo nano /etc/scx_loader/config.toml
+   ```
+
+3. **Establece el planificador y modo predeterminados**. Por ejemplo, para establecer `scx_pandemonium` en modo `Auto`:
+   ```toml
+   # Este campo especifica el planificador que se iniciará automáticamente cuando scx_loader se inicie (por ejemplo, en el arranque).
+   default_sched = "scx_pandemonium"
+
+   # Este campo especifica el modo que se usará cuando scx_loader se inicie (por ejemplo, en el arranque).
+   default_mode = "Auto"
+   ```
+
+4. **Habilita e inicia el servicio**:
+   ```sh
+   sudo systemctl enable --now scx_loader.service
+   ```
+</Steps>
+
+#### Orden de Búsqueda de Configuración
+
+`scx_loader` busca el archivo de configuración en el siguiente orden:
+
+1. `/etc/scx_loader/config.toml` (Preferido)
+2. `/etc/scx_loader.toml`
+3. `/usr/share/scx_loader/config.toml` (Plantilla predeterminada)
+4. `/usr/share/scx_loader.toml`
+
+### Personalizar Argumentos del Planificador
+
+Puedes personalizar los argumentos pasados a cada planificador para diferentes modos añadiendo una sección `[scheds.scx_nombre]` a tu archivo de configuración.
+
+Para información detallada y ejemplos sobre cómo configurar argumentos por planificador, consulta la [documentación de configuración de scx_loader](https://github.com/sched-ext/scx-loader/blob/main/crates/scx_loader/configuration.md).
+
 ## Transición de scx.service a scx_loader: Una Guía Completa
 
 :::caution
-No intente ejecutar scx_loader.service junto con scx.service, de lo contrario, el servicio del cargador se iniciará pero no hará nada.
+No intentes ejecutar scx_loader.service junto con scx.service, de lo contrario, el servicio del cargador se iniciará pero no hará nada.
 
 Este conflicto surge porque ambos servicios no son conscientes el uno del otro, especialmente en lo que respecta a cuál de ellos gestiona los planificadores.
 :::
 
 :::tip
-El Gestor de Kernel de CachyOS ya incluye una [GUI para gestionar el scx_loader.](/es/features/kernel_manager#gestión-del-framework-sched-ext)
+El Gestor de Kernel de CachyOS ya incluye una [GUI para gestionar el scx_loader.](/es/features/kernel_manager#gestion-del-framework-sched-ext)
 :::
 
 Primero, comencemos con una comparación detallada entre la estructura de archivos de scx.service y la estructura del archivo de configuración de scx_loader.
@@ -853,7 +1130,7 @@ Primero, comencemos con una comparación detallada entre la estructura de archiv
 # Lista de scx_schedulers: scx_bpfland scx_central scx_flash scx_lavd scx_layered scx_nest scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_userland
 SCX_SCHEDULER=scx_lavd
 
-# Establecer flags personalizados para el planificador
+# Establecer flags personalizadas para el planificador
 SCX_FLAGS='--performance'
 ```
 
@@ -869,7 +1146,7 @@ auto_mode = ["--performance"]
 
 [Para más información sobre cómo configurar el archivo scx_loader](https://github.com/sched-ext/scx-loader/blob/main/crates/scx_loader/configuration.md#scx_loader-configuration-file)
 
-  Siga la guía a continuación para una transición sencilla del `servicio systemd scx` a la nueva utilidad `scx_loader`.
+  Sigue la guía a continuación para una transición sencilla del `servicio systemd scx` a la nueva utilidad `scx_loader`.
   <Steps>
   1. ```sh title='Deshabilitando scx.service en favor de scx_loader.service'
       systemctl disable --now scx.service && systemctl enable --now scx_loader.service
@@ -877,17 +1154,17 @@ auto_mode = ["--performance"]
   2. ```sh title='Creando el archivo de configuración para scx_loader y añadiendo la estructura por defecto'
      # El editor Micro va a crear un nuevo archivo.
      sudo micro /etc/scx_loader.toml
-     # Añada las siguientes líneas:
+     # Añade las siguientes líneas:
 
-     default_sched = "scx_bpfland" # Edite esta línea con el planificador que desea que scx_loader inicie en el arranque
+     default_sched = "scx_bpfland" # Edita esta línea con el planificador que quieres que scx_loader inicie en el arranque
      default_mode = "Auto" # Valores posibles: "Auto", "Gaming", "LowLatency", "PowerSave".
 
-     # Pulse CTRL + S para guardar los cambios y CTRL + Q para salir de Micro.
+     # Pulsa CTRL + S para guardar los cambios y CTRL + Q para salir de Micro.
      ```
   3. ```sh title='Reiniciando el scx_loader'
      systemctl restart scx_loader.service
      ```
-     - Ha terminado, el scx_loader ahora cargará e iniciará el planificador deseado.
+     - Has terminado, el scx_loader ahora cargará e iniciará el planificador deseado.
 
   </Steps>
 
@@ -908,22 +1185,30 @@ auto_mode = ["--performance"]
 </TabItem>
 <TabItem label='Registro extendido'>
 
-*Para obtener un registro más detallado, siga estos pasos.*
+*Para obtener un registro más detallado, sigue estos pasos.*
   - ```sh title='Editar el archivo del servicio'
      sudo systemctl edit scx_loader.service
      ```
-  - ```sh title='Añada la siguiente línea bajo la sección [Service]'
+  - ```sh title='Añade la siguiente línea bajo la sección [Service]'
      Environment=RUST_LOG=trace
      ```
-  - ```sh title='Reinicie el servicio'
+  - ```sh title='Reinicia el servicio'
      sudo systemctl restart scx_loader.service
      ```
-  - Revise los registros de nuevo para obtener información de depuración más detallada.
+  - Revisa los registros de nuevo para obtener información de depuración más detallada.
 </TabItem>
 
 </Tabs>
 
 ## Preguntas Frecuentes
+
+### Hay tantas opciones... ¿por qué no hacer un solo planificador que sea bueno en todo?
+
+La razón principal es que no existe una solución única para todo cuando se trata de planificación de CPU. Diferentes cargas de trabajo tienen diferentes requisitos y prioridades, y un planificador optimizado para un tipo de carga de trabajo puede no funcionar bien para otro.
+
+Podrías ver los planificadores de CPU como diferentes pares de zapatos, cada uno diseñado para una actividad específica. Por ejemplo, ejecutar un juego en un planificador optimizado para cargas de trabajo de servidor puede llevar a un rendimiento subóptimo y mayor latencia, mientras que usar un planificador diseñado para juegos en un servidor puede resultar en una utilización ineficiente de recursos y menor throughput.
+
+Esa es la magia de sched-ext. Las limitaciones ya no son un problema.
 
 ### ¿Por qué el planificador X rinde peor que el otro?
 
@@ -933,34 +1218,34 @@ auto_mode = ["--performance"]
 ### ¿Por qué todo el mundo sigue diciendo que este planificador X es el mejor para el caso X pero no me rinde tan bien?
 
 - Al igual que en la respuesta anterior, la elección de la CPU y su diseño, como la disposición de los núcleos, cómo comparten la caché entre los núcleos y otros factores relacionados, pueden hacer que el planificador funcione de manera menos eficiente.
-- Por eso tener opciones es uno de los puntos fuertes del framework sched-ext, así que no tenga miedo de probar uno y ver cuál funciona mejor para su caso de uso. `Ejemplos: estabilidad de fps, rendimiento máximo, capacidad de respuesta bajo cargas de trabajo intensivas, etc.`
+- Por eso tener opciones es uno de los puntos fuertes del framework sched-ext, así que no tengas miedo de probar uno y ver cuál funciona mejor para tu caso de uso. `Ejemplos: estabilidad de fps, rendimiento máximo, capacidad de respuesta bajo cargas de trabajo intensivas, etc.`
 
 ### Los casos de uso de estos planificadores son bastante similares... ¿por qué es eso?
 
 Principalmente porque son planificadores multipropósito, lo que significa que pueden adaptarse a una variedad de cargas de trabajo, aunque puede que no destaquen en todas las áreas.
 
-- Para determinar qué planificador se adapta mejor a usted, no hay mejor consejo que probarlo por sí mismo.
+- Para determinar qué planificador se adapta mejor a ti, no hay mejor consejo que probarlo por sí mismo.
 
 ### ¿Por qué me falta un planificador que algunos usuarios mencionan o prueban en el servidor de Discord de CachyOS?
-Asegúrese de que está utilizando la versión más reciente del paquete scx-scheds, llamada `scx-scheds-git`
+Asegúrate de que estás utilizando la versión de vanguardia del paquete scx-scheds, llamada `scx-scheds-git`
 
 - Una de las razones será que este planificador es muy nuevo y actualmente está siendo probado por los usuarios, por lo tanto, aún no se ha añadido al paquete `scx-scheds-git`.
 
 ### ¿Por qué el planificador se ha colgado de repente? ¿Es inestable?
 
 - *Podría haber algunas razones por las que esto ocurrió:*
-  - Una de las razones más comunes es que estaba usando ananicy-cpp junto con el planificador. Por eso añadimos esta [advertencia](/es/configuration/sched-ext#ananicy-cpp-y-sched-ext)
-  - Otra razón podría ser que la carga de trabajo que estaba ejecutando excedió los límites y la capacidad del planificador, provocando que se detuviera.
+  - Una de las razones más comunes es que estabas usando ananicy-cpp junto con el planificador. Por eso añadimos esta [advertencia](/es/configuration/sched-ext#ananicy-cpp-y-sched-ext)
+  - Otra razón podría ser que la carga de trabajo que estabas ejecutando excedió los límites y la capacidad del planificador, provocando que se detuviera.
     - Ejemplo de una carga de trabajo irrazonable: `hackbench`
-  - O la razón más obvia, ha encontrado un error en el planificador. Si es así, por favor repórtelo como un "issue" en su [GitHub](https://github.com/sched-ext/scx/issues) o hágaselo saber
+  - O la razón más obvia, has encontrado un error en el planificador. Si es así, por favor repórtalo como un "issue" en su [GitHub](https://github.com/sched-ext/scx/issues) o hágaselo saber
     en el canal de Discord de CachyOS `sched-ext`
 
-### He utilizado previamente el scx_loader en la GUI del Gestor de Kernel. ¿Aun así necesito seguir los pasos de transición?
+### He utilizado previamente el scx_loader en la GUI del Gestor de Kernel. ¿Aún así necesito seguir los pasos de transición?
 
 - En este caso particular, no, no es necesario porque el Gestor de Kernel ya se encarga del proceso de transición.
-  - *A menos que haya añadido previamente flags personalizados en `/etc/default/scx` y todavía quiera usarlos.*
+  - *A menos que hayas añadido previamente flags personalizadas en `/etc/default/scx` y todavía quieras usarlas.*
 
-## Aprenda Más
+## Aprende Más
 
 :::note[Créditos]
 Algunos de los enlaces a continuación fueron referenciados originalmente del [repositorio de GitHub de sched-ext](https://github.com/sched-ext/scx?tab=readme-ov-file#sched_ext-schedulers-and-tools).

--- a/src/content/docs/es/configuration/secure_boot_setup.mdx
+++ b/src/content/docs/es/configuration/secure_boot_setup.mdx
@@ -1,20 +1,14 @@
 ---
 title: Configuración del Arranque Seguro
 description: Configura el arranque seguro con sbctl después de instalar CachyOS
+tableOfContents:
+  minHeadingLevel: 1
+  maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
-
-# sbctl
-
-[sbctl](https://github.com/Foxboron/sbctl) es un gestor de claves de arranque seguro fácil de usar, capaz de configurar el arranque seguro,
-ofrecer capacidades de gestión de claves y hacer un seguimiento de los archivos que necesitan ser firmados en la cadena de arranque.
-
-## Instalando sbctl
-
-```bash
-sudo pacman -S sbctl
-```
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 ## Pre-configuración
 
@@ -31,8 +25,9 @@ Cargar módulos innecesarios en tu gestor de arranque tiene el potencial de pres
 Solo ejecuta este comando si realmente necesitas el arranque seguro.
 :::
 
-### Entrando en Modo de Configuración en UEFI
-Primero, necesitamos ir a la configuración del firmware y poner el modo de arranque seguro en "Setup Mode" (Modo de Configuración). Puedes reiniciar desde un
+### Habilitar el Modo de Configuración en UEFI
+
+Primero, necesitamos ir a la configuración del firmware y poner el modo de arranque seguro en "Setup Mode". Puedes reiniciar desde un
 sistema ya en funcionamiento a la configuración del firmware con el siguiente comando.
 
 ```bash
@@ -45,41 +40,198 @@ systemctl reboot --firmware-setup
 Así es como se ve la BIOS en un Lenovo Ideapad 5 Pro. Restablece al modo de configuración o restaura las claves de fábrica y reinicia de vuelta
 al sistema.
 
-Sin embargo, algunas placas base MSI no tienen un modo de configuración. Para lograr el mismo efecto, sigue los dos pasos de la imagen a continuación:
+#### Restablecimiento Automático
+
+En algunas placas base Gigabyte, "restablecer al modo de configuración" es seguido inmediatamente por un diálogo de "restablecer sin guardar"
+<ImageComponent imgsrc={import('~/assets/images/gigabyte-reset-without-saving.jpg')} />
+esto debe ser rechazado ya que causará un reinicio del sistema y deshabilitará el modo de configuración.
+
+En su lugar, arranca directamente el SO (Guardar y Salir, y selecciona tu gestor de arranque en Boot Override).
+
+#### Sin modo de configuración
+
+Algunas placas base MSI y ASUS no tienen un Modo de Configuración.
+
+##### MSI
+
+Establece el Modo de Arranque Seguro en "custom" y selecciona la opción de compatibilidad "maximum security" (esto es importante: con el modo predeterminado, ¡podrías no poder arrancar desde tu gestor de arranque hacia CachyOS!). Luego, ve a "key management" y sigue los dos pasos ilustrados en la imagen a continuación:
 <br />
 <ImageComponent imgsrc={import('~/assets/images/MSI-bios-secure-boot.jpg')} />
 
-## Configurando sbctl
+##### ASUS
 
-```bash
-sudo sbctl status # Si el modo de configuración está habilitado, podemos proceder al siguiente paso
-Installed:      ✘ sbctl is not installed
-Setup Mode:     ✘ Enabled
-Secure Boot     ✘ Disabled
+Navega a Boot → Secure Boot, establece Secure Boot Mode en Custom, luego abre Key Management y selecciona "Delete all Secure Boot Variables".
 
-sudo sbctl create-keys # Crea tus claves de arranque seguro personalizadas
-Created Owner UUID a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
-Creating secure boot keys...✔
-Secure boot keys created!
+#### Instalando sbctl e Inscribiendo Claves
 
-sudo sbctl enroll-keys --microsoft # Inscribe tus claves con las claves de Microsoft
-Enrolling keys to EFI variables...✔
-Enrolled keys to the EFI variables!
+Antes de continuar, asegúrate de comprobar si `sbctl` está instalado.
 
-sudo sbctl status
-# sbctl ahora debería estar instalado, podemos proceder a firmar las imágenes del kernel y el gestor de arranque
-Installed:      ✔ sbctl is installed
-Owner GUID:     a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
-Setup Mode:     ✔ Disabled
-Secure Boot     ✘ Disabled
-Vendor Keys:    microsoft
-```
+[sbctl](https://github.com/Foxboron/sbctl) es un gestor de claves de arranque seguro fácil de usar, capaz de configurar el arranque seguro,
+ofrecer capacidades de gestión de claves y hacer un seguimiento de los archivos que necesitan ser firmados en la cadena de arranque.
+
+<details>
+    <summary>Cómo instalar sbctl</summary>
+    ```bash title='Abre una terminal y ejecuta el siguiente comando'
+    sudo pacman -S sbctl
+    ```
+</details>
+
+Ahora que `sbctl` está instalado, tienes que configurar sbctl e inscribir tus claves en el firmware. Este proceso es bastante sencillo, solo sigue los pasos a continuación.
+
+<Steps>
+1. Comprueba si el Modo de Configuración está habilitado:
+    ```bash
+    sudo sbctl status
+    ```
+    <details>
+        <summary>Salida esperada</summary>
+        ```bash
+        Installed:      ✘ sbctl is not installed
+        Setup Mode:     ✘ Enabled
+        Secure Boot     ✘ Disabled
+        ```
+    </details>
+2. Crea tus claves de Arranque Seguro personalizadas:
+    ```bash
+    sudo sbctl create-keys
+    ```
+    <details>
+        <summary>Ejemplo de creación exitosa de claves</summary>
+        ```bash
+        Created Owner UUID a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
+        Creating secure boot keys...✔
+        Secure boot keys created!
+        ```
+    </details>
+3. Inscribe tus claves con las claves integradas de Microsoft y del firmware del OEM:
+    ```bash
+    sudo sbctl enroll-keys --microsoft --firmware-builtin
+    ```
+    <details>
+        <summary>Salida esperada</summary>
+        ```bash
+        Enrolling keys to EFI variables...✔
+        Enrolled keys to the EFI variables!
+        ```
+    </details>
+
+    :::caution[Placas base ASUS / Gigabyte — No uses `--firmware-builtin`]
+    En algunas placas base ASUS y Gigabyte, usar la flag `--firmware-builtin` causa entradas duplicadas
+    en las variables de claves EFI (por ejemplo, `builtin-db` apareciendo múltiples veces en `Vendor Keys`).
+    Al activar Secure Boot en la configuración UEFI después, la placa detecta esta
+    estructura de claves inconsistente y lanza un **Secure Boot Violation** antes de que el gestor
+    de arranque pueda cargar.
+
+    Usa solo `--microsoft` en placas ASUS / Gigabyte:
+
+    ```bash
+    sudo sbctl enroll-keys --microsoft
+    ```
+
+    Si `Vendor Keys` muestra `microsoft builtin-db builtin-db ...`, las claves necesitan ser
+    reinscritas. Vuelve a entrar en Setup Mode en el UEFI (usando delete all keys), luego ejecuta
+    `sbctl enroll-keys --microsoft` de nuevo sin `--firmware-builtin`.
+    :::
+
+
+4. Comprueba el estado de sbctl de nuevo para asegurarte de que las claves están inscritas y el modo de configuración está deshabilitado:
+    ```bash
+    sudo sbctl status
+    ```
+    <details>
+        <summary>Salida esperada</summary>
+        ```bash
+        Installed:      ✔ sbctl is installed
+        Owner GUID:     a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
+        Setup Mode:     ✔ Disabled
+        Secure Boot     ✘ Disabled
+        Vendor Keys:    microsoft
+        ```
+    </details>
+
+    :::note[¿El Modo de Configuración muestra Habilitado?]
+    Si `Setup Mode` muestra **Enabled**, ve a la configuración del firmware y **deshabilita temporalmente Secure Boot**.
+    Arranca de nuevo en el sistema, comprueba el estado de sbctl de nuevo, continúa con [Firmando la Imagen del Kernel y el Gestor de Arranque](#firmando-la-imagen-del-kernel-y-el-gestor-de-arranque)
+    a continuación, luego reinicia y reactiva Secure Boot en la configuración del firmware.
+    :::
+
+</Steps>
 
 ## Firmando la Imagen del Kernel y el Gestor de Arranque
 
+<Tabs>
+<TabItem label='Limine'>
+Limine es un gestor de arranque especial que permite comprobar el hash de las imágenes del
+kernel y otros archivos que Limine usa durante el arranque. Si esto está habilitado, cualquier
+tipo de configuración manual hecha por el usuario, por ejemplo, firmar la imagen a través de
+`sbctl-batch-sign`, modificará el hash de los archivos correspondientes y
+hará que la verificación de suma de comprobación de Limine falle.
+
+Sin embargo, firmar estos archivos no es necesario en Limine porque tiene un proceso de
+arranque especial que evita el encadenamiento de EFI (chainloading) y las comprobaciones de firma. Los únicos binarios EFI
+que necesitan ser firmados son Limine mismo.
+
+:::caution[Limine >= 11.2.0]
+A partir de Limine 11.2.0, las políticas de Secure Boot se **aplican estrictamente** cuando el UEFI Secure Boot está activo:
+
+- Una suma de verificación de configuración BLAKE2B **debe** estar registrada en el binario EFI de Limine, de lo contrario Limine entrará en pánico con: `SECURE BOOT IS ACTIVE BUT NO CONFIG CHECKSUM IS ENROLLED`
+- Todas las rutas de archivos en `limine.conf` (kernel, initramfs, etc.) **deben** tener hashes BLAKE2B añadidos (por ejemplo, `boot():/vmlinuz-linux#<hash>`)
+- El editor de configuración está incondicionalmente deshabilitado
+- Los conflictos de hash siempre causan un pánico
+:::
+
+Para habilitar el registro automático de la suma de verificación de configuración, establece lo siguiente en `/etc/default/limine`:
+
+```sh
+ENABLE_ENROLL_LIMINE_CONFIG=yes
+```
+
+Procede a generar un hash para la imagen de splash de Limine:
+
+:::note[Se requieren permisos de root para realizar los siguientes pasos, asegúrate de usar sudo o cambiar al usuario root antes de continuar.]
+:::
+
+<Steps>
+
+1. Comprueba el nombre y ruta actuales de la imagen de splash en el archivo de configuración:
+    ```sh title="Abre una terminal y ejecuta el siguiente comando:"
+    sudo cat /boot/limine.conf
+    ```
+    Deberías poder encontrar una línea como esta:
+    ```sh
+    wallpaper: boot():/limine-splash.png
+    ```
+2. Genera un hash BLAKE2B para la imagen de splash y añádelo a la ruta en el archivo de configuración:
+    ```sh title="Ejecuta el siguiente comando, reemplazando la ruta con la que encontraste en el paso anterior:"
+    sudo b2sum /boot/limine-splash.png
+    ```
+    Esto generará un hash como este ejemplo:
+    ```sh
+    75205d08fa9c61599897857e861d6b2f6da25465183fc4cc9efecffb22ee630efb510f2ef1b17677db94c28d5c69ad2ceb4d3892f5bec9cfa65c97b5ba16f52f
+    ```
+3. Después de copiar el hash recién generado del paso anterior. Abre el archivo de configuración con un editor de texto y añade el hash a la ruta de la imagen de splash, así:
+    :::note[No uses el hash de ejemplo de arriba, asegúrate de usar el que generaste en el paso anterior.]
+    :::
+    ```sh
+    wallpaper: boot():/limine-splash.png#75205d08fa9c61599897857e861d6b2f6da25465183fc4cc9efecffb22ee630efb510f2ef1b17677db94c28d5c69ad2ceb4d3892f5bec9cfa65c97b5ba16f52f
+    ```
+    Como puedes ver, el hash se añade a la ruta con un símbolo `#`. Guarda el archivo después de hacer el cambio.
+
+</Steps>
+
+Después de habilitar el registro de la suma de verificación de configuración y generar el hash para la imagen de splash, ejecuta los siguientes comandos para registrar la suma de verificación de configuración y firmar el binario EFI de Limine:
+
+```sh
+# Usa limine-enroll-config para registrar la suma de verificación de configuración y firmar el binario EFI de Limine
+# Esto usa sbctl internamente
+sudo limine-enroll-config
+sudo limine-update
+```
+</TabItem>
+<TabItem label='systemd-boot'>
+
 CachyOS proporciona [sbctl-batch-sign](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/sbctl-batch-sign),
 un script que toma la lista de archivos que necesitan ser firmados de `sudo sbctl verify` y los firma todos.
-Los usuarios de Limine deben saltar a [Limine](#Limine).
 
 :::caution
 En sistemas con una estructura de particiones `/boot` y `/boot/efi` separadas, es posible que `sbctl` solo busque binarios EFI en `/boot/efi`.
@@ -107,16 +259,36 @@ Verifying file database and EFI images in /boot...
 ✔ /boot/1c4b5246eef05ac3bc87339323cd5101/6.10.0-cn3.0.fc40.x86_64/linux is signed
 ```
 
-Ahora que todos los archivos están firmados. **Reinicia tu sistema y ve a la configuración de tu UEFI para habilitar el arranque seguro.**
+Ahora que todos los archivos están firmados. **Reinicia tu sistema y ve a tu Configuración UEFI para habilitar el Arranque Seguro.**
 
-Ten en cuenta que este es un proceso de una sola vez, ya que firmar archivos con la bandera `-s` guardará esos archivos en la base de datos de `sbctl`.
+:::caution[Placas base ASUS — habilitando Secure Boot]
+Algunas placas base ASUS se comportan de manera diferente a otros fabricantes al habilitar Secure Boot:
+
+- **Usa `Windows UEFI Mode`, no `Other OS`:**
+  El nombre es engañoso, esta configuración simplemente controla si Secure Boot se aplica.
+  Establecer `OS Type` en `Other OS` **deshabilita activamente** Secure Boot en placas ASUS,
+  independientemente de cualquier otra configuración. `sbctl status` continuará mostrando
+  `Secure Boot: Disabled` incluso después de reiniciar.
+
+- **No hay un interruptor separado de Secure Boot on/off** en algunas placas ASUS.
+  Secure Boot se activa implícitamente al seleccionar `Windows UEFI Mode`.
+
+La configuración correcta de la BIOS de ASUS para activar Secure Boot en este caso es:
+```
+Boot → Secure Boot
+  OS Type          → Windows UEFI Mode
+  Secure Boot Mode → Custom
+```
+:::
+
+Consulta [esta parte como referencia](/es/configuration/secure_boot_setup#habilitar-el-modo-de-configuracion-en-uefi)
+
+Ten en cuenta que este es un proceso de una sola vez, ya que firmar archivos con la flag `-s` guardará esos archivos en la base de datos de `sbctl`.
 
 :::tip[Recordatorio]
 `sbctl` viene con un [hook de pacman](https://wiki.archlinux.org/title/Pacman_hook) lo que significa que firmará
 automáticamente todos los archivos nuevos tras una actualización del kernel o del gestor de arranque.
 :::
-
-### systemd-boot
 
 CachyOS usa `systemd-boot-update.service` proporcionado por systemd para actualizar el gestor de arranque al reiniciar. Esto significa que el hook
 de pacman de `sbctl` **no** firmará los binarios EFI actualizados. Como solución, podemos firmar el gestor de arranque directamente
@@ -124,44 +296,10 @@ de pacman de `sbctl` **no** firmará los binarios EFI actualizados. Como soluci�
 ```sh
 sudo sbctl sign -s -o /usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi
 ```
+</TabItem>
+</Tabs>
 
-### Limine
-
-Limine es un gestor de arranque especial que permite comprobar el hash de las imágenes del
-kernel y otros archivos que Limine usa durante el arranque. Si esto está habilitado, cualquier
-tipo de configuración manual hecha por el usuario, por ejemplo, firmar la imagen a través de
-`sbctl-batch-sign`, modificará el hash de los archivos correspondientes y
-hará que la verificación de suma de comprobación de Limine falle.
-
-Sin embargo, firmar estos archivos no es necesario en Limine porque tiene un proceso de
-arranque especial que evita el encadenamiento de EFI (chainloading) y las comprobaciones de firma. Los únicos binarios EFI
-que necesitan ser firmados son Limine mismo.
-
-:::caution[Limine >= 11.2.0]
-A partir de Limine 11.2.0, las políticas de Secure Boot se **aplican estrictamente** cuando el UEFI Secure Boot está activo:
-
-- Una suma de verificación de configuración BLAKE2B **debe** estar registrada en el binario EFI de Limine, de lo contrario Limine entrará en pánico con: `SECURE BOOT IS ACTIVE BUT NO CONFIG CHECKSUM IS ENROLLED`
-- Todas las rutas de archivos en `limine.conf` (kernel, initramfs, etc.) **deben** tener hashes BLAKE2B añadidos (por ejemplo, `boot():/vmlinuz-linux#<hash>`)
-- El editor de configuración está incondicionalmente deshabilitado
-- Los conflictos de hash siempre causan un pánico
-:::
-
-Para habilitar el registro automático de la suma de verificación de configuración, establece lo siguiente en `/etc/default/limine`:
-
-```sh
-ENABLE_ENROLL_LIMINE_CONFIG=yes
-```
-
-Luego ejecuta:
-
-```sh
-# Usa limine-enroll-config para registrar la suma de verificación de configuración y firmar el binario EFI de Limine
-# Esto usa sbctl internamente
-sudo limine-enroll-config
-sudo limine-update
-```
-
-## Verificar que el Arranque Seguro está Habilitado
+## Verificación del Estado del Arranque Seguro
 
 Para comprobar que el arranque seguro está efectivamente habilitado. Puedes ejecutar uno de los siguientes comandos
 

--- a/src/content/docs/es/features/cachy_chroot.mdx
+++ b/src/content/docs/es/features/cachy_chroot.mdx
@@ -4,6 +4,7 @@ description: Herramienta de ayuda para facilitar el proceso de chroot en sistema
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import {Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -113,6 +114,9 @@ El símbolo **❯** indica la opción actualmente seleccionada.
     Ahora puedes ejecutar comandos como si hubieras arrancado en el sistema instalado. Por ejemplo, puedes actualizar el sistema con:
     ```bash title="Actualizando el sistema en chroot"
     pacman -Syu
+    ```
+    ```bash title="Regenera tu initramfs por si acaso"
+    mkinitcpio -P
     ```
     o realizar otras tareas de mantenimiento según sea necesario.
 8. Cuando termines, sal del entorno chroot introduciendo `exit` en la terminal o presionando `CTRL+D` en el teclado.

--- a/src/content/docs/es/features/cachyos_settings.mdx
+++ b/src/content/docs/es/features/cachyos_settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuraciones de CachyOS
+ai_translated: true
 ---
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
@@ -7,117 +8,406 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 Junto con nuestros kernels y repositorios optimizados, también proporcionamos configuraciones que mejoran aún más la experiencia de escritorio, así como algunos
 scripts de ayuda para mejoras en la calidad de vida. Todas estas configuraciones y scripts se encuentran en el paquete `cachyos-settings`.
 
-## Ajustes de sysctl
+Consulta el [repositorio de CachyOS Settings](https://github.com/CachyOS/CachyOS-Settings?tab=readme-ov-file#cachyos-settings) para leer más sobre todas las configuraciones y scripts que proporcionamos.
+
+## Scripts y Herramientas
+
+### [cachyos-bugreport.sh](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/cachyos-bugreport.sh)
+
+Así es como puedes generar un informe de errores usando el script `cachyos-bugreport.sh`:
+<Steps>
+1. Abre una terminal y ejecuta el siguiente comando:
+    ```sh
+    sudo cachyos-bugreport.sh
+    ```
+    <details>
+        <summary>Ejemplo de salida</summary>
+        ```sh
+        sudo cachyos-bugreport.sh
+        [sudo] password for array:
+        Starting with bugreport
+        Redacting personal information...
+        Do you want to upload this log to https://paste.cachyos.org? [Y]es/[N]o: Y
+        Uploading Log
+          % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
+                                         Dload  Upload  Total   Spent   Left   Speed
+        100 130.3k 100     10 100 130.3k      7  96934   00:01   00:01         117.7k
+        # Se proporcionará una URL aquí después de que la carga se complete.
+        ```
+    </details>
+2. El script generará un archivo de registro en tu directorio personal que contiene información del sistema y registros que pueden ser útiles para la depuración. También preguntará si quieres subir el registro a nuestro servicio de pastebin, lo que puede ser útil al reportar errores.
+</Steps>
+
+### DLSS Swapper
+
+Puede ser útil en algunos casos. Especialmente para la versión de Proton proporcionada por Valve.
+
+:::note
+Proton-CachyOS ya proporciona una funcionalidad de actualización integrada.
+:::
+
+:::caution
+No combines `PROTON_DLSS_UPGRADE=1` y `dlss-swapper` al mismo tiempo, ya que ambos hacen lo mismo y pueden causar conflictos.
+:::
+
+Lo que hace es intentar actualizar las DLLs y preajustes de DLSS a la última versión disponible, lo que puede ser útil para algunos juegos que requieren una versión específica de DLSS para funcionar correctamente.
+
+¿Cómo? Inyectando variables de entorno al proceso del juego:
+
+<details>
+    <summary>Variables de entorno de dlss-swapper</summary>
+    ```sh
+    export PROTON_ENABLE_NGX_UPDATER=1
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    ```
+</details>
+<details>
+    <summary>Variables de entorno de dlss-swapper-dll</summary>
+    ```sh
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+    export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+    ```
+</details>
+
+- ¿Cuál es la diferencia entre `dlss-swapper` y `dlss-swapper-dll`?
+    - `dlss-swapper` actualiza las DLLs y preajustes de DLSS a las últimas versiones disponibles proporcionadas por NGX Updater y `dlss-swapper-dll` se basa en las DLLs ya presentes en el directorio del juego.
+
+
+### [game-performance](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/game-performance)
+
+Script pequeño que habilita el perfil de rendimiento de `powerprofilesctl` para el proceso objetivo (puede usarse para juegos o cualquier otro proceso) y deshabilita el protector de pantalla mientras el proceso se está ejecutando.
+
+Preguntas y respuestas:
+
+<details>
+    <summary>Cómo usar</summary>
+    Digamos que quieres usar `game-performance` para un juego de Steam. Puedes hacerlo añadiendo el comando `game-performance` como opción de lanzamiento para el juego en Steam:
+        <Steps>
+            1. Abre Steam y ve a tu Biblioteca.
+            2. Haz clic derecho en el juego con el que quieres usar `game-performance` y selecciona "Propiedades".
+            3. En la pestaña "General", encuentra la sección "Opciones de lanzamiento" y añade el siguiente comando:
+                ```sh
+                game-performance %command%
+                ```
+                :::tip[Guía sobre cómo gestionar opciones de lanzamiento en Steam]
+                CachyOS Wiki - [Cómo Configurar Correctamente Múltiples Opciones de Lanzamiento](/es/configuration/gaming#como-configurar-correctamente-multiples-opciones-de-lanzamiento)
+                :::
+            4. Cierra la pestaña de propiedades y lanza el juego.
+        </Steps>
+        <details>
+            <summary>Uso fuera de Steam</summary>
+            Dado que `game-performance` es solo un script envoltorio, puedes usarlo para lanzar cualquier proceso con el perfil de rendimiento habilitado. Solo ejecuta el siguiente comando en la terminal:
+            ```sh
+            game-performance <comando>
+            ```
+        </details>
+</details>
+
+<details>
+    <summary>¿game-performance proporciona algún beneficio para una CPU antigua?</summary>
+    Generalmente no. Deberías evitarlo en CPUs antiguas ya que puede causar más daño que beneficio.
+
+    Para dar una guía aproximada, usar game-performance en cualquier CPU con menos de 6 núcleos/12 hilos probablemente no aumentará o incluso disminuirá el rendimiento. Como con la mayoría de opciones, deberías probar tú mismo si mejoran el rendimiento en tu sistema específico o no.
+      - Para CPUs de escritorio Intel, el corte aproximado es la 8ª generación (Coffee Lake) para CPUs i7 e i9 y la 10ª generación (Comet Lake) para CPUs i5. Todas las CPUs Intel Ultra deberían funcionar.
+      - Para CPUs de escritorio AMD es la serie 1000 (Zen) para CPUs Ryzen 7 y Ryzen 9. Para CPUs Ryzen 5 también es la serie 1000, pero solo el Ryzen 5 1600 y superior. Este es el caso hasta la serie 5000 (Zen 3) donde ahora todas las CPUs Ryzen 5 tienen 6 núcleos y 12 hilos.
+      - Las CPUs de escritorio Intel i3 y Ryzen 3 nunca tienen más de cuatro núcleos.
+      - Los conteos de núcleos para CPUs móviles, de estación de trabajo y de servidor varían mucho, así que investiga lo que tienes y prueba diferentes configuraciones, ¡esa es la mitad de la diversión de tener hardware de PC!
+</details>
+
+<details>
+    <summary>¿Por qué no está habilitado por defecto?</summary>
+    Habilitar el perfil de rendimiento puede no ser ideal para todos los usuarios y puede causar un mayor consumo de energía y generación de calor. Al no habilitarlo por defecto, damos a los usuarios la opción de habilitarlo cuando lo necesitan, sin imponérselo a todos.
+</details>
+
+### [kerver](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/kerver)
+
+kerver es un script que comparte un breve resumen de:
+
+- Tu versión actual del kernel
+    - Comprueba el soporte x86_64 y las optimizaciones del compilador de la CPU
+- Planificador de E/S actual
+- Resumen de la CPU, E/S y planificador sched-ext (si está activo).
+
+<details>
+    <summary>Uso</summary>
+    ```sh title='Abre una terminal y ejecuta el siguiente comando:'
+    kerver
+    ```
+    <details>
+        <summary>Ejemplo de salida</summary>
+        ```sh
+        kerver
+
+        Check kernel version:
+
+        Linux version 6.19.8-1-hC (linux-hC@hC) (clang version 22.1.1, LLD 22.1.1) #1 SMP PREEMPT_DYNAMIC Sun, 15 Mar 2026 16:27:53 +0000
+        Linux CatchyOS 6.19.8-1-hC #1 SMP PREEMPT_DYNAMIC Sun, 15 Mar 2026 16:27:53 +0000 x86_64 GNU/Linux
+
+
+        Check x86_64 support:
+
+          x86-64-v3 (supported, searched)
+          x86-64-v2 (supported, searched)
+
+
+        Check CPU config:
+
+        CONFIG_X86_NATIVE_CPU=y
+        # CONFIG_GENERIC_CPU is not set
+        # CONFIG_MZEN4 is not set
+
+
+        Current disk schedulers:
+
+        sda: none mq-deadline kyber [adios] bfq
+        sdb: none mq-deadline kyber [adios] bfq
+
+        Check available schedulers:
+
+        BORE CPU Scheduler modification 6.6.2 by Masahito Suzuki
+        rcu: RCU calculated value of scheduler-enlistment delay is 100 jiffies.
+        io scheduler mq-deadline registered
+        io scheduler kyber registered
+        Adaptive Deadline I/O Scheduler 3.2.0 by Masahito Suzuki
+        io scheduler adios registered
+        io scheduler bfq registered
+        sched_ext: BPF scheduler "bpfland_1.1.0_gc505008f_x86_64_unknown_linux_gnu" enabled with options scx_bpfland
+        ```
+    </details>
+</details>
+
+### [paste-cachyos](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/paste-cachyos)
+
+Una herramienta CLI simple que te permite subir texto a nuestro [servicio de pastebin](https://paste.cachyos.org). Puede ser útil para compartir registros y otro contenido de texto al reportar errores o buscar ayuda.
+
+:::note
+Para usar `paste-cachyos`. Tienes que pasar `|` el contenido que quieres subir al comando.
+
+Ejemplo:
+```sh
+<comando> | paste-cachyos
+```
+:::
+
+Aquí tienes algunos ejemplos de cómo usar `paste-cachyos`
+
+<details>
+    <summary>Compartiendo una salida de actualización de pacman</summary>
+    ```sh
+    sudo pacman -Syu | paste-cachyos
+    ```
+    [Ejemplo](https://paste.cachyos.org/p/079e1cc)
+</details>
+
+<details>
+    <summary>Registro journalctl de systemd-resolved</summary>
+    ```sh
+    journalctl -u systemd-resolved.service | paste-cachyos
+    ```
+</details>
+
+### [pci-latency](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/pci-latency)
+
+Un script simple destinado a intentar reducir la latencia y mejorar el rendimiento para tarjetas de sonido PCI cambiando el temporizador de latencia PCI.
+
+Disponible tanto en formato binario como de servicio systemd. El servicio systemd aplicará automáticamente los cambios en el arranque, mientras que el binario puede usarse para aplicar los cambios bajo demanda.
+
+<details>
+    <summary>Uso único para la sesión actual</summary>
+    ```sh
+    sudo pci-latency
+    ```
+</details>
+<details>
+    <summary>Habilitando el servicio systemd</summary>
+    ```sh
+    systemctl enable pci-latency.service
+    ```
+</details>
+<details>
+    <summary>Deshabilitando el servicio systemd</summary>
+    ```sh
+    systemctl disable pci-latency.service
+    ```
+</details>
+
+### [sbctl-batch-sign](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/sbctl-batch-sign)
+
+:::note
+No compatible con Limine.
+:::
+
+`sbctl-batch-sign` es un script de ayuda diseñado para facilitar a los usuarios la firma de archivos necesarios para el soporte de arranque seguro.
+
+El caso obvio en el que este script ayuda mucho es al tener un arranque dual con Windows, ya que hay muchos archivos de Windows que necesitan ser firmados en EFI.
+
+Resumen breve al ejecutar el script:
+
+- Busca archivos sin firmar usando `sbctl verify`
+    - Si es necesario, firma los archivos detectados usando `sbctl sign`
+- Evita archivos que pertenecen a Windows, GRUB o por extensión de archivo: `.mui` y `.dll`
+
+Consulta nuestra sección [Configuración del Arranque Seguro](/es/configuration/secure_boot_setup#firmando-la-imagen-del-kernel-y-el-gestor-de-arranque) para más información.
+
+### [topmem](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/topmem)
+
+Script Lua que muestra los procesos con mayor consumo de memoria por su uso de RAM, SWAP y compartición KSM (Kernel Same-page Merging).
+
+<details>
+    <summary>Antes de usar</summary>
+    ```sh
+    # Instala lua-luv para ejecutar el script:
+    sudo pacman -S lua-luv
+    ```
+</details>
+<details>
+    <summary>Uso</summary>
+    ```sh
+    topmem
+    ```
+    <details>
+        <summary>Ejemplo de salida</summary>
+        ```sh
+        topmem
+
+        MEMORY                Top 10 processes        SWAP      KSM
+        1333M     node                                0M        0M
+        811M      exe                                 0M        0M
+        759M      VQ6B1EUZqoCU04zoRU= --cha...        0M        0M
+        681M      node                                0M        0M
+        531M      zed-editor                          0M        0M
+        484M      brave                               0M        0M
+        424M      qs                                  0M        0M
+        408M      mdx-language-server                 0M        0M
+        395M      Telegram                            0M        0M
+        365M      VQ6B1EUZqoCU04zoRU= --cha...        0M        0M
+        ```
+    </details>
+</details>
+
+### [zink-run](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/zink-run)
+
+Fuerza el uso de Zink (OpenGL sobre Vulkan) para el proceso objetivo estableciendo las variables de entorno apropiadas.
+
+<details>
+    <summary>Variables de entorno usadas</summary>
+    ```sh
+    MESA_LOADER_DRIVER_OVERRIDE=zink
+    GALLIUM_DRIVER=zink
+    __GLX_VENDOR_LIBRARY_NAME=mesa
+    __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
+    ```
+</details>
+
+Puede ser útil en Steam para algunos juegos que tienen mejor rendimiento o compatibilidad con Zink.
+
+<details>
+    <summary>Uso</summary>
+    ```sh
+    zink-run <comando>
+    ```
+</details>
+
+## Creación de Overrides
+
+¿Qué es un override?
+
+Un override es un archivo de configuración que creas para cambiar la configuración predeterminada proporcionada por `cachyos-settings`. Esto te permite personalizar tu sistema sin modificar los archivos originales, lo que puede ser útil para mantener la compatibilidad con futuras actualizaciones de `cachyos-settings`.
+
+### sysctl
 
 Proporcionamos una gran cantidad de ajustes de sysctl que tienen como objetivo mejorar el rendimiento general del escritorio. Cada entrada de sysctl está bien documentada
 en el archivo [70-cachyos-settings.conf](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/sysctl.d/70-cachyos-settings.conf).
 
-Para realizar cambios en cualquiera de estos valores, copie la entrada original y cree un nuevo archivo en `/etc/sysctl.d/` con el valor modificado.
+Para realizar cambios en cualquiera de estos valores, copia la entrada original y crea un nuevo archivo en `/etc/sysctl.d/` con el valor modificado.
 
-### Modificando valores de sysctl
+<details>
+    <summary>Ejemplo de override de sysctl</summary>
+    <Steps>
 
-<Steps>
+    1. Echa un vistazo al valor original de `cachyos-settings`
 
-1. Eche un vistazo al valor original de `cachyos-settings`
+        ```sh
+        cat /usr/lib/sysctl.d/70-cachyos-settings.conf
+        # Only experimental!
+        # Let Realtime tasks run as long they need
+        # sched: RT throttling activated
+        kernel.sched_rt_runtime_us=-1
+        ```
+    2. Crea un nuevo archivo en `/etc/sysctl.d` para realizar cambios en la configuración de sysctl
 
-    ```sh
-    cat /usr/lib/sysctl.d/70-cachyos-settings.conf
-    # Only experimental!
-    # Let Realtime tasks run as long they need
-    # sched: RT throttling activated
-    kernel.sched_rt_runtime_us=-1
-    ```
+        ```sh title="Revirtiendo kernel.sched_rt_runtime_us= a su valor por defecto"
+        sudo micro /etc/sysctl.d/99-kernel-sched-rt.conf # Si el archivo no existe, este comando lo crea y te permite editarlo
+        kernel.sched_rt_runtime_us=950000
+        ```
+    3. Guarda el archivo pulsando `CTRL + S` y sal del editor pulsando `CTRL + Q`.
+    4. Después de realizar cambios en la configuración de sysctl, asegúrate de aplicar los cambios:
+        ```sh
+        sudo sysctl --system
+        ```
+    </Steps>
+</details>
 
-2. Cree un nuevo archivo en `/etc/sysctl.d` para realizar cambios en la configuración de sysctl
+### Reglas udev
 
-    ```sh title="Revirtiendo kernel.sched_rt_runtime_us= a su valor por defecto"
-    sudo micro /etc/sysctl.d/99-kernel-sched-rt.conf # Si el archivo no existe, este comando lo crea y le permite editarlo
-    kernel.sched_rt_runtime_us=950000
-    ```
+Lo mismo aplica para las reglas udev. Puedes crear tus propios overrides creando un nuevo archivo en `/etc/udev/rules.d/` con el mismo nombre que el archivo original.
 
-</Steps>
+:::tip[Usa el siguiente comando para encontrar los archivos originales]
+```sh
+pacman -Ql cachyos-settings | grep udev
+```
+:::
 
-## Reglas udev
+<details>
+    <summary>Ejemplo de override de regla udev</summary>
+    1. Comprueba la regla udev original de CachyOS:
+        ```sh
+        cat /usr/lib/udev/rules.d/60-ioschedulers.rules
+        ```
+        <details>
+            <summary>Salida:</summary>
+                ```sh
+                # HDD
+                ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
+                    ATTR{queue/scheduler}="bfq"
 
-- [Reglas ZRAM](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/30-zram.rules) - Establece el swappiness de ZRAM a un valor más agresivo
-para que la caché sea más propensa a intercambiarse a ZRAM
-- [Permisos HPET](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/40-hpet-permissions.rules) - Permite el acceso a los nodos de dispositivo `rtc0`
-y `hpet` por parte del grupo de audio
-- [Gestión de Energía SATA](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/50-sata.rules) - Establece la política de gestión de energía de los dispositivos SATA a `max_performance`. Solo si el dispositivo es compatible con LPM.
-- [Reglas del Planificador de E/S](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/60-ioschedulers.rules) - Selecciona el planificador óptimo para cada tipo de unidad (HDD, SSD, NVMe)
-- [Reglas hdparm](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/69-hdparm.rules) - Establece los discos duros SATA e IDE a máximo rendimiento
-- [NVIDIA RTD3](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/71-nvidia.rules) - Configura la funcionalidad de gestión dinámica de energía para la generación de GPU Turing. `RTD3 no funciona correctamente en GPUs Turing con los módulos abiertos`
-- [Latencia DMA de la CPU](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/99-cpu-dma-latency.rules) -
-Permite el acceso al nodo de dispositivo `cpu_dma_latency` por parte del grupo de audio
-- [PM de snd_hda_intel](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/udev/rules.d/20-audio-pm.rules) - Establece el ahorro de energía en `0` con alimentación de CA y restaura el valor anterior al cambiar a batería
+                # SSD
+                ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
+                    ATTR{queue/scheduler}="mq-deadline"
 
-## Opciones de modprobe
+                # NVMe SSD
+                ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
+                    ATTR{queue/scheduler}="none"
+                ```
+        </details>
+        Ahora imagina que quieres cambiar el planificador de E/S para SSDs y NVMe a `kyber` en lugar de `mq-deadline` y `none`, respectivamente. Puedes hacerlo creando un archivo override.
+    2. Crea un nuevo archivo en `/etc/udev/rules.d` para anular la regla original:
+        ```sh
+        sudo micro /etc/udev/rules.d/60-ioschedulers.rules # Si el archivo no existe, este comando lo crea y te permite editarlo
+        # HDD
+        ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
+            ATTR{queue/scheduler}="bfq"
 
-- Fuerza el controlador AMDGPU en Southern Islands (GCN 1.0) y Sea Islands (GCN 2.0)
-- Habilita [varios ajustes](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/modprobe.d/nvidia.conf) para NVIDIA
-- Pone en lista negra los módulos watchdog
-- Desactiva power_save para el controlador de audio **sna_hda_intel**
+        # SSD
+        ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
+            ATTR{queue/scheduler}="kyber"
 
-## Scripts de Ayuda
+        # NVMe SSD
+        ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
+            ATTR{queue/scheduler}="kyber"
+        ```
+    3. Guarda el archivo pulsando `CTRL + S` y sal del editor pulsando `CTRL + Q`.
+    4. Después de realizar cambios en las reglas udev, asegúrate de recargar las reglas y activarlas:
 
-- `cachyos-bugreport.sh` - Recopila varios registros de `inxi`, `dmesg` y `journalctl` para ayudar en la resolución de problemas
-- `game-performance` - Script envoltorio para `powerprofilesctl` para cambiar al perfil de rendimiento bajo demanda.
-Consulte [Cambio de perfil de energía bajo demanda](/es/configuration/gaming#cambio-de-perfil-de-energia-a-demanda)
-- `dlss-swapper` - Script envoltorio para forzar el último preajuste de DLSS en juegos que soportan la tecnología
-- `dlss-swapper-dll` - Como `dlss-swapper`, pero requiere actualizar manualmente la biblioteca `nvngx_dlss.dll` que viene con el juego; puede funcionar con juegos que tienen problemas con la versión regular del script
-- `kerver` - Script de calidad de vida para mostrar información sobre el kernel actual
-- `paste-cachyos` - Script para pegar la salida de la terminal o archivos de texto del sistema
-
-    <Tabs>
-        <TabItem label="Subiendo archivos de texto">
-            ```sh
-            paste-cachyos /ruta/al/archivo
-            ```
-        </TabItem>
-        <TabItem label="Subiendo salida de la terminal">
-            ```sh
-            <comando> | paste-cachyos
-            ```
-        </TabItem>
-    </Tabs>
-- [pci-latency](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/pci-latency) - Reduce el valor de latency_timer a `80` para las tarjetas de sonido PCI y restablece todos los demás dispositivos PCI a `20` y `0`
-    ```sh title="Habilitando pci-latency en todo el sistema"
-    sudo systemctl enable --now pci-latency.service
-    ```
-- `sbctl-batch-sign` - Script de ayuda para firmar fácilmente imágenes de kernel y binarios EFI para el arranque seguro y los guarda en la base de datos
-de sbctl
-- `topmem` - Muestra estadísticas de RAM, swap y ksm de 10 procesos en orden descendente
-- `zink-run` - Facilita la ejecución de un programa OpenGL a través del controlador Zink Gallium
-
-
-## Otras configuraciones
-
-### Ajustes de Uso de Memoria
-
-- Configuración del Reductor THP `max_ptes_none = 409`
-- Establece el tamaño máximo en `50MB` para el journal de systemd
-- [Generador ZRAM](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/systemd/zram-generator.conf) - Configura ZRAM al mismo tamaño que la RAM y utiliza ZSTD para la compresión
-
-### Reglas de Ananicy-cpp
-
-- [ananicy-cpp](https://gitlab.com/ananicy-cpp/ananicy-cpp) con [conjuntos de reglas mantenidos por la comunidad](https://github.com/CachyOS/ananicy-rules)
-
-### Modificaciones de Red
-
-- [systemd-resolved como el resolvedor DNS por defecto](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/NetworkManager/conf.d/dns.conf) para NetworkManager
-
-### Calidad de vida de NTP
-
-- Servidor preferido establecido en `Cloudflare`
-- Servidores de respaldo: `Google` y `Arch Linux`
-
-### Ajustes de Servicios de systemd
-
-- Tiempo de espera para iniciar un servicio/unidad establecido en `15s`
-- Tiempo de espera para detener un servicio/unidad establecido en `10s`
-- Límite blando para descriptores de archivo abiertos establecido en `2048`
-- Límite duro para descriptores de archivo abiertos establecido en `2097152`
-
-### X.Org
-
-- Habilita [Tocar para Hacer Clic](https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/share/X11/xorg.conf.d/20-touchpad.conf) por defecto para todas las sesiones X11
+        ```sh
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger
+        ```
+</details>

--- a/src/content/docs/es/features/chwd/chwd.mdx
+++ b/src/content/docs/es/features/chwd/chwd.mdx
@@ -1,6 +1,7 @@
 ---
 title: Gestionando Hardware con chwd
 description: Detección y Configuración de Hardware para CachyOS
+ai_translated: true
 ---
 
 La [Detección de Hardware de CachyOS](https://github.com/CachyOS/chwd/) (más conocida como `chwd`) nos permite dar soporte a una variedad de hardware instalando los paquetes
@@ -25,23 +26,38 @@ Una alternativa al método anterior es instalar cada perfil específico.
 
 ```sh title='Listar todos los perfiles disponibles'
 chwd --list-all
-╭─────────────────────────┬─────────╮
-│ Name                    ┆ NonFree │
-╞═════════════════════════╪═════════╡
-│ nvidia-open-dkms.prime  ┆ true    │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ nvidia-dkms             ┆ true    │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ macbook-t2              ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ phoenix                 ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ steam-deck              ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ amd                     ┆ false   │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ intel                   ┆ false   │
-╰─────────────────────────┴─────────╯
+> All PCI profiles:
+╭─────────────────────────┬──────────╮
+│ Name                    ┆ Priority │
+╞═════════════════════════╪══════════╡
+│ nouveau                 ┆ 18       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ nvidia-dkms-470xx       ┆ 14       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ nvidia-dkms-580xx       ┆ 12       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ nvidia-open-dkms        ┆ 10       │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ macbook-t2              ┆ 9        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ virtualmachine          ┆ 5        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ amd                     ┆ 4        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ intel                   ┆ 4        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ fallback                ┆ 3        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld.intel-msi-claw ┆ 2        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld.rog-ally       ┆ 2        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld.steam-deck     ┆ 2        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ handheld                ┆ 1        │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+│ broadcom-wl             ┆ 1        │
+╰─────────────────────────┴──────────╯
 ```
 
 ```sh title='Instalando un perfil de chwd'

--- a/src/content/docs/es/features/kernel.mdx
+++ b/src/content/docs/es/features/kernel.mdx
@@ -4,6 +4,7 @@ description: Características y cambios en el kernel de CachyOS
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 El kernel de CachyOS es un kernel personalizado que utiliza mejoras, configuraciones y parches de versiones superiores (upstream).
@@ -12,43 +13,56 @@ El kernel de CachyOS es un kernel personalizado que utiliza mejoras, configuraci
 
 ### Optimizaciones de Rendimiento
 
-- **Compilación Avanzada**: PKGBUILD altamente personalizable con soporte para compiladores GCC y Clang.
-- **Optimización en Tiempo de Enlazado (LTO)**: Thin LTO activado por defecto para un mejor rendimiento.
-- **Optimización Guiada por Perfil (PGO)**: Perfilado con AutoFDO + Propeller para una generación de código óptima ([Aprende más](https://cachyos.org/blog/2411-kernel-autofdo/)).
-- **Integridad de Flujo de Control del Kernel (kCFI)**: Disponible al usar LLVM para una seguridad mejorada.
-- **Opciones de Frecuencia del Temporizador**: Configurable entre 300Hz, 500Hz, 600Hz, 750Hz y 1000Hz (por defecto: 1000Hz).
-- **Optimizaciones de Arquitectura**: Soporte para compilaciones específicas de x86-64-v3, x86-64-v4 y AMD Zen4.
-- **Optimizaciones del Compilador**: Opciones avanzadas de GCC, incluyendo `-fivopts` y `-fmodulo-sched`.
+- **Compilación Avanzada**: PKGBUILD altamente personalizable con soporte para compiladores GCC y Clang
+- **Optimización en Tiempo de Enlazado (LTO)**: Clang Thin LTO activado por defecto en el paquete principal `linux-cachyos`
+- **ThinLTO Distribuido**: Soporte para compilaciones distribuidas de Clang ThinLTO para acelerar la compilación del kernel
+- **Optimización Guiada por Perfil**: Perfilado AutoFDO + Propeller en el kernel por defecto para una generación de código óptima ([Aprende más](https://cachyos.org/blog/2411-kernel-autofdo/))
+- **Integridad de Flujo de Control del Kernel (kCFI)**: Disponible al usar LLVM para una seguridad mejorada
+- **Opciones de Frecuencia del Temporizador**: Configurable entre 100Hz, 250Hz, 300Hz, 500Hz, 600Hz, 750Hz y 1000Hz (por defecto: 1000Hz)
+- **Optimizaciones de Arquitectura**: Soporte para compilaciones específicas de x86-64-v3, x86-64-v4 y AMD Zen4
+- **Optimizaciones del Compilador**: Opciones avanzadas de GCC, incluyendo `-fivopts` y `-fmodulo-sched`
+- **PREEMPT_DYNAMIC**: Modos de preemption seleccionables en tiempo de ejecución (full, lazy, voluntary, none)
 
 ### Mejoras de CPU
 
-- **Múltiples Planificadores**: Planificadores BORE, EEVDF y BMQ para optimización de diferentes cargas de trabajo.
-- **Mejoras en AMD P-State**: Soporte para Preferred Core y las últimas mejoras de amd-pstate de linux-next.
-- **Soporte de Tiempo Real**: Compilaciones de kernel RT disponibles con integración del planificador BORE.
-- **CachyOS Sauce**: Configuración personalizada `CONFIG_CACHY` con ajustes del planificador y del sistema.
-- **Optimizaciones de Baja Latencia**: Parches para una capacidad de respuesta mejorada y una menor fluctuación (jitter).
+- **Múltiples Planificadores**: Planificadores BORE, EEVDF y BMQ para optimización de diferentes cargas de trabajo
+- **[POC Selector](https://github.com/masahitoS/scx_cake)**: Selector rápido de CPU inactiva Piece-Of-Cake inspirado en scx_cake, reduciendo la latencia de despertar
+- **CachyOS Sauce**: Configuración personalizada `CONFIG_CACHY` con ajustes del planificador y del sistema
+- **Mejoras en AMD P-State**: Soporte para Preferred Core y las últimas mejoras de amd-pstate de linux-next
+- **Soporte de Tiempo Real**: Compilaciones de kernel RT disponibles con integración del planificador BORE
+- **Optimizaciones de Baja Latencia**: Parches para una capacidad de respuesta mejorada y una menor fluctuación (jitter)
+- **sched/wait LIFO accept()**: accept() de sockets procesado en orden LIFO para una mejor eficiencia de caché
+
+### Networking
+
+- **[BBR3 TCP](https://github.com/google/bbr)**: Control de congestión BBRv3 disponible como módulo separado junto con BBRv1
 
 ### Sistema de Archivos y Memoria
 
-- **Soporte para ZFS**: Soporte integrado para el sistema de archivos ZFS con módulos precompilados.
+- **Soporte para ZFS**: Soporte integrado para el sistema de archivos ZFS con módulos precompilados
+- **Mejoras NTFS**: Correcciones del controlador NTFS upstream para validación del espejo MFT, verificación de límites de atributos y manejo de logfile
+- **Mejoras MGLRU**: Manejo mejorado de dirty writeback, estadísticas simplificadas de reclamo vmscan y ajuste Cachy Sauce MM (protección de conjunto de trabajo LRU-gen, ajustes de compactación/marcas de agua, reclamo de hugepage)
 - **Integración de NVIDIA**:
-  - Módulos del controlador privativo de NVIDIA con parches.
-  - Soporte para el controlador de código abierto de NVIDIA.
-  - Módulos listos para usar en el repositorio.
+  - Módulos del controlador privativo de NVIDIA con parches
+  - Soporte para el controlador de código abierto de NVIDIA
+  - Módulos listos para usar en el repositorio
 - **Mejoras en el Planificador de E/S**:
-  - Rendimiento mejorado de BFQ y mq-deadline.
-  - Soporte para el planificador de E/S alternativo [ADIOS](https://github.com/firelzrd/adios).
-- **Gestión de Memoria**:
-  - Parche [le9uo](https://github.com/firelzrd/le9uo) para prevenir la hiperpaginación (page thrashing) bajo presión de memoria.
-  - Ajustes de gestión de memoria de Zen-kernel (compactación, optimización de marcas de agua).
+  - Rendimiento mejorado de BFQ y mq-deadline
+  - Soporte para el planificador de E/S multi-cola [ADIOS](https://github.com/firelzrd/adios) v3.2.0
+- **VRAM Cgroup (DMEM)**: Controlador de memoria de dispositivo para restringir el uso de VRAM de GPU por cgroup en el subsistema DRM
 
 ### Características Adicionales
 
 #### Soporte de Hardware
-- **Hardware para Juegos**: Parches para Steam Deck (Audio, peculiaridades de HW, HID) y soporte para ROG Ally.
-- **Hardware de Apple**: Soporte para MacBook T2 incluido por defecto.
-- **Hardware de ASUS**: Parches extendidos para compatibilidad con hardware ASUS.
-- **Gráficos**: Soporte HDR activado, anulación de `min_powercap` de AMDGPU (`amdgpu_ignore_min_pcap`).
+- **AMD ISP4**: Nuevo controlador de cámara AMD ISP 4 para plataformas compatibles
+- **Hardware para Juegos**: Parches para Steam Deck (Audio, HW Quirks, HID), soporte para ROG Ally y controlador HID para MSI Claw (deckify)
+- **Hardware de Apple**: Soporte para MacBook T2 con controlador apple-bce en staging
+- **Hardware de ASUS**: Parches extendidos para compatibilidad con hardware ASUS
+- **Hardware de Lenovo**: Limitación de carga de batería WMI, atributos ajustables de GPU/CPU y capdata debugfs
+- **Hardware de HP**: Soporte para portátiles OMEN Slim y OMEN MAX vía hp-wmi
+- **Gráficos**: Soporte HDR activado, anulación de `min_powercap` de AMDGPU (`amdgpu_ignore_min_pcap`)
+- **Pantalla**: HDMI VRR en AMD, propiedades de conector ALLM y VRR pasivo, análisis de bits por píxel VESA DSC desde EDID
+- **Códigos de Audio**: Soporte para códigos de audio AW88399 y MAX98390 HDA side
 
 #### Mejoras del Sistema
 - **Multimedia**: Módulos v4l2loopback incluidos por defecto.

--- a/src/content/docs/es/features/optimized_repos.mdx
+++ b/src/content/docs/es/features/optimized_repos.mdx
@@ -4,6 +4,7 @@ description: Información sobre nuestros repositorios optimizados
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -135,13 +136,52 @@ Ejemplo: De znver4 a v4.
 
 ## Añadir Nuestros Repositorios a una Instalación Existente de Arch Linux
 
-:::caution
-Instalar el Pacman de CachyOS instalará un pacman bifurcado con características añadidas de CachyOS, como "INSTALLED_FROM" y una comprobación automática de arquitectura. Pacman 6.1 añadió una función de validación de características, lo que podría generar advertencias al usar el pacman de Arch Linux. Estamos trabajando con Arch Linux para ofrecer de nuevo una compatibilidad adecuada. Si quieres evitar esto, no añadas el repositorio "cachyos", que contiene el pacman personalizado. Todos los demás repositorios como cachyos-v3, cachyos-v4, cachyos-extra/core-v3/4 son seguros de añadir.
-:::
-
 :::tip
 Antes de considerar añadir nuestros repositorios, por favor echa un vistazo a la **[lista de compatibilidad de CPUs](/es/installation/installation_prepare#soporte-de-nivel-de-microarquitectura-x86_64)**
 :::
+
+<Tabs>
+
+<TabItem label='Automatizada'>
+
+Proporcionamos un script que automatiza la instalación de nuestros repositorios en tus instalaciones existentes basadas en Arch.
+
+```sh
+curl https://mirror.cachyos.org/cachyos-repo.tar.xz -o cachyos-repo.tar.xz
+tar xvf cachyos-repo.tar.xz && cd cachyos-repo
+sudo ./cachyos-repo.sh
+```
+
+:::tip[Cómo funciona el script]
+Este script detecta los conjuntos de instrucciones que tu CPU es capaz de ejecutar e instala la versión de nuestros repositorios que esté más optimizada para ella. También hace una copia de seguridad de tu antiguo `pacman.conf` para la eliminación del repositorio a través del script.
+:::
+
+</TabItem>
+
+<TabItem label='Manual'>
+    :::caution
+    Instalar el Pacman de CachyOS instalará un pacman bifurcado con características añadidas de CachyOS, como "INSTALLED_FROM" y una comprobación automática de arquitectura. Pacman 6.1 añadió una función de validación de características, lo que podría generar advertencias al usar el pacman de Arch Linux. Estamos trabajando con Arch Linux para ofrecer de nuevo una compatibilidad adecuada. Si quieres evitar esto, no añadas el repositorio "cachyos", que contiene el pacman personalizado. Todos los demás repositorios como cachyos-v3, cachyos-v4, cachyos-extra/core-v3/4 son seguros de añadir.
+    :::
+
+<Steps>
+
+1. Instala el llavero de CachyOS:
+
+   ```sh
+   # Importar la clave del repositorio
+   sudo pacman-key --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com
+   # Firmar la clave del repositorio
+   sudo pacman-key --lsign-key F3B607488DB35A47
+   ```
+2. Instala los paquetes necesarios:
+
+   ```sh
+   sudo pacman -U 'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-keyring-20240331-1-any.pkg.tar.zst' \
+   'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-mirrorlist-27-1-any.pkg.tar.zst' \
+   'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst' \
+   'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v4-mirrorlist-27-1-any.pkg.tar.zst' \
+   'https://mirror.cachyos.org/repo/x86_64/cachyos/pacman-7.1.0.r9.g54d9411-4-x86_64.pkg.tar.zst'
+   ```
 
 <Tabs>
 
@@ -180,7 +220,6 @@ Este script detecta los conjuntos de instrucciones que tu CPU es capaz de ejecut
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-mirrorlist-27-1-any.pkg.tar.zst' \
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst' \
    'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-v4-mirrorlist-27-1-any.pkg.tar.zst' \
-   'https://mirror.cachyos.org/repo/x86_64/cachyos/pacman-7.1.0.r7.gb9f7d4a-3-x86_64.pkg.tar.zst'
    ```
 3. Añade los repositorios de CachyOS al archivo de configuración de pacman:
    :::note

--- a/src/content/docs/es/installation/boot_managers.mdx
+++ b/src/content/docs/es/installation/boot_managers.mdx
@@ -4,6 +4,7 @@ description: Descripción y recomendaciones para los gestores de arranque ofreci
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 3
+ai_translated: true
 ---
 
 Para ofrecer la mejor experiencia en una variedad de dispositivos, CachyOS ofrece actualmente los siguientes gestores de arranque: **systemd-boot, rEFInd, GRUB y Limine**.
@@ -29,7 +30,7 @@ Si te encuentras con estos problemas, considera usar `systemd-boot` o `Limine`.
   .bm-table th, .bm-table td {
     padding: 8px 10px;
     vertical-align: top;
-    break-word: break-word;
+    word-break: break-word;
   }
   /* vertical separators between boot-manager columns */
   .bm-table th:not(:first-child),

--- a/src/content/docs/es/installation/desktop_environments.mdx
+++ b/src/content/docs/es/installation/desktop_environments.mdx
@@ -1,6 +1,7 @@
 ---
 title: Entornos de escritorio
 description: Entornos de escritorio proporcionados por CachyOS
+ai_translated: true
 ---
 
 import ImageComponent from '~/components/image-component.astro';
@@ -16,7 +17,7 @@ Por favor, selecciona solo un entorno de escritorio durante la instalación.
 Las opciones disponibles son:
 
 1. **KDE Plasma:** un entorno de escritorio completo y flexible que ofrece múltiples estilos de menús para acceder a las aplicaciones. Utiliza el gestor de ventanas KWin. KDE Plasma también cuenta con una interfaz intuitiva que te permite descargar e instalar fácilmente nuevos temas, widgets y más desde la web.
-2. **Niri:** es un compositor de Wayland de tipo tiling y desplazable que enfatiza la simplicidad y la gestión fluida de ventanas. Utiliza un diseño de cuadrícula continua, optimizado tanto para la navegación con teclado como con panel táctil. Encuentra nuestros [dotfiles](https://github.com/CachyOS/cachyos-niri-settings) de Niri.
+2. **Niri:** es un compositor de Wayland de tipo tiling y desplazable que enfatiza la simplicidad y la gestión fluida de ventanas. Utiliza un diseño de cuadrícula continua, optimizado tanto para la navegación con teclado como con panel táctil. Encuentra nuestros [dotfiles](https://github.com/CachyOS/cachyos-niri-noctalia) de Niri.
 3. **i3:** un popular gestor de ventanas de tipo tiling para X11, conocido por su único archivo de configuración autocontenido y su uso eficiente del espacio en pantalla. Encuentra nuestros [dotfiles de i3 aquí](https://github.com/CachyOS/cachyos-i3wm-settings).
 4. **Qtile:** un gestor de ventanas para X11/Wayland que se configura con el lenguaje de programación Python. Ofrece varios diseños y widgets. Encuentra nuestros [dotfiles aquí](https://github.com/CachyOS/cachyos-qtile-settings).
 5. **Wayfire:** un compositor de Wayland basado en wlroots que equilibra la personalización, la extensibilidad y la estética. Encuentra nuestros [dotfiles](https://github.com/CachyOS/cachyos-wayfire-settings) de Wayfire.
@@ -26,13 +27,12 @@ Las opciones disponibles son:
 9. **Budgie:** un entorno de escritorio simple y elegante construido con el toolkit GTK. Está diseñado para proporcionar una interfaz moderna y atractiva que es fácil de usar y, al mismo tiempo, altamente configurable.
 10. **Cinnamon:** un entorno de escritorio para Linux que equilibra características avanzadas con una experiencia de usuario tradicional.
 11. **Cosmic:** un entorno de escritorio moderno y orientado al rendimiento, construido con Rust y Smithay. Diseñado para la productividad y los usuarios avanzados, su objetivo es ofrecer características avanzadas manteniendo una interfaz limpia pero intuitiva.
-12. **Hyprland:** un compositor de Wayland visualmente agradable que utiliza tiling dinámico.
+12. **Hyprland:** un compositor de Wayland visualmente agradable que utiliza tiling dinámico. Viene con CachyOS Noctalia por defecto. Consulta nuestros dotfiles [aquí](https://github.com/CachyOS/cachyos-hypr-noctalia).
 13. **LXDE** (Lightweight X11 Desktop Environment): un entorno de escritorio rápido y de bajo consumo energético diseñado para ser utilizado en ordenadores antiguos y sistemas con recursos limitados. Utiliza Openbox como su gestor de ventanas predeterminado y se centra en proporcionar una interfaz simple, limpia y fácil de usar.
 14. **LXQt:** un entorno de escritorio ligero formado a partir de la fusión de los proyectos LXDE y Razor-qt y construido con Qt.
 15. **Mate Desktop:** un entorno de escritorio tradicional derivado de GNOME 2. Se caracteriza por su apariencia clásica, con una interfaz de usuario simple e intuitiva. Mate proporciona una experiencia de escritorio fácil de usar y altamente personalizable para usuarios que prefieren una apariencia más clásica.
 16. **Openbox:** un gestor de ventanas para X11 muy popular, conocido por su excelente documentación y una amplia selección de temas disponibles.
 17. **Sway:** un compositor de Wayland de tipo tiling y un reemplazo directo del gestor de ventanas i3 para X11. Funciona con tu configuración de i3 existente y es compatible con la mayoría de las características de i3, además de algunos extras.
-18. **UKUI:** un entorno de escritorio ligero que es eficiente y funciona bien en ordenadores antiguos. Utiliza tecnologías GTK y Qt, y tiene una apariencia visual similar a Windows 7, lo que lo hace fácil de usar para los nuevos usuarios de Linux.
 
 ## Capturas de pantalla
 
@@ -63,6 +63,11 @@ Las opciones disponibles son:
 
 <br />
 <ImageComponent imgsrc={import('~/assets/images/niri.jpg')} />
+
+### Hyprland
+
+<br />
+<ImageComponent imgsrc={import('~/assets/images/hyprland.png')} />
 
 ### Qtile
 

--- a/src/content/docs/es/installation/filesystem.md
+++ b/src/content/docs/es/installation/filesystem.md
@@ -1,6 +1,7 @@
 ---
 title: Sistemas de archivos
-description: Descripción y recomendaciones para los sistemas de archivos disponibles. (ext4, f2fs, btrfs, xfs, zfs, bcachefs)
+description: Descripción y recomendaciones para los sistemas de archivos disponibles. (ext4, f2fs, btrfs, xfs, zfs)
+ai_translated: true
 ---
 
 CachyOS ofrece 5 sistemas de archivos diferentes para permitir al usuario elegir el que mejor se adapte a sus necesidades. A continuación se detallarán las ventajas, desventajas y recomendaciones para cada sistema de archivos. Cada sistema de archivos viene con sus requisitos/utilidades preinstalados en CachyOS.

--- a/src/content/docs/es/installation/installation_handheld.mdx
+++ b/src/content/docs/es/installation/installation_handheld.mdx
@@ -1,15 +1,16 @@
 ---
 title: Edición para Portátiles (Handheld Edition)
 description: Cómo instalar CachyOS en dispositivos portátiles
+ai_translated: true
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 CachyOS ofrece una edición para dispositivos portátiles, como la Steam Deck, ROG Ally y Legion Go. Esta edición proporciona una experiencia similar a SteamOS con cambio de modo de juego (Game Mode), aplicaciones de juego preinstaladas y más.
 
 La Edición para Portátiles emplea el planificador LAVD como el planificador de CPU por defecto, el cual está optimizado para dispositivos portátiles. Esto resulta en una mejora de la tasa de fotogramas y de la duración de la batería durante el juego.
 
-La Edición para Portátiles utiliza `systemd-boot` como gestor de arranque. La selección del gestor de arranque no está disponible, a diferencia de la ISO por defecto de CachyOS. Esto tiene como objetivo simplificar el proceso de instalación.
+La Edición para Portátiles utiliza `limine` como gestor de arranque con instantáneas automáticas. `systemd-boot` también está disponible como alternativa.
 
 :::note[KDE Plasma es el único entorno de escritorio soportado para la Edición para Portátiles.]
 :::
@@ -54,10 +55,33 @@ Este proceso puede tardar hasta 2 minutos.
 
 5. Calamares se abrirá ahora. Siga las instrucciones en pantalla.
 
-6. En el paso de particionado necesita seleccionar **Manual Partition** (Particionado manual) y crear las siguientes particiones:
+6. En el paso de particionado necesita seleccionar **Manual Partition** (Particionado manual) y crear las siguientes particiones dependiendo de su gestor de arranque:
 
-    - 2GB /boot
-    - XGB / (X puede ser cualquier cantidad de espacio de almacenamiento que desee asignar al sistema de archivos raíz)
+    Partición de arranque:
+    <Tabs>
+    <TabItem label='Limine'>
+    - ##### Tamaño: Al menos **4096 MiB**
+    - ##### Sistema de archivos: **FAT32**
+    - ##### Punto de montaje: **/boot**
+    - ##### Flags: **boot**
+    Partición raíz:
+    - ##### Tamaño: Al menos **20000 MiB**
+    - ##### Sistema de archivos: **BTRFS**
+    - ##### Punto de montaje: **/**
+    - ##### Flags:
+    </TabItem>
+    <TabItem label='systemd-boot'>
+    - ##### Tamaño: Al menos **2048 MiB**
+    - ##### Sistema de archivos: **FAT32**
+    - ##### Punto de montaje: **/boot**
+    - ##### Flags: **boot**
+    Partición raíz:
+    - ##### Tamaño: Al menos **20000 MiB**
+    - ##### Sistema de archivos: **BTRFS**
+    - ##### Punto de montaje: **/**
+    - ##### Flags:
+    </TabItem>
+    </Tabs>
 
 7. Continúe con los pasos e instale el sistema.
 

--- a/src/content/docs/es/installation/installation_on_root.mdx
+++ b/src/content/docs/es/installation/installation_on_root.mdx
@@ -6,6 +6,7 @@ sidebar:
 tableOfContents:
   minHeadingLevel: 1
   maxHeadingLevel: 4
+ai_translated: true
 ---
 
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -69,14 +70,14 @@ La tabla de particiones para cada gestor de arranque varía. Sigue las instrucci
 
 5. Crea una nueva partición con los siguientes parámetros dependiendo del gestor de arranque elegido:
     <Tabs>
-        <TabItem label='systemd-boot & rEFInd'>
-            - ##### Tamaño: Al menos **2048 MiB**
+        <TabItem label='Limine'>
+            - ##### Tamaño: Al menos **4096 MiB**
             - ##### Sistema de archivos: **FAT32**
             - ##### Punto de montaje: **/boot**
             - ##### Banderas: **boot**
         </TabItem>
-        <TabItem label='Limine'>
-            - ##### Tamaño: Al menos **4096 MiB**
+        <TabItem label='systemd-boot & rEFInd'>
+            - ##### Tamaño: Al menos **2048 MiB**
             - ##### Sistema de archivos: **FAT32**
             - ##### Punto de montaje: **/boot**
             - ##### Banderas: **boot**
@@ -196,6 +197,12 @@ Los sistemas de archivos FAT no se pueden redimensionar en el lugar. Para "redim
   - Consulta la sección [Crear una unidad USB de arranque de CachyOS](/es/installation/installation_prepare#creación-de-una-unidad-usb-de-arranque-de-cachyos).
 
 <Tabs>
+    <TabItem label='Limine'>
+        Limine debería detectar automáticamente la partición EFI de Windows y añadirla al menú de arranque. Si Windows no aparece en el menú de arranque, ejecuta el siguiente comando:
+        ```bash
+        sudo limine-scan
+        ```
+    </TabItem>
     <TabItem label='systemd-boot'>
         **Necesitamos copiar los binarios EFI de Windows a la partición EFI de Linux para que el gestor de arranque pueda reconocerlos.**
 
@@ -241,7 +248,9 @@ Los sistemas de archivos FAT no se pueden redimensionar en el lugar. Para "redim
         </Steps>
     </TabItem>
 
-    <TabItem label='GRUB'>
+    <TabItem label='GRUB (Solo para instalaciones antiguas)'>
+        :::tip[CachyOS habilita os-prober por defecto.]
+        :::
         **GRUB usa os-prober para detectar automáticamente la partición EFI de Windows y añadirla al menú de arranque.**
 
         <Steps>

--- a/src/content/docs/es/installation/installation_t2macbook.mdx
+++ b/src/content/docs/es/installation/installation_t2macbook.mdx
@@ -1,6 +1,7 @@
 ---
 title: MacBook T2
 description: Cómo instalar CachyOS en un MacBook T2
+ai_translated: true
 ---
 
 import { Steps } from '@astrojs/starlight/components';
@@ -46,7 +47,7 @@ Si planeas hacer un arranque dual con macOS (recomendado), necesitas crear espac
 4.  Haz clic en el botón **"+" (más)** debajo del gráfico circular que representa el uso de tu disco.
 5.  **Crucialmente**, cuando se te pida, elige **"Añadir partición"**, *no* "Añadir volumen". Necesitas crear una partición separada para Linux.
 6.  **Nombre:** Introduce un nombre descriptivo para la nueva partición (p. ej., "CachyOS" o "Linux").
-7.  **Formato:** Selecciona cualquier formato disponible (como APFS o Mac OS Plus). El instalador de CachyOS reformateará esta partición más tarde, por lo que la elección inicial no importa.
+7.  **Formato:** Selecciona cualquier formato disponible (como APFS o Mac OS Extended). El instalador de CachyOS reformateará esta partición más tarde, por lo que la elección inicial no importa.
 8.  **Tamaño:** Asigna la cantidad deseada de espacio de almacenamiento para CachyOS. **Ten en cuenta que redimensionar particiones más tarde puede ser difícil o imposible**, así que elige un tamaño que satisfaga tus necesidades.
 10. Haz clic en **"Aplicar"** para crear la nueva partición. Utilidad de Discos redimensionará tu partición de macOS y creará el nuevo espacio vacío.
 

--- a/src/content/docs/es/policy/code_of_conduct.md
+++ b/src/content/docs/es/policy/code_of_conduct.md
@@ -1,5 +1,6 @@
 ---
 title: Código de Conducta
+ai_translated: true
 ---
 
 # Código de Conducta del Pacto del Contribuyente
@@ -120,12 +121,12 @@ la comunidad.
 
 Este Código de Conducta está adaptado del [Pacto del Contribuyente][homepage],
 versión 2.0, disponible en
-<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html](<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>).
 
 Las Directrices de Impacto Comunitario se inspiraron en la [escala de aplicación del código de conducta de Mozilla](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
 Para obtener respuestas a preguntas comunes sobre este código de conducta, consulta las Preguntas Frecuentes en
-<https://www.contributor-covenant.org/faq>. Hay traducciones disponibles en
-<https://www.contributor-covenant.org/translations>.
+[FAQ](<https://www.contributor-covenant.org/faq>). Las traducciones están disponibles en
+[https://www.contributor-covenant.org/translations](<https://www.contributor-covenant.org/translations>).

--- a/src/content/docs/es/policy/repository_policy.md
+++ b/src/content/docs/es/policy/repository_policy.md
@@ -1,5 +1,6 @@
 ---
 title: Política de Uso del Repositorio
+ai_translated: true
 ---
 
 Política de Uso del Repositorio de CachyOS
@@ -37,7 +38,7 @@ Los usuarios de otras distribuciones **NO ESTÁN SOPORTADOS** y se **DESACONSEJA
 - Parabola
 - Usuarios de cualquier otra distribución de Linux no mencionada explícitamente en la sección "Usuarios Soportados".
 
-## 5. Redistribución del Repositorio
+## 6. Redistribución del Repositorio
 
 Esta política define la "redistribución" como las acciones de inclusión del repositorio de CachyOS (y sus réplicas) o de los paquetes obtenidos del repositorio de CachyOS como parte de la imagen distribuida del sistema operativo o de los sysroots.
 La redistribución también incluye las acciones de las **distribuciones de Linux** de proporcionar utilidades que habiliten el repositorio de CachyOS a elección del usuario, o de proporcionar cualquier documento oficial o distribuido que guíe a los usuarios a habilitar el repositorio de CachyOS
@@ -45,7 +46,7 @@ La redistribución también incluye las acciones de las **distribuciones de Linu
 
 La redistribución del repositorio de CachyOS está autorizada exclusivamente al equipo de CachyOS.
 
-## 6. Redistribución Prohibida
+## 7. Redistribución Prohibida
 
 La redistribución del repositorio de CachyOS (y sus réplicas) en cualquier distribución de Linux no autorizada, incluidas otras distribuciones basadas en Arch, está **ESTRICTAMENTE PROHIBIDA**. Esto incluye, entre otras:
 
@@ -55,29 +56,29 @@ La redistribución del repositorio de CachyOS (y sus réplicas) en cualquier dis
 - Parabola
 - Cualquier otra distribución de Linux no mencionada explícitamente en la sección "Redistribución del Repositorio".
 
-## 7. Réplica (Mirror)
+## 8. Réplica (Mirror)
 
 Se permite replicar el repositorio mediante rsync y syncthing. Las réplicas de terceros pueden replicar el repositorio y proporcionar un servidor web para ello, siempre y cuando se aseguren de que los datos del repositorio no se modifiquen.
 
-## 8. Cumplimiento y Supervisión
+## 9. Cumplimiento y Supervisión
 
 Nos reservamos el derecho de supervisar el uso de nuestro repositorio para garantizar el cumplimiento de esta política. Cualquier uso no autorizado puede resultar en la revocación del acceso.
 
-## 9. Reportar Infracciones
+## 10. Reportar Infracciones
 
 Si sospecha que se está infringiendo esta política, por favor repórtelo a [admin@cachyos.org].
 
-## 10. Cambios en la Política
+## 11. Cambios en la Política
 
 CachyOS se reserva el derecho de modificar esta política en cualquier momento. Los cambios se comunicarán a través de nuestros canales oficiales.
 
-## 11. Información de Contacto
+## 12. Información de Contacto
 
 Para cualquier pregunta o duda sobre esta política, por favor contáctenos en:
 
-- Correo electrónico: <admin@cachyos.org>
-- Sitio web: <https://cachyos.org>
+- Correo electrónico: [admin@cachyos.org](mailto:admin@cachyos.org)
+- Sitio web: [https://cachyos.org](https://cachyos.org)
 
-## 12. Aceptación
+## 13. Aceptación
 
 Al utilizar el repositorio de CachyOS (y sus réplicas), usted reconoce que ha leído, entendido y acepta cumplir con esta política.

--- a/src/content/docs/es/support/donation.md
+++ b/src/content/docs/es/support/donation.md
@@ -1,6 +1,7 @@
 ---
 title: Donación
 description: Formas de apoyarnos
+ai_translated: true
 ---
 
 Si quieres apoyar nuestro trabajo, puedes donarnos y ayudar a pagar nuestros servidores de compilación.
@@ -12,11 +13,9 @@ Aquí hay una lista de los costos actuales por mes:
 - Segundo servidor de compilación 70€ (Hetzner 7700X)
 - Servidor web/mirror 17 €
 - Servidor de correo/mirror 17 €
-- Servidor del foro (Netcup VPS) 7 euros
+- Servidor del foro (Netcup VPS) 7 €
 
-### Patreon
-
-<https://www.patreon.com/CachyOS>
+### [Patreon](<https://www.patreon.com/CachyOS>)
 
 ### Ethereum
 


### PR DESCRIPTION
# Updating languages with local AI: Spanish

As discussed in Issue #550 I will be starting to AI-translate the languages that don't have anyone translating them by hand like I'm doing with the German one. As most of the existing translations are done by AI anyway, this will just be an update, rather than a step back in quality.

This is the third language by priority after Russian and Portuguese. Next up is simplified Chinese as the Steam hardware survey lists a ton of Chinese people using Linux but their capability to understand a Wiki is fairly low. That one will be one hell of a task tho since it's a completely new but absolutely needed language. I might drop down from Q6 to Q4 so I can fit 262k instead of 131k KV-cache for that one, let's see. 

I ran the wiki page local with bun and while I obviously can't verify the translation itself, I always try to verify if the site is visually identical to the English one to spot syntax errors and if things are or aren't translated. @Aarrayy didn't you mention you are from Argentinia? Maybe you can verify if my GPU is producing slop or not haha.

## As I have strong critical opinions on AI-use myself, I want the process to be ran on local hardware and as transparent as possible, which is why I'm listing prompt, model, soft- and hardware that were used. Feel free to suggest any changes or request any clarification of my approach.

### Prompt used:
"Today we are going to translate technical documentation for the CachyOS wiki (Arch-based Linux distro).

TRANSLATION RULES:

TRANSLATE:
- Body text and explanatory content
- Headings, titles, section labels
- UI labels (TabItem labels, button text, etc.)
- Link display text (visible text, not the URL itself)
- Explanatory comments (in code blocks and around terminal output)

DO NOT TRANSLATE:
- Actual commands and code
- Terminal output
- Program/package/file names and paths (pacman, gcc, /etc/pacman.conf, etc.)
- URLs
- Technical terms (bootloader, kernel, PGO, LTO, BOLT, etc.)
- External link URLs

GOAL: Translate the context so a native reader understands what to do, without over-translating. Users are expected to know basic Linux concepts by their English names.

INTERNAL LINKS: English files live at /src/content/docs/<path>.mdx, translations at /src/content/docs/<lang-code>/<path>.mdx. When a link points to another wiki page, add the language code (e.g., /ru/installation/...) so users stay on the translated site. External links stay unchanged.

UPDATING EXISTING TRANSLATIONS:
- Translated pages usually exist but are outdated; keep existing translation for unchanged content
- Apply all differences from English: add new content, remove deleted content, update changed content
- Minimal changes only; do not rewrite unchanged sections
- Match English formatting EXACTLY: same line breaks, same punctuation marks (' stays ', not ` or "), same spacing
- At the top of the file there usually is a field seperated by a --- at the top and bottom. Always add an ai_translated: true as the last line above the bottom ---

VERIFYING CHANGES:
There already is a local build running with bun, you can verify the changes live at http://localhost:4321/ if needed.

HOW TO WRITE CHANGES:
- Start with the first file and translate/update them one by one. Only when you are done with the first one, proceed to the second and so on.
- If unchecked, you like to write 1000+ lines at once which will result in the tool-call failing. Only write up to 500 lines at once, save the file, then continue with the next batch.

FILES THAT NEED TO BE TRANSLATED/UPDATED TO SPANISH (es):

OUTDATED:
    cachyos_basic/faq.mdx
    configuration/automount_with_fstab.mdx
    configuration/boot_manager_configuration.mdx
    configuration/btrfs_snapshots.mdx
    configuration/desktop_environments/switch_desktop.mdx
    configuration/dual_gpu.mdx
    configuration/enabling_hardware_acceleration_in_google_chrome.mdx
    configuration/gaming.mdx
    configuration/general_system_tweaks.mdx
    configuration/post_install_setup.mdx
    configuration/sched-ext.mdx
    configuration/secure_boot_setup.mdx
    features/cachy_chroot.mdx
    features/cachyos_settings.mdx
    features/chwd/chwd.mdx
    features/kernel.mdx
    features/optimized_repos.mdx
    installation/boot_managers.mdx
    installation/desktop_environments.mdx
    installation/filesystem.md
    installation/installation_handheld.mdx
    installation/installation_on_root.mdx
    installation/installation_t2macbook.mdx
    policy/code_of_conduct.md
    policy/repository_policy.md
    support/donation.md

MISSING:
    configuration/desktop_environments/hyprland.mdx"

### Model used:
[A Qwen3.6 27B finetune](https://huggingface.co/DavidAU/Qwen3.6-27B-Fable-Fusion-711-Uncensored-Heretic-NM-DAU-NEO-MAX-MTP-GGUF/blob/main/Qwen3.6-27B-Fable-Fus-711-UnHeretic-NM-DAU-NEO-MAX-NEO-MTP-Q6_K.gguf) at Q6_K with Q8_0 KV-cache

### Software used:
My own AUR packages [llama.cpp-sycl](https://github.com/cantosun99/llama.cpp-sycl) and [intel-deep-learning-essentials](https://github.com/cantosun99/intel-deep-learning-essentials) to run the model, [Pi Coding Agent](https://pi.dev/) as the harness, running on CachyOS of course

### Hardware used:
Sparkle Intel Arc Pro B70 with 32GB VRAM
