### PR TITLE
TranslationBanner.astro: Added all languages

### DIFF
--- a/src/components/TranslationBanner.astro
+++ b/src/components/TranslationBanner.astro
@@ -8,18 +8,107 @@ if (!locale || isFallback) return null;
 const aiTranslated = entry.data.ai_translated ?? false;
 
 const hasOutdatedBanner = !!entry.data.banner;
+
+const translations: Record<string, { title: string; line1: string; line2: string; line3: string }> = {
+  cs: {
+    title: 'Poznámka k překladu',
+    line1: 'Toto je překlad spravovaný komunitou. Autoritativním zdrojem je anglická verze.',
+    line2: 'Tato stránka byla přeložena pomocí generativní umělé inteligence a nemusela být ještě zkontrolována rodilým mluvčím.',
+    line3: 'Našli jste chybu? Otevřete prosím issue nebo pošlete opravu. Příspěvky komunity nám pomáhají udržovat překlady přesné a aktuální.',
+  },
+  de: {
+    title: 'Übersetzungshinweis',
+    line1: 'Dies ist eine von der Community gepflegte Übersetzung. Die englische Version ist die maßgebliche Quelle.',
+    line2: 'Diese Seite wurde mit generativer KI übersetzt und wurde möglicherweise noch nicht von einer muttersprachlichen Person überprüft.',
+    line3: 'Fehler gefunden? Bitte öffne ein Issue oder reiche eine Korrektur ein. Beiträge aus der Community helfen uns, Übersetzungen korrekt und aktuell zu halten.',
+  },
+  el: {
+    title: 'Σημείωση μετάφρασης',
+    line1: 'Αυτή είναι μια μετάφραση που συντηρείται από την κοινότητα. Η αγγλική έκδοση είναι η έγκυρη πηγή.',
+    line2: 'Αυτή η σελίδα μεταφράστηκε με χρήση παραγωγικής τεχνητής νοημοσύνης και ενδέχεται να μην έχει ακόμη ελεγχθεί από φυσικό ομιλητή.',
+    line3: 'Βρήκατε κάποιο σφάλμα; Ανοίξτε ένα issue ή υποβάλετε μια διόρθωση. Οι συνεισφορές της κοινότητας μάς βοηθούν να διατηρούμε τις μεταφράσεις ακριβείς και ενημερωμένες.',
+  },
+  es: {
+    title: 'Aviso de traducción',
+    line1: 'Esta es una traducción mantenida por la comunidad. La versión en inglés es la fuente autorizada.',
+    line2: 'Esta página se ha traducido con IA generativa y es posible que aún no haya sido revisada por un hablante nativo.',
+    line3: '¿Has encontrado un error? Abre un issue o envía una corrección. Las contribuciones de la comunidad nos ayudan a mantener las traducciones precisas y actualizadas.',
+  },
+  fr: {
+    title: 'Avis de traduction',
+    line1: 'Ceci est une traduction maintenue par la communauté. La version anglaise fait foi.',
+    line2: "Cette page a été traduite à l'aide de l'IA générative et n'a peut-être pas encore été relue par un locuteur natif.",
+    line3: 'Vous avez trouvé une erreur ? Veuillez ouvrir une issue ou proposer une correction. Les contributions de la communauté nous aident à maintenir des traductions exactes et à jour.',
+  },
+  ja: {
+    title: '翻訳に関する注意事項',
+    line1: 'これはコミュニティによって保守されている翻訳です。英語版が正式なソースです。',
+    line2: 'このページは生成 AI を使用して翻訳されており、ネイティブスピーカーによるレビューがまだ行われていない可能性があります。',
+    line3: '誤りを見つけた場合は、Issue を作成するか、修正を提出してください。コミュニティの貢献により、翻訳の正確性と最新性を保つことができます。',
+  },
+  ko: {
+    title: '번역 안내',
+    line1: '이 번역은 커뮤니티에서 관리합니다. 영어 버전이 공식 원본입니다.',
+    line2: '이 페이지는 생성형 AI로 번역되었으며 아직 원어민이 검토하지 않았을 수 있습니다.',
+    line3: '오류를 발견하셨나요? 이슈를 열거나 수정 사항을 제출해 주세요. 커뮤니티 기여를 통해 번역을 정확하고 최신 상태로 유지할 수 있습니다.',
+  },
+  pl: {
+    title: 'Informacja o tłumaczeniu',
+    line1: 'To jest tłumaczenie utrzymywane przez społeczność. Wersja angielska jest źródłem autorytatywnym.',
+    line2: 'Ta strona została przetłumaczona przy użyciu generatywnej sztucznej inteligencji i mogła jeszcze nie zostać sprawdzona przez native speakera.',
+    line3: 'Znaleziono błąd? Otwórz issue lub prześlij poprawkę. Wkład społeczności pomaga nam utrzymywać dokładne i aktualne tłumaczenia.',
+  },
+  pt: {
+    title: 'Aviso de tradução',
+    line1: 'Esta é uma tradução mantida pela comunidade. A versão em inglês é a fonte autoritativa.',
+    line2: 'Esta página foi traduzida com IA generativa e pode ainda não ter sido revista por um falante nativo.',
+    line3: 'Encontrou um erro? Abra um issue ou envie uma correção. As contribuições da comunidade ajudam a manter as traduções precisas e atualizadas.',
+  },
+  ru: {
+    title: 'Уведомление о переводе',
+    line1: 'Это перевод, поддерживаемый сообществом. Авторитетным источником является английская версия.',
+    line2: 'Эта страница была переведена с помощью генеративного ИИ и, возможно, ещё не проверена носителем языка.',
+    line3: 'Нашли ошибку? Откройте issue или отправьте исправление. Вклад сообщества помогает нам поддерживать точность и актуальность переводов.',
+  },
+  sk: {
+    title: 'Poznámka k prekladu',
+    line1: 'Toto je preklad udržiavaný komunitou. Autoritatívnym zdrojom je anglická verzia.',
+    line2: 'Táto stránka bola preložená pomocou generatívnej umelej inteligencie a nemusela byť ešte skontrolovaná rodeným hovorcom.',
+    line3: 'Našli ste chybu? Otvorte issue alebo pošlite opravu. Príspevky komunity nám pomáhajú udržiavať preklady presné a aktuálne.',
+  },
+  bg: {
+    title: 'Забележка за превода',
+    line1: 'Това е превод, поддържан от общността. Английската версия е авторитетният източник.',
+    line2: 'Тази страница е преведена с помощта на генеративен изкуствен интелект и може все още да не е прегледана от носител на езика.',
+    line3: 'Открили сте грешка? Отворете issue или изпратете корекция. Приносите на общността ни помагат да поддържаме преводите точни и актуални.',
+  },
+  zh: {
+    title: '翻译说明',
+    line1: '这是由社区维护的翻译。英文版本为权威来源。',
+    line2: '本页面使用生成式 AI 翻译，可能尚未经过母语人士审核。',
+    line3: '发现错误？请新建 issue 或提交更正。社区贡献有助于我们保持翻译的准确性和时效性。',
+  },
+  en: {
+    title: 'Translation notice',
+    line1: 'This is a community-maintained translation. The English version is the authoritative source.',
+    line2: 'This page was translated using generative AI and may not yet have been reviewed by a native speaker.',
+    line3: 'Found an error? Please open an issue or submit a correction. Community contributions help us keep translations accurate and up to date.',
+  },
+};
+
+const t = translations[locale] ?? translations.en;
 ---
 
 {hasOutdatedBanner && <DefaultBanner />}
 
-<div id="translation-banner" class="sl-banner" data-pagefind-ignore lang="en" data-ai={String(aiTranslated)} style="display: none;">
+<div id="translation-banner" class="sl-banner" data-pagefind-ignore lang={locale} data-ai={String(aiTranslated)} style="display: none;">
   <div class="sl-banner-content">
-    <strong>Translation notice</strong>
-    <p>This is a community-maintained translation. The English version is the authoritative source.</p>
+    <strong>{t.title}</strong>
+    <p>{t.line1}</p>
     {aiTranslated && (
-      <p>This page was translated using generative AI and may not yet have been reviewed by a native speaker.</p>
+      <p>{t.line2}</p>
     )}
-    <p>Found an error? Please open an issue or submit a correction. Community contributions help us keep translations accurate and up to date.</p>
+    <p>{t.line3}</p>
   </div>
   <button
     type="button"


### PR DESCRIPTION
Relevant to Issue #550 and #609 

@MintJapan Did my AI translate Japanese correct?

@Aarrayy @SoongVilda Do you think the banner should stay in English or support all the languages as in this PR?

Note: English is never actually used but kept as a fallback, Chinese is already added for the translation that I'm gonna do this week.