### PR TITLE
tailwind.css: Improved Mobile UI

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -12,6 +12,11 @@
   order: -1;
 }
 
+#starlight__sidebar .mobile-preferences {
+  border-top: none;
+  border-bottom: 1px solid var(--sl-color-gray-6);
+}
+
 @theme {
   --font-sans: 'Inter Variable', sans-serif;
   --font-mono: 'JetBrains Mono Variable', monospace;

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -7,6 +7,11 @@
 @import '@fontsource-variable/inter';
 @import '@fontsource-variable/jetbrains-mono';
 
+/* Mobile sidebar: move footer (theme/lang/social) above navigation */
+#starlight__sidebar .sidebar-content > .md\:sl-hidden {
+  order: -1;
+}
+
 @theme {
   --font-sans: 'Inter Variable', sans-serif;
   --font-mono: 'JetBrains Mono Variable', monospace;


### PR DESCRIPTION
While I already was at it, I went ahead and made a little change to the mobile UI, specifically the hamburger menu.

As @MintJapan stated in Issue #416 it's kind of unintuitive to hide the language switch at the footer of the hamburger menu on mobile. Personally when I switched from Arch to CachyOS I thought there were no translations of the Wiki since I did my first reading on my phone and didn't think to scroll all the way down on the hamburger menu.

This PR provides a very simple but intuitive fix: why not have it in the header instead?

**Current live version: 1. open the hamburger menu 2. scroll all the way to the bottom (if you are even aware that that's a thing)**

<img width="3440" height="1440" alt="live" src="https://github.com/user-attachments/assets/4ad537cb-82cd-47cd-96fe-3e3f53b29499" />

**Proposed change: 1. open the hamburger menu 2. profit**

<img width="3440" height="1440" alt="newversion" src="https://github.com/user-attachments/assets/c66068cf-0a6d-4690-8091-592e6e20fdbf" />

EDIT: I my second commit moves the divider from the top to the bottom

<img width="572" height="1046" alt="Bildschirmfoto_20260811_100741" src="https://github.com/user-attachments/assets/82e6d6ed-c9f4-420a-8952-883c1fa640ea" />
