### PR TITLE
Gaming: document shader cache default from cachyos-gaming-meta

### DIFF
--- a/src/content/docs/configuration/gaming.mdx
+++ b/src/content/docs/configuration/gaming.mdx
@@ -435,7 +435,7 @@ In Steam, click on `Steam`->`Settings`, go to `Downloads`, and uncheck these set
 - **Enable Shader Pre-caching**
 
 :::note
-It's highly recommended to [increase your maximum shader cache size](#increase-maximum-shader-cache-size) after disabling shader pre-caching on Steam.
+`cachyos-gaming-meta` already raises your [shader cache size](#increase-maximum-shader-cache-size) to 12GB. See that section if you need a different size.
 :::
 
 ### Repurposing a Windows NTFS Game Partition
@@ -570,7 +570,11 @@ Game shaders are compiled automatically while playing, which may cause long load
 
 However, there is a maximum limit to the shader cache's file size, causing old shaders to be forgotten when exceeding the default size. This can be an issue since large games can have shaders over 1GB in size, causing them to re-compile shaders every launch.
 
-To avoid long loading times and stuttering, we can increase the global shader cache size:
+If you installed the [essential gaming packages](#essential-packages), `cachyos-gaming-meta` already raises this limit to **12GB** for AMD, Intel, and NVIDIA GPUs. After installing or upgrading that package, reboot or log out and back in once for the change to apply. Most users can stop here.
+
+#### Change the size manually
+
+Only follow these steps if you want a different size, or you have not installed the gaming packages:
 
 <Steps>
 
@@ -587,26 +591,26 @@ To avoid long loading times and stuttering, we can increase the global shader ca
       ```sh
       micro ~/.config/environment.d/gaming.conf
       ```
-      And paste the following depending on your GPU vendor:
+      And paste the following depending on your GPU vendor (change `12G` / `12000000000` if you want a different size):
       <details>
-        <summary>AMD</summary>
+        <summary>AMD / Intel</summary>
         ```sh
-        # Increase AMD's shader cache size to 12GB
+        # Increase shader cache size to 12GB
         MESA_SHADER_CACHE_MAX_SIZE=12G
         ```
       </details>
       <details>
         <summary>NVIDIA</summary>
         ```sh
-        # Increase Nvidia's shader cache size to 12GB
+        # Increase shader cache size to 12GB
         __GL_SHADER_DISK_CACHE_SIZE=12000000000
         ```
       </details>
-  5. Save the file by pressing `CTRL+S` and `CTRL+Q` to exit Micro. Restart your system.
+  5. Save the file by pressing `CTRL+S` and `CTRL+Q` to exit Micro. Restart your system (or log out and back in).
 
 </Steps>
 
-After restarting, the maximum shader cache size should be permanently increased. Thanks to [psygreg's shader booster](https://github.com/psygreg/shader-booster/) for helping this guide.
+Thanks to [psygreg's shader booster](https://github.com/psygreg/shader-booster/) for helping this guide.
 
 ### Forcing the Latest DLSS Preset
 


### PR DESCRIPTION
## Summary
- Document that `cachyos-gaming-meta` already raises the shader cache limit to 12GB for AMD, Intel, and NVIDIA when the [essential gaming packages](https://wiki.cachyos.org/configuration/gaming/#essential-packages) are installed.
- Keep the existing manual `~/.config/environment.d/` steps only for users who want a different size or do not have the meta package.
- Update the Steam shader pre-caching note to match.

Companion package change: https://github.com/CachyOS/CachyOS-PKGBUILDS/pull/1772

## Test plan
- [ ] Confirm the shader cache section reads clearly for users who already installed gaming packages via Hello
- [ ] Confirm the manual steps still work for overrides / non-meta installs
- [ ] Confirm the pre-caching note links to the updated section