### PR TITLE
Unify GRUB EFI partition minimum size to 512 MiB

### DIFF
--- a/src/content/docs/cs/installation/installation_on_root.mdx
+++ b/src/content/docs/cs/installation/installation_on_root.mdx
@@ -103,7 +103,7 @@ Tabulka oddílů se pro každý zavaděč liší. Postupujte prosím podle sprá
 4. Vyberte **Ruční rozdělení disku**.
 
 5. Vytvořte nový oddíl s následujícími parametry:
-    * Velikost: ***Alespoň 100MiB***
+    * Velikost: ***Alespoň 512MiB***
     * Souborový systém: ***FAT32***
     * Přípojný bod: ***/boot/efi***
     * Příznaky: **boot**

--- a/src/content/docs/sk/installation/installation_on_root.mdx
+++ b/src/content/docs/sk/installation/installation_on_root.mdx
@@ -103,7 +103,7 @@ Tabuľka partícií sa pre jednotlivých správcov zavádzania líši. Postupujt
 4. Vyberte **Manuálne rozdelenie disku**.
 
 5. Vytvorte novú partíciu s nasledujúcimi parametrami:
-    * Veľkosť: ***Minimálne 100MiB***
+    * Veľkosť: ***Minimálne 512MiB***
     * Filesystem: ***FAT32***
     * Prípojný bod: ***/boot/efi***
     * Flags: **boot**


### PR DESCRIPTION
The Czech (cs) and Slovak (sk) installation_on_root guides specified a GRUB /boot/efi partition minimum of 100 MiB, while all other locales recommend 512 MiB. This inconsistency could lead to too-small EFI partitions when following the Czech/Slovak instructions.
This PR aligns the cs and sk manuals with the rest of the wiki by updating the GRUB EFI partition minimum to 512 MiB.

If you need any edits let me know.