### PR TITLE
Fix spelling mistakes across docs

### DIFF
--- a/src/content/docs/cachyos_basic/changelogs/gui_installer.md
+++ b/src/content/docs/cachyos_basic/changelogs/gui_installer.md
@@ -161,7 +161,7 @@ sidebar:
   * GRUB now uses LUKS2 for encryption.
   * Pass --needed to pacman to avoid installing packages twice.
   * Use single-level compression on NVMe for Btrfs
-  * Removed xorg dependecies on Wayland desktops environments.
+  * Removed xorg dependencies on Wayland desktops environments.
 * **ISO:**
   * Switched to `plasma-login-manager` for the ISO environment.
   * The ISO now contains both Stable and LTS kernels. The Stable kernel is selected by default.
@@ -939,7 +939,7 @@ sidebar:
 - CachyOS-sddm-theme got added to the KDE Installation
 - Automatic version script added when creating the ISO
 - Calamares updated to the latest commit
-- The mirrors are now ranked with "cachyos-rate-mirros", which ranks our mirrors and the arch ones
+- The mirrors are now ranked with "cachyos-rate-mirrors", which ranks our mirrors and the arch ones
 - Packages Update: 6.1.1 Kernel, mesa 22.3.1, plasma 5.26.4,...
 - The Kofuku Desktop Environment got removed
 - extra ISO with llvm 15 included to provide support for newer AMD Cards
@@ -1061,7 +1061,7 @@ Following options you can select for a kernel compile:
 - Set performance governor as default
 - Enable BBR2
 - Tickrate (500Hz, 600Hz, 750Hz, 1000Hz)
-- tickless (idle, perodic, full)
+- tickless (idle, periodic, full)
 - disable MQ-Deadline I/O Scheduler
 - disable Kyber I/O Scheduler
 - Enable or disable MG-LRU

--- a/src/content/docs/cachyos_basic/faq.mdx
+++ b/src/content/docs/cachyos_basic/faq.mdx
@@ -555,7 +555,7 @@ In the case of a deleted `/boot` partition, please create a new one following th
 
 ### Steps to recover your bootloader
 
-Useful for cases where the bootloader entries dissapear after a BIOS update or just in case of need to do so.
+Useful for cases where the bootloader entries disappear after a BIOS update or just in case of need to do so.
 
 :::tip
 If you're unsure on how to use `cachy-chroot`, please refer to the [CachyOS chroot Helper](/features/cachy_chroot) documentation first.

--- a/src/content/docs/configuration/automount_with_fstab.mdx
+++ b/src/content/docs/configuration/automount_with_fstab.mdx
@@ -71,7 +71,7 @@ Once you are confident you've found the correct partition, copy the UUID. Copyin
 ### 3. Creating the Systemd Mount File
 Let us say we want to use this drive primarily for games, a good place to mount that is in your user home. It can be anywhere you want, but for simplicity's sake we're going with in /home/user (replace user with your linux username). This matters because the mounting path dictates the name of the systemd mount file. Because this drive is intended for games, we'll mount it to the games folder in user home, `/home/user/games`.
 
-For a systemd mount file, that translates to home-$USER-games.mount (forward slashes `/` get replaced with hypens `-`) and systemd mount files go in /etc/systemd/system.
+For a systemd mount file, that translates to home-$USER-games.mount (forward slashes `/` get replaced with hyphens `-`) and systemd mount files go in /etc/systemd/system.
 
 :::tip
 If you want to use a space, a hyphen, a CJK character, or an accented character in your mount folder name, it must be formatted differently. Let's say you want to use the folder path of `/home/grzegorz/brzęczyszczykiewicz`, run the following command to get the name you need to use with your file:

--- a/src/content/docs/configuration/post_install_setup.mdx
+++ b/src/content/docs/configuration/post_install_setup.mdx
@@ -56,7 +56,7 @@ Make sure to check our [Security & Best Practices](/cachyos_basic/faq#security--
     ```
     </details>
     <details>
-    <summary>Upgrade standard packages (Arch derivates) + install package:</summary>
+    <summary>Upgrade standard packages (Arch derivatives) + install package:</summary>
     ```sh
     shelly install --upgrade {pkg}
     # Example:
@@ -243,7 +243,7 @@ The `/etc/pacman.d/offline.conf` file is crucial for managing which packages are
 Fork of [Arch-Update](https://github.com/Antiz96/arch-update)
 
 An update notifier & applier for Arch Linux that assists you with important pre / post update tasks.
-Includes a dynamic & clickeable systray applet for an easy integration with any Desktop Environment / Window Manager.
+Includes a dynamic & clickable systray applet for an easy integration with any Desktop Environment / Window Manager.
 
 <details>
     <summary>How to enable Cachy-Update</summary>

--- a/src/content/docs/configuration/sched-ext.mdx
+++ b/src/content/docs/configuration/sched-ext.mdx
@@ -38,7 +38,7 @@ Example: EEVDF or BORE.
 ## How to Launch and Manage the Scheduler
 
 :::note
-Both `scxctl` and `scx_loader` require administrative previleges to start/stop/switch schedulers.
+Both `scxctl` and `scx_loader` require administrative privileges to start/stop/switch schedulers.
 
 Therefore you'll need to run them with `sudo` or using a polkit agent that grants the necessary permissions.
 


### PR DESCRIPTION
- previleges -> privileges (sched-ext.mdx)
- perodic -> periodic (gui_installer.md)
- mirros -> mirrors (gui_installer.md)
- hypens -> hyphens (automount_with_fstab.mdx)
- derivates -> derivatives (post_install_setup.mdx)
- dependecies -> dependencies (gui_installer.md)
- dissapear -> disappear (faq.mdx)
- clickeable -> clickable (post_install_setup.mdx)