### PR TITLE
Hyprland: Swash FAQ, inputs.lua, Super+digit focuses monitors

### DIFF
--- a/src/content/docs/configuration/desktop_environments/hyprland.mdx
+++ b/src/content/docs/configuration/desktop_environments/hyprland.mdx
@@ -31,7 +31,7 @@ You will want to configure a few user-specific things after setup. For additiona
 * `variables.lua`
   * Add your monitor assignments here. your `PRIMARY_MONITOR` and `MONITOR1` should generally be the same monitor. You can remove/add `MONITOR#` variables as needed.
   * Define your number of workspaces per monitor. Do not exceed 10.
-* `input.lua` You can define your various hypr input settings here. You'll probably want to adjust the `sensitivity`.
+* `inputs.lua` You can define your various hypr input settings here. You'll probably want to adjust the `sensitivity`.
 * `binds.lua` Review this file to see all the keybinds for these dots. You can also check out the general overview below.
 * `windowrules.lua` If you find yourself wondering why certain windows have certain behaviors check this file; you can also add/remove rules as you see fit.
 * `workspaces.lua` Add various workspace settings here. It's recommended to add 3 workspaces per monitor (as shown in the examples) plus the gaming workspace to the primary monitor.
@@ -130,11 +130,11 @@ Most of the key combinations require the use of the mod key which in our case is
 
 | Description | Key |
 |-------------|-----|
-| Switch to workspace [1-10] | <Kbd linux="Super+[0-9]" /> |
-| Move window to workspace [1-10] (follow) | <Kbd linux="Super+Shift+[0-9]" /> |
-| Move window to workspace [1-10] (don't follow) | <Kbd linux="Super+Alt+[0-9]" /> |
-| Focus workspace (Relative) | <Kbd linux="Super+Control+#" /> |
-| Focus workspace (Absolute) | <Kbd linux="Super+Alt+#" /> |
+| Focus monitor [1-3] | <Kbd linux="Super+[1-3]" /> |
+| Move window to monitor [1-3] | <Kbd linux="Super+Shift+[1-3]" /> |
+| Focus workspace (Absolute) | <Kbd linux="Super+Alt+[0-9]" /> |
+| Focus workspace (Relative) | <Kbd linux="Super+Control+[0-9]" /> |
+| Move window to workspace [1-10] (don't follow) | <Kbd linux="Super+Control+Shift+[0-9]" /> |
 | Focus next workspace | <Kbd linux="Super+Control+Right" /> |
 | Focus previous workspace | <Kbd linux="Super+Control+Left" /> |
 | Focus first empty workspace | <Kbd linux="Super+Control+Down" /> |
@@ -228,9 +228,9 @@ Rebooting should make the changes take effect. If the shell fails to load, try r
 
 You need to setup a secrets store for this to work properly. Kwallet is installed by default but you can also use gnome-keyring or another secrets store. If you want to use kwallet, install `kwalletmanager` from the repo, then open it and create a new wallet. It's easiest to make the password blank, but you can also setup auto unlock with your display manager, which is outside the scope of this wiki; see the [Arch wiki](https://wiki.archlinux.org/title/KDE_Wallet#Configuration) for more details. After setting up a wallet, initialize it in your `autostart.lua` file with `hl.exec_cmd("kwalletd6")`.
 
-> "_How do I not have satty pop up after taking a screenshot?_"
+> "_How do I not have Swash pop up after taking a screenshot?_"
 
-You can easily dismiss satty by pressing ctrl + s to save your screenshot or ctrl + c to copy. If you don't want satty to pop up at all, you can configure the setting to copy to clipboard or save to file in Noctalia settings > shell > screenshot.
+Print-screen now opens [Swash](https://github.com/lemmy/swash) (Satty was replaced in cachyos-hypr-noctalia). If you don't want the annotator at all, set copy to clipboard or save to file in Noctalia settings > shell > screenshot.
 
 > _"How do I change my keyboard input?"_
 


### PR DESCRIPTION
## Summary
- Post-setup still said `input.lua`; the file in cachyos-hypr-noctalia is `inputs.lua`.
- Workspaces & Monitors table listed Super+[0-9] as workspace switch. After CachyOS/cachyos-hypr-noctalia#29 those number-row keys focus MONITOR1/2/3. Workspace switch is Super+Alt+[0-9] (absolute) and Super+Control+[0-9] (relative). Super+Control+Shift+[0-9] moves a window to a relative workspace without following.
- FAQ still told people how to dismiss Satty. Screenshots now open Swash.

English page only; other locales still have the old names. No pkgver bump.

## Test plan
- [ ] Check binds.lua in CachyOS/cachyos-hypr-noctalia master against the keybind table
- [ ] Confirm skel file is `inputs.lua`
- [ ] Confirm config.toml screenshot pipe is Swash